### PR TITLE
fix(config): gate /docs + /redoc and trim /health in production

### DIFF
--- a/backend/app/api/debug.py
+++ b/backend/app/api/debug.py
@@ -4,6 +4,7 @@ import os
 import logging
 import httpx
 from app.services.nim_service import NIMService
+from app.core.config import is_production
 
 
 def _debug_enabled() -> bool:
@@ -11,7 +12,7 @@ def _debug_enabled() -> bool:
 
     Fail-closed: an unset ENVIRONMENT is treated as production, so the debug
     endpoints return 404 unless ENVIRONMENT is explicitly non-production."""
-    if os.getenv("ENVIRONMENT", "production") == "production":
+    if is_production():
         raise HTTPException(status_code=404, detail="Not found")
     return True
 

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, Request
 from datetime import datetime, timezone
-from importlib.metadata import version
 
 router = APIRouter()
 
@@ -11,11 +10,6 @@ async def health_check(request: Request):
     return {
         "status": "ok",
         "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
-        "system": {
-            "python_version": f"{__import__('sys').version_info.major}.{__import__('sys').version_info.minor}.{__import__('sys').version_info.micro}",
-            "fastapi_version": version("fastapi"),
-            "uvicorn_version": version("uvicorn"),
-        },
         "features": {
             "ai_coaching": "enabled",
             "code_execution": "enabled",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,4 +1,3 @@
-import os
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import Optional
 from pydantic import model_validator
@@ -6,6 +5,9 @@ from pydantic import model_validator
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    # Environment (fail-closed: unset = production for security gates)
+    ENVIRONMENT: str = "production"
 
     # Database
     DATABASE_URL: str = "sqlite+aiosqlite:///./codecoach.db"
@@ -17,8 +19,7 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def _require_jwt_key_in_production(self):
-        env = os.getenv("ENVIRONMENT", "development")
-        if env == "production" and not self.JWT_SECRET_KEY:
+        if self.ENVIRONMENT == "production" and not self.JWT_SECRET_KEY:
             raise ValueError("JWT_SECRET_KEY must be set in production")
         return self
 
@@ -38,3 +39,8 @@ def get_settings() -> Settings:
     """Construct fresh settings — no caching so env overrides (e.g. from test
     fixtures) take effect and runtime env changes are picked up."""
     return Settings()
+
+
+def is_production() -> bool:
+    """Fail-closed environment check: unset ENVIRONMENT = production."""
+    return get_settings().ENVIRONMENT == "production"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,13 +42,11 @@ from app.api import (  # noqa: E402
     progress,
     admin,
 )
-from app.core.config import get_settings  # noqa: E402
+from app.core.config import get_settings, is_production  # noqa: E402
 from app.core.database import init_db  # noqa: E402
 from app.middleware.rate_limit import limiter  # noqa: E402
 from app.middleware.security_headers import SecurityHeadersMiddleware  # noqa: E402
 from app.services.redis_service import RedisCache  # noqa: E402
-
-settings = get_settings()
 
 
 @asynccontextmanager
@@ -77,15 +75,17 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         logger.info("Redis cache connection closed")
 
 
+settings = get_settings()
+
+_production = is_production()
 app = FastAPI(
     title="CodeCoach AI Backend",
     description="AI-powered coding interview practice platform backend",
     version="1.0.0",
-    docs_url="/docs",
-    redoc_url="/redoc",
+    docs_url="/docs" if not _production else None,
+    redoc_url="/redoc" if not _production else None,
     lifespan=lifespan,
 )
-
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,6 +2,14 @@
 Test configuration and fixtures for CodeCoach AI API testing.
 """
 
+import os
+
+# Set safe defaults BEFORE app.main is imported so that Settings() does not
+# fail-fast at collection time (ENVIRONMENT unset = production = requires a
+# JWT secret). Individual tests override via monkeypatch/test_env_vars.
+os.environ.setdefault("ENVIRONMENT", "testing")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-testing-only-32chars!!")
+
 import pytest
 import pytest_asyncio
 import asyncio

--- a/backend/tests/integration/test_health_endpoints.py
+++ b/backend/tests/integration/test_health_endpoints.py
@@ -12,7 +12,7 @@ class TestHealthEndpoints:
 
     def test_health_check_basic(self, test_client: TestClient):
         """Test basic health check endpoint."""
-        response = test_client.get("/health/health")
+        response = test_client.get("/health/")
 
         assert response.status_code == 200
         data = response.json()
@@ -22,22 +22,19 @@ class TestHealthEndpoints:
 
     def test_health_check_detailed(self, test_client: TestClient):
         """Test detailed health check endpoint."""
-        response = test_client.get("/health/health")
+        response = test_client.get("/health/")
 
         assert response.status_code == 200
         data = response.json()
 
         assert data["status"] == "ok"
         assert "timestamp" in data
-        assert "system" in data
         assert "features" in data
         assert "dependencies" in data
 
-        # Check system information
-        system = data["system"]
-        assert "python_version" in system
-        assert "fastapi_version" in system
-        assert "uvicorn_version" in system
+        # The health payload must not leak version/stack details
+        assert "system" not in data
+        assert "python_version" not in data
 
         # Check features
         features = data["features"]
@@ -55,7 +52,7 @@ class TestHealthEndpoints:
     @pytest.mark.asyncio
     async def test_health_check_async(self, async_client: AsyncClient):
         """Test health check with async client."""
-        response = await async_client.get("/health/health", follow_redirects=True)
+        response = await async_client.get("/health/", follow_redirects=True)
 
         assert response.status_code == 200
         data = response.json()
@@ -64,7 +61,7 @@ class TestHealthEndpoints:
 
     def test_health_check_response_format(self, test_client: TestClient):
         """Test health check response format consistency."""
-        response = test_client.get("/health/health")
+        response = test_client.get("/health/")
 
         assert response.status_code == 200
         assert response.headers["content-type"] == "application/json"
@@ -85,18 +82,18 @@ class TestHealthEndpoints:
     def test_health_check_error_handling(self, test_client: TestClient):
         """Test health check error handling."""
         # Test with invalid HTTP method
-        response = test_client.post("/health/health")
+        response = test_client.post("/health/")
         assert response.status_code == 405
 
-        response = test_client.put("/health/health")
+        response = test_client.put("/health/")
         assert response.status_code == 405
 
-        response = test_client.delete("/health/health")
+        response = test_client.delete("/health/")
         assert response.status_code == 405
 
     def test_health_check_caching_headers(self, test_client: TestClient):
         """Test health check caching headers."""
-        response = test_client.get("/health/health")
+        response = test_client.get("/health/")
 
         assert response.status_code == 200
 
@@ -109,7 +106,7 @@ class TestHealthEndpoints:
         import time
 
         start_time = time.time()
-        response = test_client.get("/health/health")
+        response = test_client.get("/health/")
         end_time = time.time()
 
         assert response.status_code == 200
@@ -125,7 +122,7 @@ class TestHealthEndpoints:
         import time
 
         start_time = time.time()
-        response = test_client.get("/health/health")
+        response = test_client.get("/health/")
         end_time = time.time()
 
         assert response.status_code == 200

--- a/backend/tests/performance/test_load_limits.py
+++ b/backend/tests/performance/test_load_limits.py
@@ -45,7 +45,7 @@ class TestLoadLimits:
     @pytest.mark.asyncio
     async def test_concurrent_requests_health(self, async_client: AsyncClient):
         """Test concurrent health check requests."""
-        tasks = [async_client.get("/health/health") for _ in range(100)]
+        tasks = [async_client.get("/health/") for _ in range(100)]
         responses = await asyncio.gather(*tasks)
 
         for response in responses:
@@ -86,7 +86,7 @@ class TestLoadLimits:
 
         for _ in range(100):
             start_time = time.time()
-            response = await async_client.get("/health/health")
+            response = await async_client.get("/health/")
             end_time = time.time()
 
             assert response.status_code == 200
@@ -109,7 +109,7 @@ class TestLoadLimits:
         responses = []
 
         for i in range(20):
-            response = await async_client.get("/health/health")
+            response = await async_client.get("/health/")
             responses.append(response.status_code)
 
         assert all(status == 200 for status in responses)
@@ -158,7 +158,7 @@ class TestLoadLimits:
     async def test_stress_test_endpoints(self, async_client: AsyncClient):
         """Stress test all endpoints."""
         endpoints = [
-            "/health/health",
+            "/health/",
             "/api/questions/",
             "/api/questions/categories",
             "/api/questions/companies",
@@ -236,7 +236,7 @@ print(len(large_list))
     @pytest.mark.asyncio
     async def test_connection_pool_limits(self, async_client: AsyncClient):
         """Test connection pool limits."""
-        tasks = [async_client.get("/health/health") for _ in range(100)]
+        tasks = [async_client.get("/health/") for _ in range(100)]
         results = await asyncio.gather(*tasks)
 
         assert all(r.status_code == 200 for r in results)
@@ -272,7 +272,7 @@ while True:
     async def test_load_balancing_simulation(self, async_client: AsyncClient):
         """Simulate load across different endpoints."""
         endpoints = [
-            "/health/health",
+            "/health/",
             "/api/questions/",
             "/api/coach/modes",
         ]
@@ -294,7 +294,7 @@ while True:
         times = []
         for _ in range(20):
             start = time.time()
-            response = await async_client.get("/health/health")
+            response = await async_client.get("/health/")
             elapsed = (time.time() - start) * 1000
             assert response.status_code == 200
             times.append(elapsed)

--- a/backend/tests/performance/test_load_profiles.py
+++ b/backend/tests/performance/test_load_profiles.py
@@ -17,7 +17,7 @@ async def test_ramp_up_rps(async_client: AsyncClient):
     duration = 10.0
     for i in range(1, target_users + 1):
         delay = i * (duration / target_users)
-        tasks = [async_client.get("/health/health") for _ in range(i)]
+        tasks = [async_client.get("/health/") for _ in range(i)]
         batch = await asyncio.gather(*tasks)
         results.extend(batch)
         if delay < duration:
@@ -41,7 +41,7 @@ async def test_sustained_load(async_client: AsyncClient):
     results = []
     start = time.time()
     while time.time() - start < 10:
-        batch = [async_client.get("/health/health") for _ in range(5)]
+        batch = [async_client.get("/health/") for _ in range(5)]
         results.extend(await asyncio.gather(*batch))
         await asyncio.sleep(0.25)
     assert all(r.status_code == 200 for r in results)

--- a/backend/tests/security/test_api_security.py
+++ b/backend/tests/security/test_api_security.py
@@ -55,7 +55,7 @@ class TestApiSecurity:
         """Wrong HTTP methods should return 405."""
         get_only_endpoints = [
             "/api/auth/me",
-            "/health/health",
+            "/health/",
             "/api/questions/categories",
         ]
         for endpoint in get_only_endpoints:
@@ -74,12 +74,12 @@ class TestApiSecurity:
             {"User-Agent": "Mozilla\r\nLocation: http://evil.com"},
         ]
         for headers in payloads:
-            response = test_client.get("/health/health", headers=headers)
+            response = test_client.get("/health/", headers=headers)
             assert response.status_code in [200, 401]
 
     def test_hsts_header(self, test_client: TestClient):
         """HSTS header should be present on responses (if configured)."""
-        response = test_client.get("/health/health")
+        response = test_client.get("/health/")
         hsts = response.headers.get("strict-transport-security")
         if hsts:
             assert "max-age=" in hsts
@@ -93,6 +93,6 @@ class TestApiSecurity:
 
     def test_server_header_not_leaked(self, test_client: TestClient):
         """Server header should not leak version info."""
-        response = test_client.get("/health/health")
+        response = test_client.get("/health/")
         server = response.headers.get("server", "")
         assert "uvicorn" not in server.lower(), f"Server header leaks version: {server}"

--- a/backend/tests/security/test_security_vulnerabilities.py
+++ b/backend/tests/security/test_security_vulnerabilities.py
@@ -192,7 +192,7 @@ class TestSecurityVulnerabilities:
         ]
 
         for headers in bypass_attempts:
-            response = test_client.get("/health/health", headers=headers)
+            response = test_client.get("/health/", headers=headers)
 
             # Should still work normally
             assert response.status_code in [200, 401]
@@ -229,7 +229,7 @@ class TestSecurityVulnerabilities:
         ]
 
         for origin in origins:
-            response = test_client.get("/health/health", headers={"Origin": origin})
+            response = test_client.get("/health/", headers={"Origin": origin})
 
             # Should handle CORS properly
             assert response.status_code in [200, 401]
@@ -297,7 +297,7 @@ class TestSecurityVulnerabilities:
 
         # Only check health endpoint; data endpoints legitimately contain these words
         endpoints = [
-            "/health/health",
+            "/health/",
         ]
 
         for endpoint in endpoints:
@@ -344,7 +344,7 @@ class TestSecurityVulnerabilities:
         ]
 
         for headers in header_injection_payloads:
-            response = test_client.get("/health/health", headers=headers)
+            response = test_client.get("/health/", headers=headers)
 
             # Should handle gracefully
             assert response.status_code in [200, 401]
@@ -360,14 +360,14 @@ class TestSecurityVulnerabilities:
         ]
 
         for headers in session_headers:
-            response = test_client.get("/health/health", headers=headers)
+            response = test_client.get("/health/", headers=headers)
 
             # Should work normally
             assert response.status_code in [200, 401]
 
     def test_clickjacking_prevention(self, test_client: TestClient):
         """Test clickjacking prevention headers (if set)."""
-        response = test_client.get("/health/health")
+        response = test_client.get("/health/")
 
         assert response.status_code in [200, 401]
 
@@ -382,7 +382,7 @@ class TestSecurityVulnerabilities:
 
     def test_secure_headers_presence(self, test_client: TestClient):
         """Test presence of security headers (skip headers not configured)."""
-        response = test_client.get("/health/health")
+        response = test_client.get("/health/")
 
         assert response.status_code in [200, 401]
 

--- a/backend/tests/unit/test_settings.py
+++ b/backend/tests/unit/test_settings.py
@@ -14,6 +14,7 @@ class TestSettings:
     def test_get_settings_respects_env_file_defaults(self, monkeypatch):
         from app.core.config import get_settings
 
+        monkeypatch.setenv("ENVIRONMENT", "testing")
         monkeypatch.delenv("REDIS_ENABLED", raising=False)
         monkeypatch.delenv("USE_DATABASE", raising=False)
         assert get_settings().REDIS_ENABLED is True
@@ -21,5 +22,7 @@ class TestSettings:
 
     def test_get_settings_returns_new_instance(self, monkeypatch):
         from app.core.config import get_settings
+
+        monkeypatch.setenv("ENVIRONMENT", "testing")
 
         assert get_settings() is not get_settings()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - "8000:8000"
     environment:
+      - ENVIRONMENT=${ENVIRONMENT:-development}
       - NVIDIA_API_KEY=${NVIDIA_API_KEY}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       - DATABASE_URL=${DATABASE_URL:-sqlite+aiosqlite:///./codecoach.db}
@@ -26,7 +27,7 @@ services:
     networks:
       - codecoach-network
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health/health').status == 200 else 1)"]
+      test: ["CMD", "python", "-c", "import urllib.request, sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health/').status == 200 else 1)"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
FastAPI served Swagger UI (/docs) and ReDoc (/redoc) in every environment
and /api/health returned python/FastAPI/uvicorn version strings, leaking
stack details and exposing an attack surface in production.
Changes:
- Settings.ENVIRONMENT now defaults to 'production' (fail-closed). The
  previous default was 'development', so security gates were fail-open when
  the env var was unset. docker-compose passes ENVIRONMENT=${ENVIRONMENT:-development}
  so local dev behavior is unchanged.
- add is_production() helper; use it in the debug guard (replacing the
  inline os.getenv check) and in main.py to set docs_url/redoc_url to None
  in production.
- /api/health no longer returns the 'system' version block.
- fix docker-compose backend healthcheck path (/health/health -> /health/).
- tests: fix wrong /health/health references across integration, security
  and performance suites; assert 'system' is absent from the health payload;
  set ENVIRONMENT=testing in settings unit tests (production default now
  requires a JWT secret).
Closes #48