### PR TITLE
refactor: move use-case description onto enum, consolidate add() (#5)

### DIFF
--- a/backend/app/api/question_validation.py
+++ b/backend/app/api/question_validation.py
@@ -97,7 +97,7 @@ async def get_available_use_cases():
     """Get list of all available validation use cases."""
     return {
         "use_cases": [
-            {"name": uc.value, "description": _get_use_case_description(uc)}
+            {"name": uc.value, "description": uc.description}
             for uc in ValidationUseCase
         ]
     }
@@ -145,35 +145,3 @@ async def get_validation_summary(
         )
 
 
-def _get_use_case_description(use_case: ValidationUseCase) -> str:
-    """Get human-readable description for a use case."""
-    descriptions = {
-        ValidationUseCase.STRUCTURE: (
-            "Validates question structure including required fields, "
-            "field types, and basic data integrity."
-        ),
-        ValidationUseCase.TEST_CASES: (
-            "Validates test cases for executability, proper format, "
-            "and deterministic outputs."
-        ),
-        ValidationUseCase.STARTER_CODE: (
-            "Validates that starter code for all languages compiles "
-            "and runs without errors."
-        ),
-        ValidationUseCase.SOLUTION: (
-            "Validates that the reference solution passes all test cases. "
-            "This is the most critical validation."
-        ),
-        ValidationUseCase.TIME_LIMITS: (
-            "Validates time complexity and time limits are reasonable "
-            "for the problem difficulty."
-        ),
-        ValidationUseCase.FUNCTION_SIGNATURE: (
-            "Validates function signatures in starter code are properly "
-            "defined with correct types."
-        ),
-        ValidationUseCase.OUTPUT_FORMAT: (
-            "Validates expected outputs have consistent formats across all test cases."
-        ),
-    }
-    return descriptions.get(use_case, "No description available.")

--- a/backend/app/api/question_validation.py
+++ b/backend/app/api/question_validation.py
@@ -143,5 +143,3 @@ async def get_validation_summary(
         raise HTTPException(
             status_code=500, detail=f"Error generating summary: {str(e)}"
         )
-
-

--- a/backend/app/models/question_validation_schemas.py
+++ b/backend/app/models/question_validation_schemas.py
@@ -30,6 +30,40 @@ class ValidationUseCase(str, Enum):
     FUNCTION_SIGNATURE = "function_signature"
     OUTPUT_FORMAT = "output_format"
 
+    @property
+    def description(self) -> str:
+        """Human-readable description for this use case."""
+        return {
+            ValidationUseCase.STRUCTURE: (
+                "Validates question structure including required fields, "
+                "field types, and basic data integrity."
+            ),
+            ValidationUseCase.TEST_CASES: (
+                "Validates test cases for executability, proper format, "
+                "and deterministic outputs."
+            ),
+            ValidationUseCase.STARTER_CODE: (
+                "Validates that starter code for all languages compiles "
+                "and runs without errors."
+            ),
+            ValidationUseCase.SOLUTION: (
+                "Validates that the reference solution passes all test cases. "
+                "This is the most critical validation."
+            ),
+            ValidationUseCase.TIME_LIMITS: (
+                "Validates time complexity and time limits are reasonable "
+                "for the problem difficulty."
+            ),
+            ValidationUseCase.FUNCTION_SIGNATURE: (
+                "Validates function signatures in starter code are properly "
+                "defined with correct types."
+            ),
+            ValidationUseCase.OUTPUT_FORMAT: (
+                "Validates expected outputs have consistent formats across "
+                "all test cases."
+            ),
+        }.get(self, "No description available.")
+
 
 class ValidationIssue(BaseModel):
     """A single validation issue found during validation."""

--- a/backend/app/services/question_bank.py
+++ b/backend/app/services/question_bank.py
@@ -113,23 +113,22 @@ class QuestionBank:
     async def add(
         self, question: Question, validate: bool = True
     ) -> QuestionValidationStatus:
+        validated = False
+        passed = False
+
         if validate and self._validator:
             result = await self._validator.validate_question(question)
             await self._persist_validation_status(question.id, result)
-
-            if not result.valid:
+            validated = True
+            passed = bool(result.valid)
+            if not passed:
                 logger.warning("Question %s failed validation", question.id)
-                await self._repo.add(question)
-                return QuestionValidationStatus(
-                    is_validated=True, validation_passed=False
-                )
-        else:
-            await self._repo.add(question)
-            return QuestionValidationStatus(is_validated=False)
 
         await self._repo.add(question)
-        await self._invalidate_cache()
-        return QuestionValidationStatus(is_validated=True, validation_passed=True)
+        if validated and passed:
+            await self._invalidate_cache()
+
+        return QuestionValidationStatus(is_validated=validated, validation_passed=passed)
 
     async def stats(self) -> QuestionStats:
         total = await self._cached_or_fetch("total_count", self._compute_total)

--- a/backend/app/services/question_bank.py
+++ b/backend/app/services/question_bank.py
@@ -128,7 +128,9 @@ class QuestionBank:
         if validated and passed:
             await self._invalidate_cache()
 
-        return QuestionValidationStatus(is_validated=validated, validation_passed=passed)
+        return QuestionValidationStatus(
+            is_validated=validated, validation_passed=passed
+        )
 
     async def stats(self) -> QuestionStats:
         total = await self._cached_or_fetch("total_count", self._compute_total)

--- a/backend/tests/unit/test_issue5_validation_refactor.py
+++ b/backend/tests/unit/test_issue5_validation_refactor.py
@@ -1,0 +1,78 @@
+"""Tests for issue #5 refactors: ValidationUseCase.description property and
+single-add consolidation in QuestionBank.add."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from app.models.question_validation_schemas import (
+    QuestionValidationResult,
+    ValidationUseCase,
+)
+from app.models.schemas import Question
+from app.services.question_bank import QuestionBank
+
+
+def test_validation_usecase_has_description():
+    assert ValidationUseCase.SOLUTION.description.startswith(
+        "Validates that the reference solution"
+    )
+    assert ValidationUseCase.STRUCTURE.description.startswith(
+        "Validates question structure"
+    )
+    for uc in ValidationUseCase:
+        assert isinstance(uc.description, str) and uc.description
+
+
+class FakeRepo:
+    def __init__(self):
+        self.add = AsyncMock()
+        self.save_validation_status = AsyncMock()
+        self.count = AsyncMock(return_value=0)
+        self.get_all = AsyncMock(return_value=[])
+
+
+def _make_question(qid="q1"):
+    q = MagicMock(spec=Question)
+    q.id = qid
+    return q
+
+
+@pytest.mark.asyncio
+async def test_add_persists_once_when_validator_missing():
+    repo = FakeRepo()
+    bank = QuestionBank(repository=repo)
+    status = await bank.add(_make_question(), validate=False)
+    repo.add.assert_awaited_once()
+    assert status.is_validated is False
+    assert status.validation_passed is False
+
+
+@pytest.mark.asyncio
+async def test_add_persists_once_when_validation_fails():
+    repo = FakeRepo()
+    validator = MagicMock()
+    validator.validate_question = AsyncMock(
+        return_value=QuestionValidationResult(question_id="q1", valid=False)
+    )
+    bank = QuestionBank(repository=repo, validator=validator)
+    status = await bank.add(_make_question(), validate=True)
+    repo.add.assert_awaited_once()
+    assert status.is_validated is True
+    assert status.validation_passed is False
+
+
+@pytest.mark.asyncio
+async def test_add_persists_once_and_invalidates_cache_when_valid():
+    repo = FakeRepo()
+    validator = MagicMock()
+    validator.validate_question = AsyncMock(
+        return_value=QuestionValidationResult(question_id="q1", valid=True)
+    )
+    cache = MagicMock()
+    cache.delete = AsyncMock()
+    bank = QuestionBank(repository=repo, validator=validator, cache=cache)
+    status = await bank.add(_make_question(), validate=True)
+    repo.add.assert_awaited_once()
+    cache.delete.assert_awaited_once()
+    assert status.is_validated is True
+    assert status.validation_passed is True


### PR DESCRIPTION
## Summary
- Add `ValidationUseCase.description` property to the `str, Enum` and delete the standalone `_get_use_case_description()` helper in `api/question_validation.py`.
- Collapse the three `self._repo.add(question)` branches in `QuestionBank.add` into a single guarded call, eliminating the fragile double-add risk described in #5.

## Test plan
- New `test_issue5_validation_refactor.py`: enum description + add-once contract (4 passed)
- Backend unit suite: 473 passed; validation endpoint integration: 10 passed
- `ruff check` clean on changed files

## Validation
Behavior preserved: a failed/disabled validation still adds once and returns `validation_passed=False`; a passing validation adds once and invalidates cache.

Closes #5