### PR TITLE
fix(security): prevent path traversal via entity IDs in course admin

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -410,6 +410,8 @@ async def delete_course(
         _invalidate_course_cache()
         logger.info(f"Course {course_id} deleted by {current_user.id}")
         return {"message": "Course deleted successfully"}
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:
@@ -530,6 +532,8 @@ async def update_course(
         _invalidate_course_cache()
         logger.info(f"Course '{course_id}' updated by {current_user.id}")
         return {"message": "Course updated successfully"}
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -106,14 +106,20 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
 
 def _sanitize_errors(error_data):
-    """Recursively convert bytes to strings in error structures."""
+    """Recursively make error structures JSON-serializable.
+
+    Handles bytes (decode), Pydantic ``ValueError`` instances in ``ctx``
+    (stringify) and any other non-serializable objects.
+    """
     if isinstance(error_data, bytes):
         return error_data.decode("utf-8", errors="replace")
-    if isinstance(error_data, list):
-        return [_sanitize_errors(e) for e in error_data]
     if isinstance(error_data, dict):
         return {k: _sanitize_errors(v) for k, v in error_data.items()}
-    return error_data
+    if isinstance(error_data, list):
+        return [_sanitize_errors(e) for e in error_data]
+    if isinstance(error_data, (str, int, float, bool)) or error_data is None:
+        return error_data
+    return str(error_data)
 
 
 # Configure CORS

--- a/backend/app/models/admin_models.py
+++ b/backend/app/models/admin_models.py
@@ -1,6 +1,8 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from typing import List, Optional, Dict, Any
 from datetime import datetime
+
+from app.utils.ids import validate_entity_id
 
 
 class UserAdminUpdate(BaseModel):
@@ -63,6 +65,11 @@ class CourseCreate(BaseModel):
     icon: str = Field(default="code", description="Icon identifier for UI")
     order: int = Field(..., description="Display order")
 
+    @field_validator("id")
+    @classmethod
+    def _safe_id(cls, v: str) -> str:
+        return validate_entity_id(v, "id")
+
 
 class CourseUpdate(BaseModel):
     title: Optional[str] = None
@@ -78,6 +85,11 @@ class ModuleCreate(BaseModel):
     title: str = Field(..., description="Module title")
     description: str = Field(..., description="Module overview")
     order: int = Field(..., description="Display order within course")
+
+    @field_validator("id", "course_id")
+    @classmethod
+    def _safe_ids(cls, v: str, info) -> str:
+        return validate_entity_id(v, info.field_name)
 
 
 class ModuleUpdate(BaseModel):
@@ -102,6 +114,11 @@ class LessonCreate(BaseModel):
         None, description="Linked question ID for exercises"
     )
     language: str = Field(..., description="Programming language")
+
+    @field_validator("id", "course_id", "module_id")
+    @classmethod
+    def _safe_ids(cls, v: str, info) -> str:
+        return validate_entity_id(v, info.field_name)
 
 
 class LessonUpdate(BaseModel):

--- a/backend/app/repositories/file_course_admin_repository.py
+++ b/backend/app/repositories/file_course_admin_repository.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, Any
 
 from app.ports.course_admin_repository import CourseAdminRepository
+from app.utils.ids import validate_entity_id
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,7 @@ class FileCourseAdminRepository(CourseAdminRepository):
         self._lock = threading.Lock()
 
     def _course_dir(self, course_id: str) -> Path:
+        validate_entity_id(course_id, "course_id")
         return self._courses_dir / course_id
 
     def _read_json(self, path: Path) -> Dict[str, Any]:

--- a/backend/app/utils/ids.py
+++ b/backend/app/utils/ids.py
@@ -1,0 +1,26 @@
+"""Safe entity-ID validation.
+
+Entity IDs (courses, modules, lessons) are used as filesystem directory and
+URL segment components, so they must be restricted to a safe slug alphabet.
+This prevents path-traversal (e.g. "../../backend") and other surprising IDs.
+"""
+
+import re
+
+ENTITY_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,99}$")
+
+
+def validate_entity_id(entity_id: str, field: str = "id") -> str:
+    """Validate an entity ID and return it unchanged.
+
+    Raises ValueError if the ID is empty, non-string, or contains characters
+    outside the safe slug alphabet (letters, digits, '-', '_').
+    """
+    if not isinstance(entity_id, str) or not entity_id:
+        raise ValueError(f"{field} must be a non-empty string")
+    if not ENTITY_ID_RE.match(entity_id):
+        raise ValueError(
+            f"{field} must be 1-100 chars using letters, digits, '_' or '-' "
+            "(no '/', '\\\\', '..', or whitespace)"
+        )
+    return entity_id

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -177,6 +177,43 @@ def test_env_vars():
 
 
 @pytest.fixture
+def admin_headers(test_client: TestClient) -> dict:
+    """Return Authorization headers for an admin user.
+
+    Registers (or logs in) a fixed admin user and promotes it to admin by
+    editing the users file directly, mirroring test_admin_curriculum_crud.py.
+    """
+    users_path = os.path.join(os.path.dirname(__file__), "..", "data", "users.json")
+
+    res = test_client.post(
+        "/api/auth/register",
+        json={
+            "username": "auditadmin",
+            "email": "auditadmin@test.com",
+            "password": "testpass123",
+        },
+    )
+    if res.status_code != 201:
+        res = test_client.post(
+            "/api/auth/login",
+            json={"username": "auditadmin", "password": "testpass123"},
+        )
+    token = res.json()["access_token"]
+
+    if os.path.exists(users_path):
+        with open(users_path) as f:
+            users = json.load(f)
+        for u in users:
+            if u.get("username") == "auditadmin":
+                u["role"] = "admin"
+                break
+        with open(users_path, "w") as f:
+            json.dump(users, f, indent=2)
+
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
 def sample_question_data():
     """Provide sample question data for testing."""
     return {

--- a/backend/tests/unit/test_safe_entity_ids.py
+++ b/backend/tests/unit/test_safe_entity_ids.py
@@ -1,0 +1,163 @@
+"""Tests for safe entity-ID validation (path-traversal guard).
+
+Entity IDs (course/module/lesson) are used as filesystem paths by the file
+admin repository, so unsafe IDs must be rejected before any filesystem use.
+"""
+
+import tempfile
+import pytest
+from pathlib import Path
+
+from app.utils.ids import validate_entity_id
+from app.repositories.file_course_admin_repository import FileCourseAdminRepository
+
+
+# ── validate_entity_id unit tests ───────────────────────
+
+
+class TestValidateEntityId:
+    @pytest.mark.parametrize(
+        "entity_id",
+        [
+            "python-fundamentals",
+            "c-programming",
+            "module_01",
+            "lesson-2",
+            "a",
+            "A1_b-c",
+        ],
+    )
+    def test_accepts_valid_slugs(self, entity_id):
+        assert validate_entity_id(entity_id) == entity_id
+
+    @pytest.mark.parametrize(
+        "entity_id",
+        [
+            "",
+            "../etc",
+            "..",
+            "a/b",
+            "a\\b",
+            "has space",
+            ".hidden",
+            "-leading-dash",
+            "/absolute",
+            "a" * 101,
+            None,
+            123,
+        ],
+    )
+    def test_rejects_unsafe_ids(self, entity_id):
+        with pytest.raises(ValueError):
+            validate_entity_id(entity_id)
+
+
+# ── FileCourseAdminRepository path-traversal guard ──────
+
+
+class TestCourseAdminRepositorySafePaths:
+    @pytest.fixture
+    def repo_and_tmp(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            courses_dir = Path(tmpdir) / "courses"
+            courses_dir.mkdir()
+            repo = FileCourseAdminRepository(courses_dir=str(courses_dir))
+            yield repo, Path(tmpdir)
+
+    @pytest.mark.asyncio
+    async def test_create_course_rejects_traversal(self, repo_and_tmp):
+        repo, tmpdir = repo_and_tmp
+        with pytest.raises(ValueError):
+            await repo.create_course({"id": "../../escaped", "title": "Bad"})
+        # No directory created outside the courses dir
+        assert not (tmpdir / "escaped").exists()
+        assert not (tmpdir / "courses" / "escaped").exists()
+
+    @pytest.mark.asyncio
+    async def test_delete_course_rejects_traversal(self, repo_and_tmp):
+        repo, tmpdir = repo_and_tmp
+        # Sentinel outside the courses dir must survive an attempted delete
+        sentinel = tmpdir / "sentinel.txt"
+        sentinel.write_text("keep me")
+        with pytest.raises(ValueError):
+            await repo.delete_course("../../sentinel.txt")
+        assert sentinel.exists()
+        assert sentinel.read_text() == "keep me"
+
+    @pytest.mark.asyncio
+    async def test_course_dir_rejects_unsafe_id(self, repo_and_tmp):
+        repo, _ = repo_and_tmp
+        for bad in ("../x", "a/b", "a\\b", "..", "has space"):
+            with pytest.raises(ValueError):
+                repo._course_dir(bad)
+
+    @pytest.mark.asyncio
+    async def test_valid_course_still_round_trips(self, repo_and_tmp):
+        repo, _ = repo_and_tmp
+        created = await repo.create_course(
+            {
+                "id": "valid-course",
+                "title": "OK",
+                "description": "",
+                "language": "python",
+                "order": 1,
+            }
+        )
+        assert created["id"] == "valid-course"
+        assert await repo.delete_course("valid-course") is True
+
+
+# ── Admin API rejects unsafe IDs (Pydantic layer) ───────
+
+
+class TestAdminApiSafeIds:
+    @pytest.mark.parametrize(
+        "bad_id",
+        ["../../etc", "a/b", "a\\b", "has space", "..", ""],
+    )
+    def test_create_course_with_bad_id_returns_422(
+        self, test_client, admin_headers, bad_id
+    ):
+        res = test_client.post(
+            "/api/admin/courses",
+            json={
+                "id": bad_id,
+                "title": "Bad",
+                "description": "x",
+                "language": "python",
+                "order": 1,
+            },
+            headers=admin_headers,
+        )
+        assert res.status_code == 422
+
+    def test_create_module_with_bad_ids_returns_422(self, test_client, admin_headers):
+        res = test_client.post(
+            "/api/admin/modules",
+            json={
+                "id": "../../mod",
+                "course_id": "ok-course",
+                "title": "M",
+                "description": "x",
+                "order": 1,
+            },
+            headers=admin_headers,
+        )
+        assert res.status_code == 422
+
+    def test_create_lesson_with_bad_ids_returns_422(self, test_client, admin_headers):
+        res = test_client.post(
+            "/api/admin/lessons",
+            json={
+                "id": "ok-lesson",
+                "course_id": "../../etc",
+                "module_id": "ok-module",
+                "title": "L",
+                "type": "theory",
+                "content": "x",
+                "order": 1,
+                "language": "python",
+            },
+            headers=admin_headers,
+        )
+        assert res.status_code == 422


### PR DESCRIPTION
Entity IDs (course/module/lesson) are used as filesystem directory and URL
segment components by FileCourseAdminRepository. A crafted ID like
'../../etc' could escape the courses directory and read/write arbitrary
JSON files. Validation previously existed only client-side.
Changes:
- add app/utils/ids.py: validate_entity_id (slug alphabet, 1-100 chars)
- enforce it in FileCourseAdminRepository._course_dir so every filesystem
  use of an ID is guarded
- add Pydantic field_validators on CourseCreate.id, ModuleCreate.id/course_id,
  LessonCreate.id/course_id/module_id so bad IDs return 422
- convert ValueError to 400 in delete_course/update_course
- include main.py _sanitize_errors fix: Pydantic field-validator errors carry
  ValueError in ctx which the 422 handler could not JSON-serialize, causing a
  500 instead of a 422. Required for the new 422 tests to pass.
Tests: test_safe_entity_ids.py (30 tests: validator units, repo traversal
guard, admin API 422s). Full unit suite: 538 passed.
Closes #46