### PR TITLE
fix(security): remove hardcoded ACAO header on coach stream

### DIFF
--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -234,7 +234,6 @@ async def get_coaching_stream(
         headers={
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
-            "Access-Control-Allow-Origin": "*",
         },
     )
 


### PR DESCRIPTION
The SSE StreamingResponse explicitly set Access-Control-Allow-Origin: *,
bypassing the CORS middleware origin allowlist and letting any origin read
streamed coaching responses. The global CORSMiddleware already handles CORS
headers per configured origins, so the hardcoded header is redundant and
unsafe.
Closes #49