### PR TITLE
fix(security): gate question-validation endpoints behind admin auth

### DIFF
--- a/backend/app/api/question_validation.py
+++ b/backend/app/api/question_validation.py
@@ -15,8 +15,9 @@ from app.models.question_validation_schemas import (
 from app.ports.code_executor import CodeExecutor
 from app.services.question_validator import QuestionValidatorService
 from app.api.dependencies import get_executor
+from app.api.auth_deps import require_admin
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_admin)])
 
 
 def get_validator_service(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -177,6 +177,43 @@ def test_env_vars():
 
 
 @pytest.fixture
+def admin_headers(test_client: TestClient) -> dict:
+    """Return Authorization headers for an admin user.
+
+    Registers (or logs in) a fixed admin user and promotes it to admin by
+    editing the users file directly, mirroring test_admin_curriculum_crud.py.
+    """
+    users_path = os.path.join(os.path.dirname(__file__), "..", "data", "users.json")
+
+    res = test_client.post(
+        "/api/auth/register",
+        json={
+            "username": "auditadmin",
+            "email": "auditadmin@test.com",
+            "password": "testpass123",
+        },
+    )
+    if res.status_code != 201:
+        res = test_client.post(
+            "/api/auth/login",
+            json={"username": "auditadmin", "password": "testpass123"},
+        )
+    token = res.json()["access_token"]
+
+    if os.path.exists(users_path):
+        with open(users_path) as f:
+            users = json.load(f)
+        for u in users:
+            if u.get("username") == "auditadmin":
+                u["role"] = "admin"
+                break
+        with open(users_path, "w") as f:
+            json.dump(users, f, indent=2)
+
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
 def sample_question_data():
     """Provide sample question data for testing."""
     return {

--- a/backend/tests/integration/test_question_validation_endpoints.py
+++ b/backend/tests/integration/test_question_validation_endpoints.py
@@ -54,7 +54,7 @@ def make_mock_result(valid: bool = True) -> QuestionValidationResult:
 
 
 class TestQuestionValidationValidate:
-    def test_validate_full_success(self, test_client: TestClient):
+    def test_validate_full_success(self, test_client: TestClient, admin_headers: dict):
         mock_validator = MagicMock()
         mock_validator.validate_question = AsyncMock(
             return_value=make_mock_result(valid=True)
@@ -67,6 +67,7 @@ class TestQuestionValidationValidate:
             response = test_client.post(
                 "/api/question-validation/validate",
                 json=VALID_QUESTION,
+                headers=admin_headers,
             )
             assert response.status_code == 200
             data = response.json()
@@ -75,7 +76,14 @@ class TestQuestionValidationValidate:
         finally:
             app.dependency_overrides.pop(get_validator_service, None)
 
-    def test_validate_full_failure(self, test_client: TestClient):
+    def test_validate_requires_auth(self, test_client: TestClient):
+        response = test_client.post(
+            "/api/question-validation/validate",
+            json=VALID_QUESTION,
+        )
+        assert response.status_code == 401
+
+    def test_validate_full_failure(self, test_client: TestClient, admin_headers: dict):
         mock_validator = MagicMock()
         result = make_mock_result(valid=False)
         result.results[ValidationUseCase.STRUCTURE] = UseCaseValidationResult(
@@ -101,6 +109,7 @@ class TestQuestionValidationValidate:
             response = test_client.post(
                 "/api/question-validation/validate",
                 json=VALID_QUESTION,
+                headers=admin_headers,
             )
             assert response.status_code == 200
             data = response.json()
@@ -109,16 +118,17 @@ class TestQuestionValidationValidate:
         finally:
             app.dependency_overrides.pop(get_validator_service, None)
 
-    def test_validate_invalid_input(self, test_client: TestClient):
+    def test_validate_invalid_input(self, test_client: TestClient, admin_headers: dict):
         response = test_client.post(
             "/api/question-validation/validate",
             json={"id": "no-fields"},
+            headers=admin_headers,
         )
         assert response.status_code == 422
 
 
 class TestQuestionValidationQuick:
-    def test_quick_validate_success(self, test_client: TestClient):
+    def test_quick_validate_success(self, test_client: TestClient, admin_headers: dict):
         mock_validator = MagicMock()
         mock_validator.quick_validate = AsyncMock(
             return_value=make_mock_result(valid=True)
@@ -131,6 +141,7 @@ class TestQuestionValidationQuick:
             response = test_client.post(
                 "/api/question-validation/validate/quick",
                 json=VALID_QUESTION,
+                headers=admin_headers,
             )
             assert response.status_code == 200
             data = response.json()
@@ -140,7 +151,9 @@ class TestQuestionValidationQuick:
 
 
 class TestQuestionValidationUseCases:
-    def test_validate_with_specific_use_cases(self, test_client: TestClient):
+    def test_validate_with_specific_use_cases(
+        self, test_client: TestClient, admin_headers: dict
+    ):
         mock_validator = MagicMock()
         mock_validator.validate_question = AsyncMock(
             return_value=make_mock_result(valid=True)
@@ -156,12 +169,15 @@ class TestQuestionValidationUseCases:
                     "question": VALID_QUESTION,
                     "use_cases": ["structure", "output_format"],
                 },
+                headers=admin_headers,
             )
             assert response.status_code == 200
         finally:
             app.dependency_overrides.pop(get_validator_service, None)
 
-    def test_validate_with_invalid_use_case_name(self, test_client: TestClient):
+    def test_validate_with_invalid_use_case_name(
+        self, test_client: TestClient, admin_headers: dict
+    ):
         mock_validator = MagicMock()
 
         from app.api.question_validation import get_validator_service
@@ -174,6 +190,7 @@ class TestQuestionValidationUseCases:
                     "question": VALID_QUESTION,
                     "use_cases": ["nonexistent_use_case"],
                 },
+                headers=admin_headers,
             )
             assert response.status_code == 400
             assert "Invalid use case" in response.json()["detail"]
@@ -182,7 +199,7 @@ class TestQuestionValidationUseCases:
 
 
 class TestQuestionValidationBatch:
-    def test_batch_validate(self, test_client: TestClient):
+    def test_batch_validate(self, test_client: TestClient, admin_headers: dict):
         mock_validator = MagicMock()
         mock_validator.validate_batch = AsyncMock(
             return_value=[make_mock_result(valid=True), make_mock_result(valid=False)]
@@ -195,6 +212,7 @@ class TestQuestionValidationBatch:
             response = test_client.post(
                 "/api/question-validation/batch-validate",
                 json=[VALID_QUESTION, VALID_QUESTION],
+                headers=admin_headers,
             )
             assert response.status_code == 200
             data = response.json()
@@ -206,8 +224,10 @@ class TestQuestionValidationBatch:
 
 
 class TestQuestionValidationInfo:
-    def test_get_use_cases(self, test_client: TestClient):
-        response = test_client.get("/api/question-validation/use-cases")
+    def test_get_use_cases(self, test_client: TestClient, admin_headers: dict):
+        response = test_client.get(
+            "/api/question-validation/use-cases", headers=admin_headers
+        )
         assert response.status_code == 200
         data = response.json()
         assert "use_cases" in data
@@ -220,8 +240,10 @@ class TestQuestionValidationInfo:
         assert "function_signature" in use_case_names
         assert "output_format" in use_case_names
 
-    def test_get_config(self, test_client: TestClient):
-        response = test_client.get("/api/question-validation/config")
+    def test_get_config(self, test_client: TestClient, admin_headers: dict):
+        response = test_client.get(
+            "/api/question-validation/config", headers=admin_headers
+        )
         assert response.status_code == 200
         data = response.json()
         assert "config" in data
@@ -232,7 +254,7 @@ class TestQuestionValidationInfo:
 
 
 class TestQuestionValidationSummary:
-    def test_get_summary(self, test_client: TestClient):
+    def test_get_summary(self, test_client: TestClient, admin_headers: dict):
         mock_validator = MagicMock()
         mock_validator.get_validation_summary = MagicMock(
             return_value={
@@ -259,9 +281,10 @@ class TestQuestionValidationSummary:
                     "warning_count": 0,
                     "validated_at": "2025-01-01T00:00:00Z",
                 },
+                headers=admin_headers,
             )
             assert response.status_code == 200
             data = response.json()
             assert data["valid"] is True
         finally:
-            app.dependency_overrides.clear()
+            app.dependency_overrides.pop(get_validator_service, None)

--- a/backend/tests/unit/test_question_validation_use_cases.py
+++ b/backend/tests/unit/test_question_validation_use_cases.py
@@ -828,6 +828,36 @@ class TestQuestionBankValidationIntegration:
 class TestQuestionValidationAPI:
     """Tests for question validation API endpoints."""
 
+    def _admin_headers(self, client) -> dict:
+        """Register an admin and promote it via the users file."""
+        res = client.post(
+            "/api/auth/register",
+            json={
+                "username": "unitvaladmin",
+                "email": "unitvaladmin@test.com",
+                "password": "testpass123",
+            },
+        )
+        if res.status_code != 201:
+            res = client.post(
+                "/api/auth/login",
+                json={"username": "unitvaladmin", "password": "testpass123"},
+            )
+        token = res.json()["access_token"]
+        users_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "data", "users.json"
+        )
+        if os.path.exists(users_path):
+            with open(users_path) as f:
+                users = json.load(f)
+            for u in users:
+                if u.get("username") == "unitvaladmin":
+                    u["role"] = "admin"
+                    break
+            with open(users_path, "w") as f:
+                json.dump(users, f, indent=2)
+        return {"Authorization": f"Bearer {token}"}
+
     @pytest.mark.asyncio
     async def test_validate_endpoint_returns_validation_result(
         self, valid_question_data
@@ -837,15 +867,32 @@ class TestQuestionValidationAPI:
         from app.main import app
 
         client = TestClient(app)
+        headers = self._admin_headers(client)
 
         response = client.post(
-            "/api/question-validation/validate", json=valid_question_data
+            "/api/question-validation/validate",
+            json=valid_question_data,
+            headers=headers,
         )
 
         assert response.status_code == 200
         data = response.json()
         assert "valid" in data
         assert "results" in data
+
+    @pytest.mark.asyncio
+    async def test_validate_endpoint_rejects_unauthenticated(self, valid_question_data):
+        """Test that the validate endpoint rejects unauthenticated requests."""
+        from fastapi.testclient import TestClient
+        from app.main import app
+
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/question-validation/validate", json=valid_question_data
+        )
+
+        assert response.status_code == 401
 
     @pytest.mark.asyncio
     async def test_batch_validate_endpoint_validates_multiple_questions(
@@ -856,12 +903,15 @@ class TestQuestionValidationAPI:
         from app.main import app
 
         client = TestClient(app)
+        headers = self._admin_headers(client)
 
         questions = [valid_question_data, valid_question_data.copy()]
         questions[1]["id"] = "test-question-2"
 
         response = client.post(
-            "/api/question-validation/batch-validate", json=questions
+            "/api/question-validation/batch-validate",
+            json=questions,
+            headers=headers,
         )
 
         assert response.status_code == 200


### PR DESCRIPTION
Require an authenticated admin for all /api/question-validation/* routes
by adding require_admin to the router-level dependencies. Previously the
endpoints accepted unauthenticated requests, allowing arbitrary AI-backed
validation and code-execution workload to be triggered.
Tests:
- integration: pass admin_headers to all existing validation tests
- integration: add test_validate_requires_auth (401 unauthenticated)
- unit: add _admin_headers helper + test_validate_endpoint_rejects_unauthenticated
- conftest: add admin_headers fixture (register/promote auditadmin)
Closes #45