### PR TITLE
fix: stop sending client NVIDIA API key to backend; use server-side key only

### DIFF
--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Header, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from typing import AsyncIterator, Optional
 import asyncio
@@ -20,10 +20,12 @@ router = APIRouter()
 
 
 def get_coaching_provider(
-    x_nvidia_api_key: Optional[str] = Header(None, alias="X-NVIDIA-API-Key"),
     cache: Optional[RedisCache] = Depends(get_redis_cache),
 ) -> CoachingProvider:
-    api_key = x_nvidia_api_key or os.getenv("NVIDIA_API_KEY")
+    # Server-side only: the API key is configured on the backend, never
+    # supplied by clients. Accepting it from a request header would let any
+    # user substitute their own key (billing) and leak it to the server.
+    api_key = os.getenv("NVIDIA_API_KEY")
     if not api_key:
         raise HTTPException(status_code=500, detail="NVIDIA API key not configured")
     return NIMService(api_key=api_key, cache=cache)

--- a/backend/tests/unit/test_coaching_provider.py
+++ b/backend/tests/unit/test_coaching_provider.py
@@ -1,0 +1,28 @@
+"""Unit tests for the coach provider factory (server-side-only API key)."""
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.coach import get_coaching_provider
+from app.services.nim_service import NIMService
+
+
+class TestGetCoachingProvider:
+    def test_raises_when_env_key_missing(self, monkeypatch):
+        monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+        with pytest.raises(HTTPException) as exc:
+            get_coaching_provider(cache=None)
+        assert exc.value.status_code == 500
+
+    def test_uses_server_env_key(self, monkeypatch):
+        monkeypatch.setenv("NVIDIA_API_KEY", "server-side-key")
+        provider = get_coaching_provider(cache=None)
+        assert isinstance(provider, NIMService)
+        assert provider.api_key == "server-side-key"
+
+    def test_does_not_accept_client_supplied_key_argument(self):
+        """The provider must not be constructible with a client header value."""
+        import inspect
+
+        signature = inspect.signature(get_coaching_provider)
+        assert "x_nvidia_api_key" not in signature.parameters

--- a/frontend/src/components/onboarding/OnboardingTour.tsx
+++ b/frontend/src/components/onboarding/OnboardingTour.tsx
@@ -35,7 +35,7 @@ const STEPS = [
   {
     title: "NVIDIA API Key",
     description:
-      "Open Settings and add your free NVIDIA API key to enable the AI Coach. Your key stays in your browser — never sent to our server.",
+      "AI coaching runs on the server-side API key. You can optionally add your own NVIDIA key in Settings — it stays in your browser and is never sent to our server.",
     icon: Settings,
   },
 ];

--- a/frontend/src/components/settings/SettingsModal.tsx
+++ b/frontend/src/components/settings/SettingsModal.tsx
@@ -75,8 +75,8 @@ export function SettingsModal({
                 NVIDIA API Key
               </label>
               <p className="text-[10px] text-muted-foreground/50 mb-3 leading-relaxed">
-                Required for AI coaching features. Your key is stored locally
-                and never sent to our servers.
+                Optional. Stored locally in your browser and never sent to our
+                servers. AI coaching uses the server-side API key.
               </p>
               <div className="rounded-2xl bg-white/[0.03] ring-1 ring-white/5 p-0.5">
                 <div className="relative rounded-[calc(1rem-0.125rem)]">

--- a/frontend/src/features/coaching/coaching.service.test.ts
+++ b/frontend/src/features/coaching/coaching.service.test.ts
@@ -72,7 +72,6 @@ describe("CoachingService", () => {
           language: "python",
           difficulty: "medium",
         },
-        expect.objectContaining({ headers: {} }),
       );
       expect(result.response).toBe("Try using a hash map");
       expect(result.structured).toBeNull();
@@ -95,11 +94,10 @@ describe("CoachingService", () => {
       expect(http.post).toHaveBeenCalledWith(
         "/api/coach/",
         expect.objectContaining({ difficulty: "medium" }),
-        expect.anything(),
       );
     });
 
-    it("sends API key from localStorage as header", async () => {
+    it("never sends the API key from localStorage to the server", async () => {
       localStorage.setItem("nvidia_api_key", "nvapi-test-key");
       vi.mocked(http.post).mockResolvedValue({
         response: "Here is a hint",
@@ -114,15 +112,13 @@ describe("CoachingService", () => {
         defaultArgs.mode,
       );
 
-      const callHeaders = (
-        vi.mocked(http.post).mock.calls[0][2] as {
-          headers: Record<string, string>;
-        }
-      ).headers;
-      expect(callHeaders["X-NVIDIA-API-Key"]).toBe("nvapi-test-key");
+      const call = vi.mocked(http.post).mock.calls[0];
+      expect(call[2]).toBeUndefined();
+      expect(JSON.stringify(call)).not.toContain("nvapi-test-key");
+      expect(JSON.stringify(call)).not.toContain("X-NVIDIA-API-Key");
     });
 
-    it("does not send API key header when not in localStorage", async () => {
+    it("does not pass request options to http.post", async () => {
       vi.mocked(http.post).mockResolvedValue({
         response: "Sure",
         structured: null,
@@ -136,12 +132,7 @@ describe("CoachingService", () => {
         defaultArgs.mode,
       );
 
-      const callHeaders = (
-        vi.mocked(http.post).mock.calls[0][2] as {
-          headers: Record<string, string>;
-        }
-      ).headers;
-      expect(callHeaders["X-NVIDIA-API-Key"]).toBeUndefined();
+      expect(vi.mocked(http.post).mock.calls[0][2]).toBeUndefined();
     });
 
     it("returns structured response when present", async () => {
@@ -187,7 +178,6 @@ describe("CoachingService", () => {
           mode: "hint",
           language: "python",
         }),
-        expect.anything(),
       );
     });
 

--- a/frontend/src/features/coaching/coaching.service.ts
+++ b/frontend/src/features/coaching/coaching.service.ts
@@ -21,12 +21,6 @@ export interface CoachingResponse {
 export class CoachingService {
   constructor(private http: HttpClient) {}
 
-  private getApiKeyHeader(): Record<string, string> {
-    if (typeof window === "undefined") return {};
-    const key = localStorage.getItem("nvidia_api_key");
-    return key ? { "X-NVIDIA-API-Key": key } : {};
-  }
-
   async getCoachResponse(
     problem: string,
     language: string,
@@ -37,7 +31,6 @@ export class CoachingService {
     lessonContext?: string,
     chatHistory?: { role: string; content: string }[],
   ): Promise<CoachingResponse> {
-    const headers = this.getApiKeyHeader();
     const body: CoachingRequest = {
       problem,
       code,
@@ -55,7 +48,7 @@ export class CoachingService {
     const data = await this.http.post<{
       response: string;
       structured: StructuredCoachingResponse | null;
-    }>("/api/coach/", body, { headers });
+    }>("/api/coach/", body);
 
     return {
       response: data.response,


### PR DESCRIPTION
## Description

Stops sending the user's NVIDIA API key from `localStorage` to the backend on `/api/coach/` requests, and stops the backend from accepting a client-supplied key. The UI copy claimed the key was "never sent to our servers" while `CoachingService` transmitted it as an `X-NVIDIA-API-Key` header on every request — and the backend used that client-controlled header as the provider key.

## Changes

- `frontend/src/features/coaching/coaching.service.ts`: remove `getApiKeyHeader()`; `http.post("/api/coach/", body)` is now called without headers. The locally-stored key stays in `localStorage` and is never transmitted.
- `backend/app/api/coach.py`: `get_coaching_provider` no longer accepts the `X-NVIDIA-API-Key` header; it uses only `os.getenv("NVIDIA_API_KEY")` (500 if unset).
- `frontend/src/components/settings/SettingsModal.tsx`, `frontend/src/components/onboarding/OnboardingTour.tsx`: update copy — the key is optional, stored locally, and AI coaching uses the server-side key.
- Tests: `coaching.service.test.ts` now asserts the key is never transmitted; new `backend/tests/unit/test_coaching_provider.py` covers the server-side-only provider factory.

## Related Issue

Fixes #28

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [x] Test update

## Testing

- [x] Backend tests pass (`cd backend && python -m pytest tests/unit/`) — 479 passed
- [x] Frontend tests pass (`cd frontend && node node_modules/vitest/vitest.mjs run`) — 396 passed
- [x] TypeScript check passes (`tsc --noEmit`)
- [x] Lint passes (`ruff check . && ruff format . --check`; `next lint`)

## Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary (only for complex logic)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have not added any secrets or API keys to the code
