### PR TITLE
fix(learn): render GFM markdown tables via react-markdown

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^9.0.0",
+    "remark-gfm": "^4.0.1",
     "styled-jsx": "^5.1.1",
     "tailwind-merge": "^2.2.0"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-markdown:
         specifier: ^9.0.0
         version: 9.1.0(@types/react@18.3.29)(react@18.3.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       styled-jsx:
         specifier: ^5.1.1
         version: 5.1.1(react@18.3.1)
@@ -1557,6 +1560,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-config-next@14.2.0:
     resolution: {integrity: sha512-N0eQkn/wz557mIpW4JQWGEv4wGU8zvJ7emLHMS15uC18jjaU4kx6leR4U9QYT/eNghUZT7N9lBlfd8E4N0cp1w==}
     peerDependencies:
@@ -2248,6 +2255,9 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked@14.0.0:
     resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
     engines: {node: '>= 18'}
@@ -2257,8 +2267,29 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -2290,6 +2321,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -2734,11 +2786,17 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4703,6 +4761,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-config-next@14.2.0(eslint@8.57.1)(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 14.2.0
@@ -5479,9 +5539,18 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   marked@14.0.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -5497,6 +5566,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5593,6 +5719,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -6115,6 +6299,17 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -6131,6 +6326,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 

--- a/frontend/src/components/learn/MarkdownRenderer.test.tsx
+++ b/frontend/src/components/learn/MarkdownRenderer.test.tsx
@@ -1,73 +1,17 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import {
-  MarkdownRenderer,
-  escapeHtml,
-  sanitizeHtml,
-  renderMarkdown,
-} from "./MarkdownRenderer";
+import { MarkdownRenderer } from "./MarkdownRenderer";
 
-describe("escapeHtml", () => {
-  it("escapes HTML metacharacters including single quotes", () => {
-    const input = `<script>alert("xss")</script> & ' "`;
-    expect(escapeHtml(input)).toBe(
-      "&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt; &amp; &#39; &quot;",
-    );
-  });
-});
-
-describe("sanitizeHtml", () => {
-  it("strips script, iframe, object and form tags", () => {
-    const html =
-      "<p>hello</p><script>alert(1)</script><iframe src=\"x\"></iframe><object></object><form></form>";
-    const out = sanitizeHtml(html);
-    expect(out).not.toContain("<script");
-    expect(out).not.toContain("<iframe");
-    expect(out).not.toContain("<object");
-    expect(out).not.toContain("<form");
-    expect(out).toContain("<p>hello</p>");
-  });
-
-  it("removes inline event handler attributes", () => {
-    const out = sanitizeHtml(
-      '<p onclick="alert(1)" onmouseover=\'steal()\'>safe</p>',
-    );
-    expect(out).not.toContain("onclick");
-    expect(out).not.toContain("onmouseover");
-    expect(out).toContain("<p>safe</p>");
-  });
-
-  it("strips javascript: URLs from href/src", () => {
-    const out = sanitizeHtml(
-      '<a href="javascript:alert(1)">x</a><img src="javascript:evil()"/>',
-    );
-    expect(out).not.toContain("javascript:");
-  });
-});
-
-describe("renderMarkdown", () => {
-  it("escapes raw HTML inside markdown text", () => {
-    const out = renderMarkdown("<script>alert(1)</script>");
-    expect(out).not.toContain("<script>");
-    expect(out).toContain("&lt;script&gt;");
-  });
-
+describe("MarkdownRenderer", () => {
   it("renders headings and paragraphs", () => {
-    const out = renderMarkdown("# Title\n\nHello");
-    expect(out).toContain("<h1");
-    expect(out).toContain("Title");
-    expect(out).toContain("<p");
-    expect(out).toContain("Hello");
+    render(<MarkdownRenderer content={"# Title\n\nHello"} />);
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Title" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Hello")).toBeInTheDocument();
   });
 
-  it("escapes code block contents", () => {
-    const out = renderMarkdown("```js\nconst a = '<b>';\n```");
-    expect(out).toContain("&lt;b&gt;");
-  });
-});
-
-describe("MarkdownRenderer component", () => {
-  it("renders content without executing injected script", () => {
+  it("escapes raw HTML so injected scripts never execute", () => {
     render(
       <MarkdownRenderer
         content={"# Safe\n\n<script>window.__xss = 1</script>"}
@@ -75,5 +19,68 @@ describe("MarkdownRenderer component", () => {
     );
     expect(screen.getByText("Safe")).toBeInTheDocument();
     expect(document.querySelector("script")).toBeNull();
+  });
+
+  it("escapes code block contents", () => {
+    render(<MarkdownRenderer content={"```js\nconst a = '<b>';\n```"} />);
+    expect(document.querySelector("pre code")).toBeInTheDocument();
+    expect(document.querySelector("b")).toBeNull();
+    expect(document.querySelector("pre")?.textContent).toContain(
+      "const a = '<b>'",
+    );
+  });
+
+  it("renders language-less fenced blocks as block code, not inline", () => {
+    render(<MarkdownRenderer content={"```\nconst a = 1;\n```"} />);
+    const pre = document.querySelector("pre");
+    expect(pre).not.toBeNull();
+    const code = pre!.querySelector("code");
+    expect(code?.className).not.toContain("bg-white/5");
+  });
+
+  it("does not render javascript: URLs as clickable links", () => {
+    render(<MarkdownRenderer content={"[click](javascript:alert(1))"} />);
+    expect(document.querySelector("a[href^='javascript:']")).toBeNull();
+    expect(screen.getByText("click")).toBeInTheDocument();
+  });
+
+  it("renders safe external links with noreferrer", () => {
+    render(<MarkdownRenderer content={"[docs](https://example.com)"} />);
+    const link = document.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("https://example.com");
+    expect(link?.getAttribute("rel")).toContain("noreferrer");
+  });
+
+  it("renders GFM tables as real table elements", () => {
+    render(
+      <MarkdownRenderer
+        content={"| Type | Example |\n|---|---|\n| `int` | 42 |\n| `str` | \"hi\" |"}
+      />,
+    );
+    const table = document.querySelector("table");
+    expect(table).not.toBeNull();
+    const headers = table!.querySelectorAll("th");
+    expect(headers).toHaveLength(2);
+    expect(headers[0].textContent).toContain("Type");
+    expect(headers[1].textContent).toContain("Example");
+    const rows = table!.querySelectorAll("tbody tr");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].querySelectorAll("td")).toHaveLength(2);
+    expect(rows[0].querySelector("code")?.textContent).toBe("int");
+  });
+
+  it("wraps list items in a ul", () => {
+    render(<MarkdownRenderer content={"- item one\n- item two"} />);
+    const ul = document.querySelector("ul");
+    expect(ul).not.toBeNull();
+    expect(ul!.querySelectorAll("li")).toHaveLength(2);
+  });
+
+  it("renders inline code and bold text", () => {
+    render(<MarkdownRenderer content={"Use `strand1` and **strand2**"} />);
+    expect(document.querySelector("code")?.textContent).toBe("strand1");
+    expect(document.querySelector("strong")?.textContent).toBe("strand2");
+    expect(screen.queryByText(/`strand1`/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\*\*strand2\*\*/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/learn/MarkdownRenderer.tsx
+++ b/frontend/src/components/learn/MarkdownRenderer.tsx
@@ -1,115 +1,115 @@
 "use client";
 
-import { useMemo } from "react";
+import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 interface MarkdownRendererProps {
   content: string;
 }
 
-export function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
-
-const DANGEROUS_TAGS_RE = /<\s*\/?\s*(script|iframe|object|embed|link|meta|base|form)\b[^>]*>/gi;
-const EVENT_HANDLER_ATTR_RE = /\son[a-z]+\s*=\s*(["'])[^"']*\1/gi;
-const JAVASCRIPT_URL_RE = /(href|src)\s*=\s*(["'])\s*javascript:[^"']*\2/gi;
-
-export function sanitizeHtml(html: string): string {
-  return html
-    .replace(DANGEROUS_TAGS_RE, "")
-    .replace(EVENT_HANDLER_ATTR_RE, "")
-    .replace(JAVASCRIPT_URL_RE, "");
-}
-
-export function renderMarkdown(md: string): string {
-  const lines = md.split("\n");
-  const html: string[] = [];
-  let inCodeBlock = false;
-  let codeBuffer: string[] = [];
-  let codeLang = "";
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-
-    if (line.startsWith("```")) {
-      if (inCodeBlock) {
-        html.push(
-          `<pre><code class="language-${escapeHtml(codeLang)}">${escapeHtml(codeBuffer.join("\n"))}</code></pre>`,
-        );
-        codeBuffer = [];
-        codeLang = "";
-        inCodeBlock = false;
-      } else {
-        inCodeBlock = true;
-        codeLang = line.slice(3).trim();
-      }
-      continue;
+const COMPONENTS: Components = {
+  h1: ({ children }) => (
+    <h1 className="text-2xl font-semibold mt-8 mb-4 text-foreground/90">
+      {children}
+    </h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="text-xl font-semibold mt-8 mb-3 text-foreground/90">
+      {children}
+    </h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="text-lg font-semibold mt-6 mb-2 text-foreground/90">
+      {children}
+    </h3>
+  ),
+  h4: ({ children }) => (
+    <h4 className="text-base font-semibold mt-5 mb-2 text-foreground/90">
+      {children}
+    </h4>
+  ),
+  p: ({ children }) => (
+    <p className="text-foreground/80 leading-relaxed my-3">{children}</p>
+  ),
+  ul: ({ children }) => (
+    <ul className="list-disc pl-6 my-3 space-y-1.5 text-foreground/80">
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="list-decimal pl-6 my-3 space-y-1.5 text-foreground/80">
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  code: ({ className, children }) =>
+    className || String(children).includes("\n") ? (
+      <code className={className}>{children}</code>
+    ) : (
+      <code className="bg-white/5 px-1.5 py-0.5 rounded text-sm font-mono text-primary/80">
+        {children}
+      </code>
+    ),
+  pre: ({ children }) => (
+    <pre className="bg-black/40 border border-white/10 rounded-lg p-4 overflow-x-auto text-sm font-mono my-4">
+      {children}
+    </pre>
+  ),
+  table: ({ children }) => (
+    <div className="overflow-x-auto my-4">
+      <table className="w-full text-sm border-collapse">{children}</table>
+    </div>
+  ),
+  thead: ({ children }) => (
+    <thead className="bg-white/[0.04]">{children}</thead>
+  ),
+  th: ({ children }) => (
+    <th className="border border-white/10 px-3 py-2 text-left font-semibold text-foreground/90">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td className="border border-white/10 px-3 py-2 text-foreground/80 align-top">
+      {children}
+    </td>
+  ),
+  a: ({ href, children }) => {
+    if (!href || !/^(https?:|mailto:|\/|#)/i.test(href)) {
+      return <span className="text-foreground/80">{children}</span>;
     }
-
-    if (inCodeBlock) {
-      codeBuffer.push(line);
-      continue;
-    }
-
-    if (line.startsWith("### ")) {
-      html.push(
-        `<h3 class="text-lg font-semibold mt-6 mb-2 text-foreground/90">${escapeHtml(line.slice(4))}</h3>`,
-      );
-    } else if (line.startsWith("## ")) {
-      html.push(
-        `<h2 class="text-xl font-semibold mt-8 mb-3 text-foreground/90">${escapeHtml(line.slice(3))}</h2>`,
-      );
-    } else if (line.startsWith("# ")) {
-      html.push(
-        `<h1 class="text-2xl font-semibold mt-8 mb-4 text-foreground/90">${escapeHtml(line.slice(2))}</h1>`,
-      );
-    } else if (line.startsWith("- ")) {
-      html.push(
-        `<li class="ml-4 text-foreground/80">${escapeHtml(line.slice(2))}</li>`,
-      );
-    } else if (line.startsWith("**") && line.endsWith("**")) {
-      html.push(
-        `<p class="font-semibold text-foreground/80 mt-3">${escapeHtml(line.slice(2, -2))}</p>`,
-      );
-    } else if (line.trim() === "") {
-      if (html.length > 0 && !html[html.length - 1].startsWith("<li")) {
-        html.push("<br/>");
-      }
-    } else {
-      const processed = escapeHtml(line)
-        .replace(
-          /`([^`]+)`/g,
-          '<code class="bg-white/5 px-1.5 py-0.5 rounded text-sm font-mono text-primary/80">$1</code>',
-        )
-        .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
-      html.push(
-        `<p class="text-foreground/80 leading-relaxed">${processed}</p>`,
-      );
-    }
-  }
-
-  if (inCodeBlock && codeBuffer.length > 0) {
-    html.push(`<pre><code>${escapeHtml(codeBuffer.join("\n"))}</code></pre>`);
-  }
-
-  return html.join("\n");
-}
+    const external = href.startsWith("http");
+    return (
+      <a
+        href={href}
+        className="text-primary/80 underline underline-offset-2 hover:text-primary"
+        target={external ? "_blank" : undefined}
+        rel={external ? "noreferrer" : undefined}
+      >
+        {children}
+      </a>
+    );
+  },
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-2 border-primary/40 pl-4 my-3 text-foreground/70 italic">
+      {children}
+    </blockquote>
+  ),
+  hr: () => <hr className="my-6 border-white/10" />,
+  strong: ({ children }) => (
+    <strong className="font-semibold text-foreground/90">{children}</strong>
+  ),
+  em: ({ children }) => (
+    <em className="italic text-foreground/80">{children}</em>
+  ),
+};
 
 export function MarkdownRenderer({ content }: MarkdownRendererProps) {
-  const html = useMemo(
-    () => sanitizeHtml(renderMarkdown(content)),
-    [content],
-  );
-
   return (
-    <div
-      className="prose prose-sm max-w-none text-foreground/80"
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
+    <div className="max-w-none">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={COMPONENTS}>
+        {content}
+      </ReactMarkdown>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #85 — markdown tables were not rendering in theory lessons and the question panel.

`MarkdownRenderer` used a hand-rolled parser with no GFM table support, so `| a | b |` syntax was escaped and dumped as a plain `<p>`. Replaced it with `react-markdown` (already a dependency) + `remark-gfm`, with a styled component map.

## Changes

- `frontend/src/components/learn/MarkdownRenderer.tsx`
  - Rewritten on `<ReactMarkdown remarkPlugins={[remarkGfm]} components={...}>`
  - Adds styled GFM tables (`table`/`thead`/`th`/`td`, borders, `overflow-x-auto` wrapper)
  - Proper `ul`/`ol` list wrapping, styled fenced code blocks, links, blockquotes, `hr`
  - Dropped the obsolete `escapeHtml`/`sanitizeHtml`/`renderMarkdown` string helpers
- `frontend/package.json` / `pnpm-lock.yaml` — add `remark-gfm@^4.0.1`
- `frontend/src/components/learn/MarkdownRenderer.test.tsx` — rewritten: GFM table rendering, XSS escaping, code-block escaping, block-vs-inline code, safe link rendering

## Security

react-markdown escapes raw HTML by default (no `rehype-raw`), preserving XSS protection. The new `<a>` rendering allowlists `http:`/`https:`/`mailto:`/relative URLs to close the `javascript:` XSS surface that did not exist under the old text-only parser.

## Testing

- 465/465 frontend unit tests pass (9 renderer tests)
- `tsc --noEmit` clean
- `next lint` clean
- Frontend Docker image rebuilt and serving HTTP 200