### PR TITLE
fix: guard debug endpoints to 404 outside non-production environments

### DIFF
--- a/backend/app/api/debug.py
+++ b/backend/app/api/debug.py
@@ -1,11 +1,22 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
 from typing import Dict, Any
 import os
 import logging
 import httpx
 from app.services.nim_service import NIMService
 
-router = APIRouter()
+
+def _debug_enabled() -> bool:
+    """Only expose debug endpoints outside production (request-time check).
+
+    Fail-closed: an unset ENVIRONMENT is treated as production, so the debug
+    endpoints return 404 unless ENVIRONMENT is explicitly non-production."""
+    if os.getenv("ENVIRONMENT", "production") == "production":
+        raise HTTPException(status_code=404, detail="Not found")
+    return True
+
+
+router = APIRouter(dependencies=[Depends(_debug_enabled)])
 logger = logging.getLogger(__name__)
 
 

--- a/backend/tests/unit/test_debug_guard.py
+++ b/backend/tests/unit/test_debug_guard.py
@@ -1,0 +1,28 @@
+"""Unit tests for the debug endpoint environment guard."""
+
+from fastapi.testclient import TestClient
+
+
+class TestDebugGuard:
+    def test_debug_disabled_in_production(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        from app.main import app
+
+        client = TestClient(app)
+        assert client.get("/debug/api-key-status").status_code == 404
+        assert client.get("/debug/environment").status_code == 404
+        assert client.get("/debug/test-connection").status_code == 404
+
+    def test_debug_disabled_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        from app.main import app
+
+        client = TestClient(app)
+        assert client.get("/debug/environment").status_code == 404
+
+    def test_debug_enabled_in_development(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        from app.main import app
+
+        client = TestClient(app)
+        assert client.get("/debug/environment").status_code == 200


### PR DESCRIPTION
## Description

Debug endpoints (`/debug/api-key-status`, `/debug/environment`, `/debug/test-connection`) were exposed with no environment guard, leaking environment variable names, API key presence/length, working directory, Python version, and triggering live outbound NVIDIA calls.

## Changes

- `backend/app/api/debug.py`: add a router-level dependency `_debug_enabled()` that raises 404 when `ENVIRONMENT == "production"`. Fail-closed: an unset `ENVIRONMENT` is treated as production. The check runs at request time, so it works correctly with per-test env overrides.
- `backend/tests/unit/test_debug_guard.py`: 3 tests — 404 in production, 404 when env unset, 200 in development.

## Related Issue

Fixes #35

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [x] Test update

## Testing

- [x] Backend tests pass (`cd backend && python -m pytest tests/unit/`) — 484 passed
- [x] Existing debug integration tests still pass (`tests/integration/test_debug_endpoints.py`)
- [x] Lint passes (`ruff check . && ruff format . --check`)

## Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary (only for complex logic)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have not added any secrets or API keys to the code
