### PR TITLE
fix(admin): run real validation pipeline in question validate endpoint

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -6,6 +6,7 @@ from app.ports.admin_repository import AdminRepository
 from app.ports.user_admin_repository import UserAdminRepository
 from app.ports.question_admin_repository import QuestionAdminRepository
 from app.ports.course_admin_repository import CourseAdminRepository
+from app.ports.code_executor import CodeExecutor
 from app.api.auth_deps import require_admin, require_super_admin
 from app.api.dependencies import (
     get_admin_repo,
@@ -13,7 +14,10 @@ from app.api.dependencies import (
     get_question_admin_repo,
     get_course_admin_repo,
     get_file_course_repo,
+    get_executor,
 )
+from app.services.question_validator import QuestionValidatorService
+from app.models.schemas import Question
 from app.models.auth_schemas import UserResponse
 from app.models.admin_models import (
     UserAdminUpdate,
@@ -353,9 +357,10 @@ async def import_questions(
 async def validate_question(
     question_id: str,
     admin_repo: QuestionAdminRepository = Depends(get_question_admin_repo),
+    executor: CodeExecutor = Depends(get_executor),
     current_user: UserResponse = Depends(require_admin),
 ):
-    """Validate question test cases (admins only)."""
+    """Run the full validation pipeline on a question (admins only)."""
     try:
         question = await admin_repo.get_question_by_id(question_id)
         if not question:
@@ -364,7 +369,31 @@ async def validate_question(
                 detail="Question not found",
             )
 
-        return {"message": "Validation completed", "result": "All test cases passed"}
+        question_data = dict(question)
+        if "starter_code" in question_data and "starter" not in question_data:
+            question_data["starter"] = question_data.pop("starter_code")
+
+        validator = QuestionValidatorService(executor=executor)
+        result = await validator.validate_question(Question(**question_data))
+
+        logger.info(
+            f"Question {question_id} validated by {current_user.id}: "
+            f"valid={result.valid}, issues={result.total_issues}"
+        )
+        return {
+            "question_id": question_id,
+            "valid": result.valid,
+            "total_issues": result.total_issues,
+            "error_count": result.error_count,
+            "warning_count": result.warning_count,
+            "results": {
+                uc.value: {
+                    "passed": r.passed,
+                    "issues": [i.message for i in r.issues],
+                }
+                for uc, r in result.results.items()
+            },
+        }
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -177,6 +177,43 @@ def test_env_vars():
 
 
 @pytest.fixture
+def admin_headers(test_client: TestClient) -> dict:
+    """Return Authorization headers for an admin user.
+
+    Registers (or logs in) a fixed admin user and promotes it to admin by
+    editing the users file directly, mirroring test_admin_curriculum_crud.py.
+    """
+    users_path = os.path.join(os.path.dirname(__file__), "..", "data", "users.json")
+
+    res = test_client.post(
+        "/api/auth/register",
+        json={
+            "username": "auditadmin",
+            "email": "auditadmin@test.com",
+            "password": "testpass123",
+        },
+    )
+    if res.status_code != 201:
+        res = test_client.post(
+            "/api/auth/login",
+            json={"username": "auditadmin", "password": "testpass123"},
+        )
+    token = res.json()["access_token"]
+
+    if os.path.exists(users_path):
+        with open(users_path) as f:
+            users = json.load(f)
+        for u in users:
+            if u.get("username") == "auditadmin":
+                u["role"] = "admin"
+                break
+        with open(users_path, "w") as f:
+            json.dump(users, f, indent=2)
+
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
 def sample_question_data():
     """Provide sample question data for testing."""
     return {

--- a/backend/tests/integration/test_admin_validate_question.py
+++ b/backend/tests/integration/test_admin_validate_question.py
@@ -1,0 +1,72 @@
+"""Tests for the admin question-validation endpoint (was a stub).
+
+Verifies the endpoint now runs the real validation pipeline and returns
+honest results instead of always claiming "All test cases passed".
+"""
+
+from app.main import app
+from app.api.dependencies import get_question_admin_repo, get_executor
+
+
+class _StubNotFound:
+    async def get_question_by_id(self, question_id):
+        return None
+
+
+class _StubQuestion:
+    async def get_question_by_id(self, question_id):
+        return {
+            "id": question_id,
+            "title": "Two Sum",
+            "difficulty": "easy",
+            "category": "arrays",
+            "company_tags": [],
+            "description": "Find two numbers that sum to target.",
+            "starter_code": {"python": "def two_sum(nums, target):\n    pass"},
+            "examples": [
+                {"input": "[2, 7, 11, 15], 9", "output": "[0, 1]", "explanation": ""}
+            ],
+            "test_cases": [
+                {
+                    "input": "[2, 7, 11, 15], 9",
+                    "expected_output": "[0, 1]",
+                    "hidden": False,
+                }
+            ],
+            "hints": [],
+            "solution": None,
+            "time_complexity": "O(n)",
+            "space_complexity": "O(n)",
+            "constraints": ["2 <= nums.length <= 10^4"],
+        }
+
+
+class TestAdminQuestionValidation:
+    def test_validate_question_not_found(self, test_client, admin_headers):
+        app.dependency_overrides[get_question_admin_repo] = lambda: _StubNotFound()
+        try:
+            res = test_client.post(
+                "/api/admin/questions/validate/nonexistent", headers=admin_headers
+            )
+            assert res.status_code == 404
+        finally:
+            app.dependency_overrides.pop(get_question_admin_repo, None)
+
+    def test_validate_question_runs_real_pipeline(
+        self, test_client, admin_headers, mock_piston_service
+    ):
+        app.dependency_overrides[get_question_admin_repo] = lambda: _StubQuestion()
+        app.dependency_overrides[get_executor] = lambda: mock_piston_service()
+        try:
+            res = test_client.post(
+                "/api/admin/questions/validate/test-q", headers=admin_headers
+            )
+            assert res.status_code == 200
+            data = res.json()
+            assert data["question_id"] == "test-q"
+            assert "valid" in data
+            assert "total_issues" in data
+            assert "results" in data
+        finally:
+            app.dependency_overrides.pop(get_question_admin_repo, None)
+            app.dependency_overrides.pop(get_executor, None)


### PR DESCRIPTION
POST /api/admin/questions/validate/{id} was a stub that always returned
'All test cases passed' without executing any validation. Wire it to
QuestionValidatorService.validate_question so it returns honest results
(valid, total_issues, per-use-case results) using the real executor.
Maps starter_code -> starter for the Question schema.
Tests: test_admin_validate_question.py (404 for missing question, 200
with real pipeline + mocked executor).
Closes #47