### PR TITLE
fix: replace or_ with and_ in admin repo filter queries

### DIFF
--- a/backend/app/repositories/sql_admin_repository.py
+++ b/backend/app/repositories/sql_admin_repository.py
@@ -1,7 +1,7 @@
 from typing import Optional, List, Dict, Any, Tuple
 from datetime import datetime, timedelta
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import update, delete, func, or_, select
+from sqlalchemy import update, delete, func, and_, select
 
 from app.models.orm import UserORM, QuestionORM, CourseORM, ModuleORM, LessonORM
 from app.models.admin_models import (
@@ -125,13 +125,13 @@ class SqlAdminRepository(AdminRepository):
             conditions.append(QuestionORM.category == filter.category)
 
         if conditions:
-            query = query.where(or_(*conditions))
+            query = query.where(and_(*conditions))
 
         query = query.offset((filter.page - 1) * filter.per_page).limit(filter.per_page)
 
         count_query = select(func.count())
         if conditions:
-            count_query = count_query.where(or_(*conditions))
+            count_query = count_query.where(and_(*conditions))
         count_result = await self.session.execute(count_query)
         total = count_result.scalar_one()
 
@@ -335,7 +335,7 @@ class SqlAdminRepository(AdminRepository):
 
         query = base_query
         if conditions:
-            query = query.where(or_(*conditions))
+            query = query.where(and_(*conditions))
 
         query = query.offset(skip).limit(limit)
 
@@ -344,7 +344,7 @@ class SqlAdminRepository(AdminRepository):
 
         count_query = select(func.count())
         if conditions:
-            count_query = count_query.where(or_(*conditions))
+            count_query = count_query.where(and_(*conditions))
         count_result = await self.session.execute(count_query)
         total = count_result.scalar_one()
 


### PR DESCRIPTION
## Summary

Fixes or_ → nd_ in sql_admin_repository.py for all filter conditions.

**Bug:** When listing questions or audit logs with multiple filters (e.g. difficulty + category, or start_date + end_date), conditions were combined with SQL OR, returning broader result sets than intended. A query for difficulty=easy AND category=arrays would return all easy questions + all array questions instead of only easy array questions.

**Fix:** Changed or_(*conditions) → nd_(*conditions) on 4 lines (128, 134, 338, 347) + import swap.

**Tests:** 452/452 unit tests pass.

Closes #2