### PR TITLE
fix: remove lru_cache from get_settings so env overrides take effect

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,6 +1,5 @@
 import os
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from functools import lru_cache
 from typing import Optional
 from pydantic import model_validator
 
@@ -35,6 +34,7 @@ class Settings(BaseSettings):
     REDIS_ENABLED: bool = True
 
 
-@lru_cache
 def get_settings() -> Settings:
+    """Construct fresh settings — no caching so env overrides (e.g. from test
+    fixtures) take effect and runtime env changes are picked up."""
     return Settings()

--- a/backend/tests/unit/test_settings.py
+++ b/backend/tests/unit/test_settings.py
@@ -1,0 +1,25 @@
+"""Unit tests for settings resolution (non-cached)."""
+
+
+class TestSettings:
+    def test_get_settings_reads_env_each_call(self, monkeypatch):
+        from app.core.config import get_settings
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "first-key")
+        assert get_settings().JWT_SECRET_KEY == "first-key"
+
+        monkeypatch.setenv("JWT_SECRET_KEY", "second-key")
+        assert get_settings().JWT_SECRET_KEY == "second-key"
+
+    def test_get_settings_respects_env_file_defaults(self, monkeypatch):
+        from app.core.config import get_settings
+
+        monkeypatch.delenv("REDIS_ENABLED", raising=False)
+        monkeypatch.delenv("USE_DATABASE", raising=False)
+        assert get_settings().REDIS_ENABLED is True
+        assert get_settings().USE_DATABASE is False
+
+    def test_get_settings_returns_new_instance(self, monkeypatch):
+        from app.core.config import get_settings
+
+        assert get_settings() is not get_settings()


### PR DESCRIPTION
## Description

`get_settings()` was decorated with `@lru_cache`, so settings were resolved once at first call. Environment overrides (e.g. from test fixtures) set after module import never took effect, and runtime env changes were impossible.

## Changes

- `backend/app/core/config.py`: remove `@lru_cache` and the now-unused `from functools import lru_cache`. `get_settings()` now constructs a fresh `Settings()` each call (cheap); it is already used as a per-request FastAPI dependency.
- `backend/tests/unit/test_settings.py`: 3 tests — env re-read per call, defaults, and fresh-instance guarantee.

## Related Issue

Fixes #36

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [x] Test update

## Testing

- [x] Backend tests pass (`cd backend && python -m pytest tests/unit/`) — 484 passed
- [x] Lint passes (`ruff check . && ruff format . --check`)

## Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary (only for complex logic)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have not added any secrets or API keys to the code
