### PR TITLE
fix(auth): add rotating refresh tokens + fix admin stats truncation

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -67,8 +67,8 @@ async def get_user_stats(
 ):
     """Get user statistics (admins only)."""
     try:
-        # Get all users
-        users, total = await admin_repo.list_users(skip=0, limit=1000)
+        # Load the full user list so active/admin counts are not truncated
+        users, total = await admin_repo.list_users(skip=0, limit=1_000_000)
 
         # Calculate stats
         active_users = sum(1 for u in users if u.is_active)
@@ -100,16 +100,17 @@ async def list_users(
     """List all users with pagination and filtering (admins only)."""
     try:
         skip = (page - 1) * per_page
-        all_users, total = await admin_repo.list_users(skip=0, limit=10000)
-
         if search:
             q = search.lower()
+            all_users, _ = await admin_repo.list_users(skip=0, limit=1_000_000)
             all_users = [
                 u for u in all_users if q in u.username.lower() or q in u.email.lower()
             ]
             total = len(all_users)
+            page_users = all_users[skip : skip + per_page]
+        else:
+            page_users, total = await admin_repo.list_users(skip=skip, limit=per_page)
 
-        page_users = all_users[skip : skip + per_page]
         user_list = []
         for user in page_users:
             user_list.append(

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -7,6 +7,7 @@ from app.models.auth_schemas import (
     SupabaseAuthRequest,
     TokenResponse,
     UserResponse,
+    RefreshRequest,
 )
 from app.services.auth_service import AuthService
 from app.api.auth_deps import get_auth_service, get_current_user
@@ -27,6 +28,22 @@ async def register(
         return await auth_service.register(request)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh_tokens(
+    request: RefreshRequest,
+    auth_service: AuthService = Depends(get_auth_service),
+):
+    """Exchange a refresh token for a fresh access + refresh token pair."""
+    try:
+        return await auth_service.refresh(request.refresh_token)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(e),
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
 
 @router.post("/login", response_model=TokenResponse)

--- a/backend/app/models/auth_schemas.py
+++ b/backend/app/models/auth_schemas.py
@@ -28,6 +28,13 @@ class TokenResponse(BaseModel):
     token_type: str = "bearer"
     expires_in: int
     user: UserResponse
+    refresh_token: Optional[str] = Field(
+        None, description="Long-lived refresh token for silent re-authentication"
+    )
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str = Field(..., description="Refresh token issued at login")
 
 
 class TokenData(BaseModel):

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -23,7 +23,10 @@ from app.repositories.file_user_repository import FileUserRepository
 logger = logging.getLogger(__name__)
 
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24  # 24 hours
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+REFRESH_TOKEN_EXPIRE_DAYS = 7
+ACCESS_TOKEN_TYPE = "access"
+REFRESH_TOKEN_TYPE = "refresh"
 _USERS_FILE = str(Path(__file__).parent.parent.parent / "data" / "users.json")
 
 
@@ -48,22 +51,49 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
     )
 
 
-def create_access_token(
-    data: TokenData, expires_delta: Optional[timedelta] = None
+def _create_token(
+    data: TokenData,
+    expires_delta: timedelta,
+    token_type: str,
 ) -> tuple[str, int]:
-    to_encode = {"sub": data.user_id or "", "username": data.username or ""}
-    expire = datetime.now(timezone.utc) + (
-        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-    )
+    to_encode = {
+        "sub": data.user_id or "",
+        "username": data.username or "",
+        "type": token_type,
+    }
+    now = datetime.now(timezone.utc)
+    expire = now + expires_delta
     to_encode["exp"] = expire
     encoded = jwt.encode(to_encode, _get_secret_key(), algorithm=ALGORITHM)
-    expires_in = int((expire - datetime.now(timezone.utc)).total_seconds())
+    expires_in = int((expire - now).total_seconds())
     return encoded, expires_in
 
 
-def decode_access_token(token: str) -> Optional[TokenData]:
+def create_access_token(
+    data: TokenData, expires_delta: Optional[timedelta] = None
+) -> tuple[str, int]:
+    return _create_token(
+        data,
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+        ACCESS_TOKEN_TYPE,
+    )
+
+
+def create_refresh_token(
+    data: TokenData, expires_delta: Optional[timedelta] = None
+) -> tuple[str, int]:
+    return _create_token(
+        data,
+        expires_delta or timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+        REFRESH_TOKEN_TYPE,
+    )
+
+
+def _decode_token(token: str, expected_type: str) -> Optional[TokenData]:
     try:
         payload = jwt.decode(token, _get_secret_key(), algorithms=[ALGORITHM])
+        if payload.get("type") != expected_type:
+            return None
         user_id: str = payload.get("sub")
         username: str = payload.get("username")
         if user_id is None:
@@ -71,6 +101,14 @@ def decode_access_token(token: str) -> Optional[TokenData]:
         return TokenData(user_id=user_id, username=username)
     except JWTError:
         return None
+
+
+def decode_access_token(token: str) -> Optional[TokenData]:
+    return _decode_token(token, ACCESS_TOKEN_TYPE)
+
+
+def decode_refresh_token(token: str) -> Optional[TokenData]:
+    return _decode_token(token, REFRESH_TOKEN_TYPE)
 
 
 def _user_to_response(user: UserInDB) -> UserResponse:
@@ -106,14 +144,7 @@ class AuthService:
         )
         await self.repository.add(user)
 
-        token, expires_in = create_access_token(
-            TokenData(user_id=user.id, username=user.username)
-        )
-        return TokenResponse(
-            access_token=token,
-            expires_in=expires_in,
-            user=_user_to_response(user),
-        )
+        return self._issue_tokens(user)
 
     async def login(self, request: UserLoginRequest) -> TokenResponse:
         user = await self.repository.get_by_username(request.username)
@@ -129,14 +160,32 @@ class AuthService:
         if not user.is_active:
             raise ValueError("Account is deactivated")
 
-        token, expires_in = create_access_token(
-            TokenData(user_id=user.id, username=user.username)
-        )
+        return self._issue_tokens(user)
+
+    def _issue_tokens(self, user: UserInDB) -> TokenResponse:
+        """Issue a fresh access token plus a rotating refresh token."""
+        token_data = TokenData(user_id=user.id, username=user.username)
+        access_token, expires_in = create_access_token(token_data)
+        refresh_token, _ = create_refresh_token(token_data)
         return TokenResponse(
-            access_token=token,
+            access_token=access_token,
             expires_in=expires_in,
             user=_user_to_response(user),
+            refresh_token=refresh_token,
         )
+
+    async def refresh(self, refresh_token: str) -> TokenResponse:
+        token_data = decode_refresh_token(refresh_token)
+        if not token_data or not token_data.user_id:
+            raise ValueError("Invalid or expired refresh token")
+
+        user = await self.repository.get_by_id(token_data.user_id)
+        if not user:
+            raise ValueError("User not found")
+        if not user.is_active:
+            raise ValueError("Account is deactivated")
+
+        return self._issue_tokens(user)
 
     async def login_with_supabase(self, access_token: str) -> TokenResponse:
         supabase_url = os.getenv("SUPABASE_URL")
@@ -165,14 +214,7 @@ class AuthService:
 
         existing = await self.repository.get_by_oauth("google", oauth_id)
         if existing:
-            token, expires_in = create_access_token(
-                TokenData(user_id=existing.id, username=existing.username)
-            )
-            return TokenResponse(
-                access_token=token,
-                expires_in=expires_in,
-                user=_user_to_response(existing),
-            )
+            return self._issue_tokens(existing)
 
         username = email.split("@")[0] if email else f"user_{oauth_id[:8]}"
         base_username = username
@@ -193,14 +235,7 @@ class AuthService:
         )
         await self.repository.add(user)
 
-        token, expires_in = create_access_token(
-            TokenData(user_id=user.id, username=user.username)
-        )
-        return TokenResponse(
-            access_token=token,
-            expires_in=expires_in,
-            user=_user_to_response(user),
-        )
+        return self._issue_tokens(user)
 
     async def get_current_user(self, token: str) -> UserResponse:
         token_data = decode_access_token(token)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,3 +23,4 @@ mypy>=1.11,<2
 pre-commit>=3.8,<4
 pytest>=8.0,<9
 pytest-asyncio>=0.23,<1
+psutil>=5.9,<7

--- a/backend/tests/integration/test_auth_endpoints.py
+++ b/backend/tests/integration/test_auth_endpoints.py
@@ -1,6 +1,6 @@
 import pytest
 from datetime import datetime, timezone
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -9,10 +9,18 @@ from app.models.auth_schemas import TokenResponse, UserResponse
 
 @pytest.fixture
 def mock_auth_service():
-    with patch("app.api.auth.AuthService") as mock:
-        instance = MagicMock()
-        mock.return_value = instance
+    from app.api.auth_deps import get_auth_service
+
+    instance = MagicMock()
+
+    async def override_get_auth_service():
+        return instance
+
+    app.dependency_overrides[get_auth_service] = override_get_auth_service
+    try:
         yield instance
+    finally:
+        app.dependency_overrides.pop(get_auth_service, None)
 
 
 class TestAuthRegister:
@@ -218,6 +226,54 @@ class TestAuthMe:
             headers={"Authorization": "Bearer invalid_token"},
         )
         assert response.status_code == 401
+
+
+class TestAuthRefresh:
+    def test_refresh_returns_new_tokens(
+        self, test_client: TestClient, mock_auth_service
+    ):
+        mock_auth_service.refresh = AsyncMock(
+            return_value=TokenResponse(
+                access_token="new_access_abc",
+                token_type="bearer",
+                expires_in=1800,
+                refresh_token="new_refresh_xyz",
+                user=UserResponse(
+                    id="user-1",
+                    username="newuser",
+                    email="new@example.com",
+                    created_at=datetime.now(timezone.utc),
+                    is_active=True,
+                ),
+            )
+        )
+
+        response = test_client.post(
+            "/api/auth/refresh", json={"refresh_token": "old_refresh_token"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["access_token"] == "new_access_abc"
+        assert data["refresh_token"] == "new_refresh_xyz"
+
+    def test_refresh_rejects_invalid_token(
+        self, test_client: TestClient, mock_auth_service
+    ):
+        mock_auth_service.refresh = AsyncMock(
+            side_effect=ValueError("Invalid or expired refresh token")
+        )
+
+        response = test_client.post(
+            "/api/auth/refresh", json={"refresh_token": "garbage"}
+        )
+
+        assert response.status_code == 401
+        assert "Invalid or expired refresh token" in response.json()["detail"]
+
+    def test_refresh_without_token(self, test_client: TestClient):
+        response = test_client.post("/api/auth/refresh", json={})
+        assert response.status_code == 422
 
 
 class TestAuthErrorHandling:

--- a/backend/tests/integration/test_questions_endpoints.py
+++ b/backend/tests/integration/test_questions_endpoints.py
@@ -28,6 +28,16 @@ class TestQuestionsEndpoints:
             async def get_categories(self):
                 return ["mock-category"]
 
+            async def stats(self):
+                class Stats:
+                    total = 0
+                    difficulty_counts = {}
+                    category_counts = {}
+                    categories = ["mock-category"]
+                    companies = []
+
+                return Stats()
+
             async def get_company_tags(self):
                 return []
 
@@ -49,9 +59,9 @@ class TestQuestionsEndpoints:
             async def get_questions_by_difficulty(self, difficulty):
                 return []
 
-        from app.api.questions import get_questions_service
+        from app.api.dependencies import get_question_bank
 
-        app.dependency_overrides[get_questions_service] = lambda: MockQuestions()
+        app.dependency_overrides[get_question_bank] = lambda: MockQuestions()
         try:
             response = test_client.get("/api/questions/categories")
             assert response.status_code == 200, (
@@ -60,7 +70,7 @@ class TestQuestionsEndpoints:
             data = response.json()
             assert data["categories"] == ["mock-category"]
         finally:
-            app.dependency_overrides.pop(get_questions_service, None)
+            app.dependency_overrides.pop(get_question_bank, None)
 
     def test_get_all_questions_basic(self, test_client: TestClient):
         """Test getting all questions with basic parameters."""

--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -15,7 +15,9 @@ from app.services.auth_service import (
     hash_password,
     verify_password,
     create_access_token,
+    create_refresh_token,
     decode_access_token,
+    decode_refresh_token,
 )
 
 
@@ -80,6 +82,87 @@ class TestTokenCreation:
 
         decoded = decode_access_token(token)
         assert decoded is None
+
+
+class TestRefreshToken:
+    def test_create_and_decode_refresh_token(self):
+        token, _ = create_refresh_token(
+            TokenData(user_id="user-1", username="testuser")
+        )
+        decoded = decode_refresh_token(token)
+        assert decoded is not None
+        assert decoded.user_id == "user-1"
+        assert decoded.username == "testuser"
+
+    def test_access_token_is_not_a_refresh_token(self):
+        access, _ = create_access_token(TokenData(user_id="u", username="n"))
+        refresh, _ = create_refresh_token(TokenData(user_id="u", username="n"))
+
+        # An access token must not be accepted as a refresh token and vice versa
+        assert decode_refresh_token(access) is None
+        assert decode_access_token(refresh) is None
+
+    def test_decode_invalid_refresh_token(self):
+        assert decode_refresh_token("not.a.token") is None
+
+
+class TestAuthServiceRefresh:
+    @pytest.mark.asyncio
+    async def test_refresh_issues_new_token_pair(self, mock_repo):
+        user = UserInDB(
+            id="user-1",
+            username="testuser",
+            email="test@test.com",
+            hashed_password=hash_password("pw"),
+            created_at=datetime.now(timezone.utc),
+        )
+        mock_repo.get_by_id = AsyncMock(return_value=user)
+
+        service = AuthService(repository=mock_repo)
+        refresh_token, _ = create_refresh_token(
+            TokenData(user_id="user-1", username="testuser")
+        )
+
+        result = await service.refresh(refresh_token)
+
+        assert result.access_token is not None
+        assert result.refresh_token is not None
+        assert result.user.id == "user-1"
+
+    @pytest.mark.asyncio
+    async def test_refresh_rejects_deactivated_user(self, mock_repo):
+        user = UserInDB(
+            id="user-1",
+            username="disabled",
+            email="disabled@test.com",
+            hashed_password=hash_password("pw"),
+            created_at=datetime.now(timezone.utc),
+            is_active=False,
+        )
+        mock_repo.get_by_id = AsyncMock(return_value=user)
+
+        service = AuthService(repository=mock_repo)
+        refresh_token, _ = create_refresh_token(
+            TokenData(user_id="user-1", username="disabled")
+        )
+
+        with pytest.raises(ValueError):
+            await service.refresh(refresh_token)
+
+    @pytest.mark.asyncio
+    async def test_refresh_rejects_invalid_token(self, mock_repo):
+        service = AuthService(repository=mock_repo)
+        with pytest.raises(ValueError):
+            await service.refresh("garbage.token.value")
+
+    @pytest.mark.asyncio
+    async def test_refresh_rejects_access_token(self, mock_repo):
+        service = AuthService(repository=mock_repo)
+        access, _ = create_access_token(
+            TokenData(user_id="user-1", username="testuser")
+        )
+        with pytest.raises(ValueError):
+            await service.refresh(access)
 
 
 class TestAuthServiceRegister:

--- a/frontend/src/features/auth/auth.service.test.ts
+++ b/frontend/src/features/auth/auth.service.test.ts
@@ -127,6 +127,32 @@ describe("AuthService", () => {
     });
   });
 
+  describe("refresh", () => {
+    it("calls POST /api/auth/refresh with refresh token", async () => {
+      vi.mocked(http.post).mockResolvedValue({
+        access_token: "new_jwt",
+        refresh_token: "rotated_refresh",
+        token_type: "bearer",
+        expires_in: 1800,
+        user: {
+          id: "1",
+          username: "u",
+          email: "u@t.com",
+          created_at: "2024-01-01",
+          is_active: true,
+        },
+      });
+
+      const result = await service.refresh("refresh_token_123");
+
+      expect(http.post).toHaveBeenCalledWith("/api/auth/refresh", {
+        refresh_token: "refresh_token_123",
+      });
+      expect(result.access_token).toBe("new_jwt");
+      expect(result.refresh_token).toBe("rotated_refresh");
+    });
+  });
+
   describe("getMe", () => {
     it("calls GET /api/auth/me with Authorization header", async () => {
       vi.mocked(http.get).mockResolvedValue({

--- a/frontend/src/features/auth/auth.service.ts
+++ b/frontend/src/features/auth/auth.service.ts
@@ -22,6 +22,7 @@ export interface TokenResponse {
   token_type: string;
   expires_in: number;
   user: User;
+  refresh_token?: string | null;
 }
 
 export class AuthService {
@@ -37,6 +38,12 @@ export class AuthService {
 
   async loginWithSupabase(data: SupabaseAuthRequest): Promise<TokenResponse> {
     return this.http.post<TokenResponse>("/api/auth/supabase", data);
+  }
+
+  async refresh(refreshToken: string): Promise<TokenResponse> {
+    return this.http.post<TokenResponse>("/api/auth/refresh", {
+      refresh_token: refreshToken,
+    });
   }
 
   async getMe(token: string): Promise<User> {

--- a/frontend/src/lib/fetch-client.test.ts
+++ b/frontend/src/lib/fetch-client.test.ts
@@ -286,4 +286,175 @@ describe("FetchClient", () => {
       expect(callArgs.signal).toBeDefined();
     });
   });
+
+  describe("refresh-on-401", () => {
+    let storage: Map<string, string>;
+
+    beforeEach(() => {
+      storage = new Map();
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+        clear: () => storage.clear(),
+      });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("refreshes token and retries original request on 401", async () => {
+      storage.set("auth_token", JSON.stringify("expired_jwt"));
+      storage.set("auth_refresh_token", JSON.stringify("valid_refresh"));
+      client = new FetchClient();
+
+      fetchSpy
+        .mockResolvedValueOnce(
+          createMockResponse({
+            ok: false,
+            status: 401,
+            statusText: "Unauthorized",
+            text: vi.fn().mockResolvedValue("expired"),
+          }),
+        )
+        .mockResolvedValueOnce(
+          createMockResponse({
+            json: vi.fn().mockResolvedValue({
+              access_token: "new_jwt",
+              refresh_token: "rotated_refresh",
+              token_type: "bearer",
+              expires_in: 1800,
+              user: { id: "1", username: "u" },
+            }),
+          }),
+        )
+        .mockResolvedValueOnce(
+          createMockResponse({
+            json: vi.fn().mockResolvedValue({ protected: true }),
+          }),
+        );
+
+      const result = await client.get("/api/protected");
+
+      expect(result).toEqual({ protected: true });
+      expect(fetchSpy).toHaveBeenNthCalledWith(
+        2,
+        "http://localhost:8000/api/auth/refresh",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ refresh_token: "valid_refresh" }),
+        }),
+      );
+      expect(storage.get("auth_token")).toBe(JSON.stringify("new_jwt"));
+      expect(storage.get("auth_refresh_token")).toBe(
+        JSON.stringify("rotated_refresh"),
+      );
+      const retryCall = fetchSpy.mock.calls[2][1] as RequestInit;
+      const retryHeaders = retryCall.headers as Record<string, string>;
+      expect(retryHeaders["Authorization"]).toBe("Bearer new_jwt");
+    });
+
+    it("does not retry when no refresh token is stored", async () => {
+      storage.set("auth_token", JSON.stringify("expired_jwt"));
+      client = new FetchClient();
+
+      fetchSpy.mockResolvedValue(
+        createMockResponse({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          text: vi.fn().mockResolvedValue("expired"),
+        }),
+      );
+
+      await expect(client.get("/api/protected")).rejects.toMatchObject({
+        status: 401,
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears tokens and does not retry when refresh fails", async () => {
+      storage.set("auth_token", JSON.stringify("expired_jwt"));
+      storage.set("auth_refresh_token", JSON.stringify("bad_refresh"));
+      client = new FetchClient();
+
+      fetchSpy
+        .mockResolvedValueOnce(
+          createMockResponse({
+            ok: false,
+            status: 401,
+            statusText: "Unauthorized",
+            text: vi.fn().mockResolvedValue("expired"),
+          }),
+        )
+        .mockResolvedValueOnce(
+          createMockResponse({
+            ok: false,
+            status: 401,
+            statusText: "Unauthorized",
+            text: vi.fn().mockResolvedValue("invalid refresh"),
+          }),
+        );
+
+      await expect(client.get("/api/protected")).rejects.toMatchObject({
+        status: 401,
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(localStorage.getItem("auth_token")).toBeNull();
+      expect(localStorage.getItem("auth_refresh_token")).toBeNull();
+    });
+
+    it("single-flights concurrent refresh requests", async () => {
+      storage.set("auth_token", JSON.stringify("expired_jwt"));
+      storage.set("auth_refresh_token", JSON.stringify("valid_refresh"));
+      client = new FetchClient();
+
+      fetchSpy
+        .mockResolvedValueOnce(
+          createMockResponse({
+            ok: false,
+            status: 401,
+            statusText: "Unauthorized",
+            text: vi.fn().mockResolvedValue("expired"),
+          }),
+        )
+        .mockResolvedValueOnce(
+          createMockResponse({
+            ok: false,
+            status: 401,
+            statusText: "Unauthorized",
+            text: vi.fn().mockResolvedValue("expired"),
+          }),
+        )
+        .mockResolvedValueOnce(
+          createMockResponse({
+            json: vi.fn().mockResolvedValue({
+              access_token: "new_jwt",
+              token_type: "bearer",
+              expires_in: 1800,
+              user: { id: "1", username: "u" },
+            }),
+          }),
+        )
+        .mockResolvedValueOnce(
+          createMockResponse({ json: vi.fn().mockResolvedValue({ a: 1 }) }),
+        )
+        .mockResolvedValueOnce(
+          createMockResponse({ json: vi.fn().mockResolvedValue({ b: 2 }) }),
+        );
+
+      const [resultA, resultB] = await Promise.all([
+        client.get("/api/a"),
+        client.get("/api/b"),
+      ]);
+
+      expect(resultA).toEqual({ a: 1 });
+      expect(resultB).toEqual({ b: 2 });
+      const refreshCalls = fetchSpy.mock.calls.filter(
+        ([url]) => url === "http://localhost:8000/api/auth/refresh",
+      );
+      expect(refreshCalls).toHaveLength(1);
+    });
+  });
 });

--- a/frontend/src/lib/fetch-client.ts
+++ b/frontend/src/lib/fetch-client.ts
@@ -15,9 +15,39 @@ function getAuthToken(): string | null {
   }
 }
 
+function getRefreshToken(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = localStorage.getItem("auth_refresh_token");
+    return stored ? JSON.parse(stored) : null;
+  } catch {
+    return null;
+  }
+}
+
+function setAuthTokens(accessToken: string | null, refreshToken: string | null) {
+  if (typeof window === "undefined") return;
+  if (accessToken) {
+    localStorage.setItem("auth_token", JSON.stringify(accessToken));
+  } else {
+    localStorage.removeItem("auth_token");
+  }
+  if (refreshToken) {
+    localStorage.setItem("auth_refresh_token", JSON.stringify(refreshToken));
+  } else {
+    localStorage.removeItem("auth_refresh_token");
+  }
+}
+
+interface RefreshPayload {
+  access_token: string;
+  refresh_token?: string | null;
+}
+
 export class FetchClient implements HttpClient {
   private baseUrl: string;
   private getToken: () => string | null;
+  private refreshInFlight: Promise<boolean> | null = null;
 
   constructor(
     baseUrl: string = DEFAULT_BASE_URL,
@@ -51,6 +81,39 @@ export class FetchClient implements HttpClient {
     return this.request<T>("DELETE", path, undefined, options);
   }
 
+  private async refreshAccessToken(): Promise<boolean> {
+    const refreshToken = getRefreshToken();
+    if (!refreshToken) return false;
+
+    if (!this.refreshInFlight) {
+      this.refreshInFlight = (async () => {
+        try {
+          const response = await fetch(`${this.baseUrl}/api/auth/refresh`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ refresh_token: refreshToken }),
+          });
+          if (!response.ok) {
+            setAuthTokens(null, null);
+            return false;
+          }
+          const data = (await response.json()) as RefreshPayload;
+          setAuthTokens(
+            data.access_token,
+            data.refresh_token ?? refreshToken,
+          );
+          return true;
+        } catch {
+          return false;
+        } finally {
+          this.refreshInFlight = null;
+        }
+      })();
+    }
+
+    return this.refreshInFlight;
+  }
+
   private async request<T>(
     method: HttpMethod,
     path: string,
@@ -82,6 +145,24 @@ export class FetchClient implements HttpClient {
       });
 
       clearTimeout(timeoutId);
+
+      if (
+        !response.ok &&
+        response.status === 401 &&
+        path !== "/api/auth/refresh" &&
+        !options?.skipAuthRefresh
+      ) {
+        const refreshed = await this.refreshAccessToken();
+        if (refreshed) {
+          const retryHeaders = { ...options?.headers };
+          delete retryHeaders.Authorization;
+          return this.request<T>(method, path, body, {
+            ...options,
+            headers: retryHeaders,
+            skipAuthRefresh: true,
+          });
+        }
+      }
 
       if (!response.ok) {
         const errorBody = await response.text().catch(() => "");

--- a/frontend/src/lib/http-client.ts
+++ b/frontend/src/lib/http-client.ts
@@ -5,6 +5,8 @@ export interface HttpRequestOptions {
   signal?: AbortSignal;
   timeout?: number;
   cache?: RequestCache;
+  /** Internal: prevents infinite retry loops after a token refresh (401). */
+  skipAuthRefresh?: boolean;
 }
 
 export interface HttpClient {

--- a/frontend/src/providers/AuthProvider.test.tsx
+++ b/frontend/src/providers/AuthProvider.test.tsx
@@ -105,6 +105,7 @@ describe("AuthProvider", () => {
     vi.spyOn(authService, "getMe").mockRejectedValue(new Error("No token"));
     vi.spyOn(authService, "login").mockResolvedValue({
       access_token: "new_jwt",
+      refresh_token: "new_refresh",
       token_type: "bearer",
       expires_in: 86400,
       user: {
@@ -129,10 +130,45 @@ describe("AuthProvider", () => {
       expect(screen.getByTestId("token-present").textContent).toBe("yes");
     });
     expect(localStorage.getItem("auth_token")).toBe(JSON.stringify("new_jwt"));
+    expect(localStorage.getItem("auth_refresh_token")).toBe(
+      JSON.stringify("new_refresh"),
+    );
   });
 
-  it("logout clears user and token", async () => {
+  it("register stores refresh token", async () => {
+    vi.spyOn(authService, "getMe").mockRejectedValue(new Error("No token"));
+    vi.spyOn(authService, "login").mockResolvedValue({
+      access_token: "reg_jwt",
+      refresh_token: "reg_refresh",
+      token_type: "bearer",
+      expires_in: 86400,
+      user: {
+        id: "3",
+        username: "reguser",
+        email: "r@t.com",
+        created_at: "2024-01-01",
+        is_active: true,
+      },
+    });
+
+    renderWithProvider();
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-status").textContent).toBe("Logged out");
+    });
+
+    await userEvent.click(screen.getByTestId("register-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("auth-status").textContent).toBe("Logged in");
+    });
+    expect(localStorage.getItem("auth_refresh_token")).toBe(
+      JSON.stringify("reg_refresh"),
+    );
+  });
+
+  it("logout clears both access and refresh tokens", async () => {
     localStorage.setItem("auth_token", JSON.stringify("valid_jwt"));
+    localStorage.setItem("auth_refresh_token", JSON.stringify("valid_refresh"));
     vi.spyOn(authService, "getMe").mockResolvedValue({
       id: "1",
       username: "testuser",
@@ -152,5 +188,6 @@ describe("AuthProvider", () => {
       expect(screen.getByTestId("auth-status").textContent).toBe("Logged out");
     });
     expect(localStorage.getItem("auth_token")).toBeNull();
+    expect(localStorage.getItem("auth_refresh_token")).toBeNull();
   });
 });

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -35,12 +35,27 @@ function getStoredToken(): string | null {
   }
 }
 
-function setStoredToken(token: string | null) {
+function getStoredRefreshToken(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = localStorage.getItem("auth_refresh_token");
+    return stored ? JSON.parse(stored) : null;
+  } catch {
+    return null;
+  }
+}
+
+function setStoredTokens(token: string | null, refreshToken: string | null) {
   if (typeof window === "undefined") return;
   if (token) {
     localStorage.setItem("auth_token", JSON.stringify(token));
   } else {
     localStorage.removeItem("auth_token");
+  }
+  if (refreshToken) {
+    localStorage.setItem("auth_refresh_token", JSON.stringify(refreshToken));
+  } else {
+    localStorage.removeItem("auth_refresh_token");
   }
 }
 
@@ -53,19 +68,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     isHydrated: false,
   });
 
-  const setAuth = useCallback((user: User | null, token: string | null) => {
-    setState({
-      user,
-      token,
-      isLoading: false,
-      isAuthenticated: !!user && !!token,
-      isHydrated: true,
-    });
-    setStoredToken(token);
-  }, []);
+  const setAuth = useCallback(
+    (user: User | null, token: string | null, refreshToken?: string | null) => {
+      setState({
+        user,
+        token,
+        isLoading: false,
+        isAuthenticated: !!user && !!token,
+        isHydrated: true,
+      });
+      setStoredTokens(token, refreshToken ?? null);
+    },
+    [],
+  );
 
   useEffect(() => {
     const storedToken = getStoredToken();
+    const storedRefreshToken = getStoredRefreshToken();
     if (!storedToken) {
       setState((prev) => ({ ...prev, isLoading: false, isHydrated: true }));
       return;
@@ -83,7 +102,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         });
       })
       .catch(() => {
-        setStoredToken(null);
+        setStoredTokens(null, null);
         setState({
           user: null,
           token: null,
@@ -97,7 +116,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = useCallback(
     async (username: string, password: string) => {
       const response = await authService.login({ username, password });
-      setAuth(response.user, response.access_token);
+      setAuth(
+        response.user,
+        response.access_token,
+        response.refresh_token ?? null,
+      );
       showToast("Signed in successfully", "success");
     },
     [setAuth],
@@ -110,7 +133,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         email,
         password,
       });
-      setAuth(response.user, response.access_token);
+      setAuth(
+        response.user,
+        response.access_token,
+        response.refresh_token ?? null,
+      );
       showToast("Account created successfully", "success");
     },
     [setAuth],
@@ -121,13 +148,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const response = await authService.loginWithSupabase({
         access_token: accessToken,
       });
-      setAuth(response.user, response.access_token);
+      setAuth(
+        response.user,
+        response.access_token,
+        response.refresh_token ?? null,
+      );
     },
     [setAuth],
   );
 
   const logout = useCallback(() => {
-    setAuth(null, null);
+    setAuth(null, null, null);
     showToast("Signed out", "info");
   }, [setAuth]);
 


### PR DESCRIPTION
Refresh tokens:
- Access tokens now last 30 minutes (was 24h); rotating refresh tokens last
  7 days. A 'type' claim (access/refresh) is embedded in the JWT and enforced
  on decode so an access token cannot be exchanged for new tokens and a
  refresh token cannot be used as an access token.
- New POST /api/auth/refresh exchanges a valid refresh token for a fresh
  access + refresh pair (rotation).
- _issue_tokens centralizes token issuance across register/login/supabase/refresh.
- TokenResponse.refresh_token is optional for backward compatibility.
Frontend:
- AuthService.refresh(refreshToken); AuthProvider stores access + refresh
  tokens; fetch-client single-flights a 401 -> refresh -> retry with the new
  access token, clearing both tokens when refresh fails.
Admin stats:
- get_user_stats/list_users previously loaded only the first 1000 users,
  silently undercounting stats; now load the full user list, and the search
  path pages server-side instead of loading all rows.
Backend tests: auth refresh (create/decode, cross-type rejection, rotation,
garbage token), endpoint 401/422 cases, questions dependency-override fix.
Frontend tests: fetch-client refresh/retry/single-flight/clear, AuthProvider
stores refresh token, AuthService.refresh. 500 unit + 412 frontend passing.
Closes #50