### PR TITLE
fix: harden markdown rendering against XSS (escape quotes + sanitize output)

### DIFF
--- a/frontend/src/components/learn/MarkdownRenderer.test.tsx
+++ b/frontend/src/components/learn/MarkdownRenderer.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  MarkdownRenderer,
+  escapeHtml,
+  sanitizeHtml,
+  renderMarkdown,
+} from "./MarkdownRenderer";
+
+describe("escapeHtml", () => {
+  it("escapes HTML metacharacters including single quotes", () => {
+    const input = `<script>alert("xss")</script> & ' "`;
+    expect(escapeHtml(input)).toBe(
+      "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt; &amp; &#39; &quot;",
+    );
+  });
+});
+
+describe("sanitizeHtml", () => {
+  it("strips script, iframe, object and form tags", () => {
+    const html =
+      "<p>hello</p><script>alert(1)</script><iframe src=\"x\"></iframe><object></object><form></form>";
+    const out = sanitizeHtml(html);
+    expect(out).not.toContain("<script");
+    expect(out).not.toContain("<iframe");
+    expect(out).not.toContain("<object");
+    expect(out).not.toContain("<form");
+    expect(out).toContain("<p>hello</p>");
+  });
+
+  it("removes inline event handler attributes", () => {
+    const out = sanitizeHtml(
+      '<p onclick="alert(1)" onmouseover=\'steal()\'>safe</p>',
+    );
+    expect(out).not.toContain("onclick");
+    expect(out).not.toContain("onmouseover");
+    expect(out).toContain("<p>safe</p>");
+  });
+
+  it("strips javascript: URLs from href/src", () => {
+    const out = sanitizeHtml(
+      '<a href="javascript:alert(1)">x</a><img src="javascript:evil()"/>',
+    );
+    expect(out).not.toContain("javascript:");
+  });
+});
+
+describe("renderMarkdown", () => {
+  it("escapes raw HTML inside markdown text", () => {
+    const out = renderMarkdown("<script>alert(1)</script>");
+    expect(out).not.toContain("<script>");
+    expect(out).toContain("&lt;script&gt;");
+  });
+
+  it("renders headings and paragraphs", () => {
+    const out = renderMarkdown("# Title\n\nHello");
+    expect(out).toContain("<h1");
+    expect(out).toContain("Title");
+    expect(out).toContain("<p");
+    expect(out).toContain("Hello");
+  });
+
+  it("escapes code block contents", () => {
+    const out = renderMarkdown("```js\nconst a = '<b>';\n```");
+    expect(out).toContain("&lt;b&gt;");
+  });
+});
+
+describe("MarkdownRenderer component", () => {
+  it("renders content without executing injected script", () => {
+    render(
+      <MarkdownRenderer
+        content={"# Safe\n\n<script>window.__xss = 1</script>"}
+      />,
+    );
+    expect(screen.getByText("Safe")).toBeInTheDocument();
+    expect(document.querySelector("script")).toBeNull();
+  });
+});

--- a/frontend/src/components/learn/MarkdownRenderer.tsx
+++ b/frontend/src/components/learn/MarkdownRenderer.tsx
@@ -6,15 +6,27 @@ interface MarkdownRendererProps {
   content: string;
 }
 
-function escapeHtml(text: string): string {
+export function escapeHtml(text: string): string {
   return text
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
-function renderMarkdown(md: string): string {
+const DANGEROUS_TAGS_RE = /<\s*\/?\s*(script|iframe|object|embed|link|meta|base|form)\b[^>]*>/gi;
+const EVENT_HANDLER_ATTR_RE = /\son[a-z]+\s*=\s*(["'])[^"']*\1/gi;
+const JAVASCRIPT_URL_RE = /(href|src)\s*=\s*(["'])\s*javascript:[^"']*\2/gi;
+
+export function sanitizeHtml(html: string): string {
+  return html
+    .replace(DANGEROUS_TAGS_RE, "")
+    .replace(EVENT_HANDLER_ATTR_RE, "")
+    .replace(JAVASCRIPT_URL_RE, "");
+}
+
+export function renderMarkdown(md: string): string {
   const lines = md.split("\n");
   const html: string[] = [];
   let inCodeBlock = false;
@@ -89,7 +101,10 @@ function renderMarkdown(md: string): string {
 }
 
 export function MarkdownRenderer({ content }: MarkdownRendererProps) {
-  const html = useMemo(() => renderMarkdown(content), [content]);
+  const html = useMemo(
+    () => sanitizeHtml(renderMarkdown(content)),
+    [content],
+  );
 
   return (
     <div


### PR DESCRIPTION
## Description

Hardens markdown rendering against XSS. `MarkdownRenderer` builds HTML from (possibly AI-generated) content and injects it via `dangerouslySetInnerHTML`; the hand-rolled `escapeHtml` did not escape single quotes, and there was no final output sanitization as defense-in-depth.

## Changes

- `frontend/src/components/learn/MarkdownRenderer.tsx`:
  - `escapeHtml` now also escapes `'` → `&#39;` (closes the attribute-injection gap).
  - New exported `sanitizeHtml()` strips `<script>/<iframe>/<object>/<embed>/<link>/<meta>/<base>/<form>` tags, `on*` event-handler attributes, and `javascript:` URLs.
  - `renderMarkdown()` output is passed through `sanitizeHtml` before injection.
- `frontend/src/components/learn/MarkdownRenderer.test.tsx`: 8 tests covering escaping, sanitization, markdown rendering, and a component render that confirms no `script` node is created.

## Related Issue

Fixes #37

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [x] Test update

## Testing

- [x] Frontend tests pass (`cd frontend && node node_modules/vitest/vitest.mjs run`) — 406 passed
- [x] TypeScript check passes (`tsc --noEmit`)
- [x] Lint passes (`next lint`) — no new warnings

## Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary (only for complex logic)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have not added any secrets or API keys to the code
