### PR TITLE
fix: resolve theme toggle hydration mismatch (#17)

### DIFF
--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -199,7 +199,11 @@ export function Header() {
             }}
             className="px-5 py-2 text-sm text-white/60 hover:text-white bg-white/5 hover:bg-white/10 rounded-full transition-all duration-500 ease-[cubic-bezier(0.32,0.72,0,1)]"
           >
-            {resolvedTheme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+            {mounted
+              ? resolvedTheme === 'dark'
+                ? 'Light Mode'
+                : 'Dark Mode'
+              : 'Theme'}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Guard the mobile-menu theme label in `Header.tsx` with the existing `mounted` flag so server and client render match (fixes React hydration mismatch: `Server: "Dark Mode" Client: "Light Mode"`).
- Replace the two `Header.test.tsx` tests that asserted dead `sun-icon`/`moon-icon` testids (Header imports icons from lucide-react directly) with `findByText` assertions on the actual toggle text.

## Test plan
- `vitest run src/components/header/Header.test.tsx` → 6 passed
- `eslint` + `tsc --noEmit` clean

Closes #17