### PR TITLE
fix: serialize dataclass results with asdict in evaluate_suite cache write

### DIFF
--- a/backend/app/services/piston_service.py
+++ b/backend/app/services/piston_service.py
@@ -183,7 +183,9 @@ class PistonService(CodeExecutor):
         results = self._parse_suite_output(exec_result, test_cases)
 
         if self.cache and cache_key:
-            await self.cache.set(cache_key, [r.model_dump() for r in results], ttl=3600)
+            await self.cache.set(
+                cache_key, [dataclasses.asdict(r) for r in results], ttl=3600
+            )
 
         return results
 

--- a/backend/tests/unit/test_piston_service.py
+++ b/backend/tests/unit/test_piston_service.py
@@ -350,6 +350,82 @@ class TestPistonServiceEvaluateSuite:
             assert results[0].passed is True
 
     @pytest.mark.asyncio
+    async def test_evaluate_suite_caches_results_with_enabled_cache(self):
+        """Regression: with a live cache, evaluate_suite must serialize dataclass
+        results (dataclasses.asdict) instead of calling nonexistent model_dump()."""
+        store: dict = {}
+
+        class FakeCache:
+            async def get(self, key):
+                return store.get(key)
+
+            async def set(self, key, value, ttl=300):
+                store[key] = value
+
+        service = PistonService(cache=FakeCache())
+
+        with patch.object(service, "execute", new=AsyncMock()) as mock_exec:
+            mock_exec.return_value = ExecutionResult(
+                stdout='@@SUITE_RESULT@@[{"index":1,"passed":true,"actual":"6"}]@@SUITE_RESULT@@',
+                stderr="",
+                exit_code=0,
+            )
+            results = await service.evaluate_suite(
+                "python",
+                "def add(a, b): return a + b",
+                [{"input": "2\n4", "expected_output": "6", "hidden": False}],
+            )
+
+            assert len(results) == 1
+            assert results[0].passed is True
+            assert len(store) == 1
+            cached = next(iter(store.values()))
+            assert cached == [
+                {
+                    "index": 1,
+                    "passed": True,
+                    "input": "2\n4",
+                    "expected": "6",
+                    "actual": "6",
+                    "hidden": False,
+                }
+            ]
+
+    @pytest.mark.asyncio
+    async def test_evaluate_suite_reads_cached_results(self):
+        """Regression: cache hits should hydrate TestCaseResult dataclasses."""
+        cached = [
+            {
+                "index": 1,
+                "passed": True,
+                "input": "2\n4",
+                "expected": "6",
+                "actual": "6",
+                "hidden": False,
+            }
+        ]
+
+        class FakeCache:
+            async def get(self, key):
+                return cached
+
+            async def set(self, key, value, ttl=300):
+                pass
+
+        service_with_cache = PistonService(cache=FakeCache())
+
+        with patch.object(service_with_cache, "execute", new=AsyncMock()) as mock_exec:
+            results = await service_with_cache.evaluate_suite(
+                "python",
+                "def add(a, b): return a + b",
+                [{"input": "2\n4", "expected_output": "6", "hidden": False}],
+            )
+            mock_exec.assert_not_called()
+            assert len(results) == 1
+            assert results[0].passed is True
+            assert results[0].expected == "6"
+
+    @pytest.mark.asyncio
     async def test_evaluate_suite_build_runner_fallback(self, service):
         with patch.object(service, "execute", new=AsyncMock()) as mock_exec:
             mock_exec.return_value = ExecutionResult(


### PR DESCRIPTION
## Description

Fixes a 500 crash when submitting solutions with the Redis cache enabled. `TestCaseResult` is a `@dataclass`, but `evaluate_suite` serialized it with `.model_dump()` (a Pydantic method) on the cache write path.

## Changes

- `backend/app/services/piston_service.py`: replace `[r.model_dump() for r in results]` with `[dataclasses.asdict(r) for r in results]` in the suite cache write (line ~186).
- `backend/tests/unit/test_piston_service.py`: add `test_evaluate_suite_caches_results_with_enabled_cache` and `test_evaluate_suite_reads_cached_results` covering the serialize + cache read path.

## Related Issue

Fixes #25

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [x] Test update

## Testing

- [x] Backend tests pass (`cd backend && python -m pytest tests/unit/`) — 479 passed
- [x] Lint passes (`ruff check . && ruff format . --check`)

## Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary (only for complex logic)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have not added any secrets or API keys to the code
