### PR TITLE
fix: include hashed_password in SqlUserAdminRepository UserInDB (#14)

### DIFF
--- a/backend/app/repositories/sql_user_admin_repository.py
+++ b/backend/app/repositories/sql_user_admin_repository.py
@@ -26,6 +26,7 @@ class SqlUserAdminRepository(UserAdminRepository):
             oauth_provider=user.oauth_provider,
             oauth_id=user.oauth_id,
             created_at=str(user.created_at) if user.created_at else None,
+            hashed_password=user.hashed_password,
         )
 
     async def get_user_by_username(self, username: str) -> Optional[UserInDB]:
@@ -43,6 +44,7 @@ class SqlUserAdminRepository(UserAdminRepository):
             oauth_provider=user.oauth_provider,
             oauth_id=user.oauth_id,
             created_at=str(user.created_at) if user.created_at else None,
+            hashed_password=user.hashed_password,
         )
 
     async def update_user_role(
@@ -98,6 +100,7 @@ class SqlUserAdminRepository(UserAdminRepository):
                     oauth_provider=u.oauth_provider,
                     oauth_id=u.oauth_id,
                     created_at=str(u.created_at) if u.created_at else None,
+                    hashed_password=u.hashed_password,
                 )
             )
         return parsed, total

--- a/backend/tests/unit/test_sql_user_admin_repository_issue14.py
+++ b/backend/tests/unit/test_sql_user_admin_repository_issue14.py
@@ -1,0 +1,57 @@
+"""Issue #14: SqlUserAdminRepository must include hashed_password when
+constructing UserInDB (it is a required field). Without it, the call 500s.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.orm import UserORM
+from app.repositories.sql_user_admin_repository import SqlUserAdminRepository
+
+
+def _fake_orm_user(hashed_password="stored-hash"):
+    u = MagicMock(spec=UserORM)
+    u.id = "u1"
+    u.username = "alice"
+    u.email = "alice@example.com"
+    u.is_active = True
+    u.role = "admin"
+    u.oauth_provider = None
+    u.oauth_id = None
+    u.created_at = "2024-01-01T00:00:00Z"
+    u.hashed_password = hashed_password
+    return u
+
+
+def _make_repo(orm_user):
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = orm_user
+    result.scalars.return_value.all.return_value = [orm_user]
+    session.execute.return_value = result
+    return SqlUserAdminRepository(session)
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_id_includes_hashed_password():
+    repo = _make_repo(_fake_orm_user())
+    user = await repo.get_user_by_id("u1")
+    assert user is not None
+    assert user.hashed_password == "stored-hash"
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_username_includes_hashed_password():
+    repo = _make_repo(_fake_orm_user())
+    user = await repo.get_user_by_username("alice")
+    assert user is not None
+    assert user.hashed_password == "stored-hash"
+
+
+@pytest.mark.asyncio
+async def test_list_users_includes_hashed_password():
+    repo = _make_repo(_fake_orm_user())
+    users, _ = await repo.list_users()
+    assert users
+    assert users[0].hashed_password == "stored-hash"


### PR DESCRIPTION
## Summary
Part 1 of #14: `UserInDB` requires `hashed_password`, but `SqlUserAdminRepository` omitted it in all three construction sites (`get_user_by_id`, `get_user_by_username`, `list_users`), causing a Pydantic `ValidationError` → HTTP 500 whenever `USE_DATABASE=true`.

- Add `hashed_password=user.hashed_password` / `u.hashed_password` to all three `UserInDB(...)` calls.

## Stale parts of #14 (no change needed)
- **Missing Lucide imports (item 2):** current admin pages already import `lucide-react` where used; the `Settings`/`User` strings in `dashboard`/`login` are plain text, not icon components.
- **MySQL `DATABASE_URL` (item 3):** the default store is sqlite/file-based (docker-compose `USE_DATABASE=false`, `.env.example` sqlite). No MySQL is configured, so the `host.docker.internal` change does not apply.

## Test plan
- New `test_sql_user_admin_repository_issue14.py`: 3 passed (get_by_id / get_by_username / list_users include hashed_password)
- `ruff check` clean
- No existing sql admin repo tests were affected

Closes #14