### PR TITLE
fix(learn): make lesson workspace full-width instead of 1280px

### DIFF
--- a/frontend/src/app/learn/lesson/[lessonId]/loading.tsx
+++ b/frontend/src/app/learn/lesson/[lessonId]/loading.tsx
@@ -28,7 +28,7 @@ export default function LessonLoading() {
       </div>
 
       {/* Content area */}
-      <div className="flex-1 flex px-6 pb-6 max-w-7xl mx-auto w-full min-h-0">
+      <div data-testid="lesson-content-container" className="flex-1 flex px-6 pb-6 w-full min-h-0">
         {/* Left panel - theory/exercise content */}
         <div className="w-[35%] pr-6 border-r border-white/[0.04] overflow-y-auto">
           <div className="space-y-3">

--- a/frontend/src/app/learn/lesson/[lessonId]/page.test.tsx
+++ b/frontend/src/app/learn/lesson/[lessonId]/page.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/mocks/server';
+import LessonLoading from './loading';
+import LessonPage from './page';
+import type { LessonSummary } from '@/types';
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ lessonId: 'test-lesson' }),
+}));
+
+vi.mock('@/providers', () => ({
+  useAuth: () => ({ isAuthenticated: false, isHydrated: true }),
+}));
+
+vi.mock('@/features/coaching/coaching.hook', () => ({
+  useCoaching: () => ({
+    messages: [],
+    isTyping: false,
+    sendMessage: vi.fn(),
+  }),
+}));
+
+const lesson: LessonSummary = {
+  id: 'test-lesson',
+  course_id: 'c1',
+  module_id: 'm1',
+  title: 'Test Lesson',
+  type: 'theory',
+  content: 'content',
+  order: 1,
+  starter_code: null,
+  test_cases: null,
+  question_id: null,
+  language: 'python',
+};
+
+vi.mock('@/features/curriculum/use-curriculum.hook', () => ({
+  useLesson: () => ({ lesson, isLoading: false, error: null }),
+}));
+
+describe('LessonPage layout width', () => {
+  beforeEach(() => {
+    server.use(
+      http.get('/api/courses/lessons/:lessonId/adjacent', () =>
+        HttpResponse.json({ prev_id: null, next_id: null }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  it('renders the main workspace container at full width (no max-w-7xl cap)', async () => {
+    render(<LessonPage />);
+    const main = await screen.findByRole('main');
+    expect(main).toHaveClass('w-full');
+    expect(main).not.toHaveClass('max-w-7xl');
+  });
+});
+
+describe('LessonLoading layout width', () => {
+  it('renders the content container at full width (no max-w-7xl cap)', () => {
+    render(<LessonLoading />);
+    const container = screen.getByTestId('lesson-content-container');
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveClass('w-full');
+    expect(container).not.toHaveClass('max-w-7xl');
+  });
+});

--- a/frontend/src/app/learn/lesson/[lessonId]/page.tsx
+++ b/frontend/src/app/learn/lesson/[lessonId]/page.tsx
@@ -269,7 +269,7 @@ export default function LessonPage() {
       >
         <Header />
 
-        <main className="flex-1 flex flex-col px-6 pt-6 pb-4 max-w-7xl mx-auto w-full min-h-0 overflow-hidden">
+        <main className="flex-1 flex flex-col px-6 pt-6 pb-4 w-full min-h-0 overflow-hidden">
           <LessonChrome lesson={lesson} prevId={prevId} nextId={nextId} />
 
           {isExercise ? (


### PR DESCRIPTION
Closes #83

## Problem

Lesson pages were capped at `max-w-7xl` (1280px), cramping the description / code editor / AI coach panes.

## Fix

- `page.tsx`: removed `max-w-7xl mx-auto` from the `<main>` container → full viewport width with `px-6` padding
- `loading.tsx`: removed the same cap so the skeleton matches the loaded page

## Why safe

- Description/reading pane widths are percentages (`useResizablePanels.ts`) and the AI pane is fixed px — both scale with the wider container
- `wide`/`compact`/`stacked` modes key off the workspace element width, so responsiveness is preserved
- `MarkdownRenderer` uses `max-w-none`; the reading pane still caps at 80% so prose stays readable

## Tests (TDD)

- `page.test.tsx` (new): renders `LessonPage` + `LessonLoading` and asserts the main/content containers have `w-full` and do **not** have `max-w-7xl`
- 466 frontend tests pass, `pnpm typecheck` clean
- Frontend Docker container rebuilt and verified: page serves 200 with no `max-w-7xl` in the HTML