### PR TITLE
feat(premium): premium tier — plan gating, AI Coach premium (rate limiting deferred)

### DIFF
--- a/backend/alembic/versions/a5369fbca804_add_user_plan_column.py
+++ b/backend/alembic/versions/a5369fbca804_add_user_plan_column.py
@@ -1,0 +1,32 @@
+"""add user plan column
+
+Revision ID: a5369fbca804
+Revises: 7fc9e8c06939
+Create Date: 2026-08-05 16:29:42.970959
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a5369fbca804"
+down_revision: Union[str, Sequence[str], None] = "7fc9e8c06939"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "users",
+        sa.Column("plan", sa.String(length=20), server_default="free", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("users", "plan")

--- a/backend/app/api/auth_deps.py
+++ b/backend/app/api/auth_deps.py
@@ -67,3 +67,14 @@ async def require_super_admin(
             detail="Insufficient permissions: super_admin role required",
         )
     return current_user
+
+
+async def require_premium(
+    current_user: UserResponse = Depends(get_current_user),
+):
+    if current_user.plan != "premium":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Premium feature — upgrade required",
+        )
+    return current_user

--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -12,7 +12,7 @@ from app.ports.coaching_provider import CoachingProvider
 from app.services.groq_service import GroqService
 from app.services.redis_service import RedisCache
 from app.services.usage_service import UsageService, check_caps, usage_headers
-from app.api.auth_deps import get_current_user
+from app.api.auth_deps import require_premium
 from app.api.dependencies import get_redis_cache, get_usage_service
 from app.models.auth_schemas import UserResponse
 from app.middleware.rate_limit import limiter, COACH_RATE_LIMIT
@@ -23,7 +23,7 @@ router = APIRouter()
 
 def get_coaching_provider(
     cache: Optional[RedisCache] = Depends(get_redis_cache),
-    user: UserResponse = Depends(get_current_user),
+    user: UserResponse = Depends(require_premium),
     usage_service: UsageService = Depends(get_usage_service),
 ) -> CoachingProvider:
     # Platform-owned key: clients never supply their own. The key is used
@@ -42,7 +42,7 @@ def get_coaching_provider(
 
 async def check_daily_token_cap(
     request: Request,
-    user: UserResponse = Depends(get_current_user),
+    user: UserResponse = Depends(require_premium),
     usage_service: UsageService = Depends(get_usage_service),
 ) -> None:
     """Enforce daily per-user input/output token caps; set X-Usage-* headers."""
@@ -61,7 +61,7 @@ async def check_daily_token_cap(
 
 
 async def enforce_user_rate_limit(
-    user: UserResponse = Depends(get_current_user),
+    user: UserResponse = Depends(require_premium),
     cache: Optional[RedisCache] = Depends(get_redis_cache),
 ) -> None:
     """Per-user requests-per-minute gate backed by Redis (degrades open)."""
@@ -82,7 +82,7 @@ async def get_coaching(
     response: Response,
     coaching_request: CoachingRequest,
     provider: CoachingProvider = Depends(get_coaching_provider),
-    user: UserResponse = Depends(get_current_user),
+    user: UserResponse = Depends(require_premium),
     _usage_guard: None = Depends(check_daily_token_cap),
     _rate_guard: None = Depends(enforce_user_rate_limit),
 ):
@@ -212,7 +212,7 @@ async def get_coaching_stream(
     request: Request,
     coaching_request: CoachingRequest,
     provider: CoachingProvider = Depends(get_coaching_provider),
-    user: UserResponse = Depends(get_current_user),
+    user: UserResponse = Depends(require_premium),
     _usage_guard: None = Depends(check_daily_token_cap),
     _rate_guard: None = Depends(enforce_user_rate_limit),
 ):
@@ -293,7 +293,9 @@ async def get_coaching_stream(
 
 
 @router.get("/modes")
-async def get_coaching_modes():
+async def get_coaching_modes(
+    user: UserResponse = Depends(require_premium),
+):
     """Get available coaching modes."""
     return {
         "modes": [mode.value for mode in CoachingMode],
@@ -308,7 +310,9 @@ async def get_coaching_modes():
 
 
 @router.get("/languages")
-async def get_supported_languages():
+async def get_supported_languages(
+    user: UserResponse = Depends(require_premium),
+):
     """Get supported programming languages."""
     return {
         "languages": [lang.value for lang in Language],

--- a/backend/app/models/auth_schemas.py
+++ b/backend/app/models/auth_schemas.py
@@ -21,6 +21,7 @@ class UserResponse(BaseModel):
     created_at: datetime
     is_active: bool = True
     role: str = "user"
+    plan: str = "free"
 
 
 class TokenResponse(BaseModel):
@@ -56,3 +57,4 @@ class UserInDB(BaseModel):
     oauth_provider: Optional[str] = None
     oauth_id: Optional[str] = None
     role: str = "user"
+    plan: str = "free"

--- a/backend/app/models/orm.py
+++ b/backend/app/models/orm.py
@@ -30,6 +30,7 @@ class UserORM(Base):
     oauth_provider = Column(String(50), nullable=True)
     oauth_id = Column(String(255), nullable=True)
     role = Column(String(20), server_default="user", nullable=False)
+    plan = Column(String(20), server_default="free", nullable=False)
 
     __table_args__ = (Index("ix_users_role", "role"),)
 

--- a/backend/app/repositories/sql_user_repository.py
+++ b/backend/app/repositories/sql_user_repository.py
@@ -22,6 +22,7 @@ class SqlUserRepository(UserRepository):
             oauth_provider=orm.oauth_provider,
             oauth_id=orm.oauth_id,
             role=orm.role or "user",
+            plan=orm.plan or "free",
         )
 
     async def get_by_username(self, username: str) -> Optional[UserInDB]:
@@ -66,6 +67,7 @@ class SqlUserRepository(UserRepository):
             oauth_provider=user.oauth_provider,
             oauth_id=user.oauth_id,
             role=user.role or "user",
+            plan=user.plan or "free",
         )
         self.session.add(orm)
         await self.session.commit()

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -116,6 +116,7 @@ def _user_to_response(user: UserInDB) -> UserResponse:
         created_at=user.created_at,
         is_active=user.is_active,
         role=user.role,
+        plan=user.plan,
     )
 
 

--- a/backend/tests/integration/test_coach_endpoints.py
+++ b/backend/tests/integration/test_coach_endpoints.py
@@ -12,7 +12,11 @@ from tests.fixtures.mock_coaching_provider import MockCoachingProvider
 
 
 @contextmanager
-def mock_auth(user_id: str = "test-id", username: str = "testuser"):
+def mock_auth(
+    user_id: str = "test-id",
+    username: str = "testuser",
+    plan: str = "premium",
+):
     """Override auth dependency for testing."""
     from app.api.auth_deps import get_current_user
 
@@ -25,6 +29,7 @@ def mock_auth(user_id: str = "test-id", username: str = "testuser"):
             email="test@example.com",
             is_active=True,
             created_at="2025-01-01T00:00:00Z",
+            plan=plan,
         )
 
     app.dependency_overrides[get_current_user] = override_get_current_user
@@ -139,7 +144,8 @@ class TestCoachEndpoints:
 
     def test_get_coaching_modes(self, test_client: TestClient):
         """Test getting available coaching modes."""
-        response = test_client.get("/api/coach/modes")
+        with mock_auth():
+            response = test_client.get("/api/coach/modes")
 
         assert response.status_code == 200
         data = response.json()
@@ -159,7 +165,8 @@ class TestCoachEndpoints:
 
     def test_get_supported_languages(self, test_client: TestClient):
         """Test getting supported programming languages."""
-        response = test_client.get("/api/coach/languages")
+        with mock_auth():
+            response = test_client.get("/api/coach/languages")
 
         assert response.status_code == 200
         data = response.json()
@@ -332,23 +339,24 @@ class TestCoachEndpoints:
             "difficulty": "easy",
         }
 
-        from app.api.auth_deps import get_current_user
+        from app.api.auth_deps import require_premium
         from app.models.auth_schemas import UserResponse
 
-        async def override_get_current_user():
+        async def override_require_premium():
             return UserResponse(
                 id="test-id",
                 username="testuser",
                 email="test@example.com",
                 is_active=True,
                 created_at="2025-01-01T00:00:00Z",
+                plan="premium",
             )
 
-        app.dependency_overrides[get_current_user] = override_get_current_user
+        app.dependency_overrides[require_premium] = override_require_premium
         try:
             response = await async_client.post("/api/coach/", json=coaching_request)
         finally:
-            app.dependency_overrides.pop(get_current_user, None)
+            app.dependency_overrides.pop(require_premium, None)
 
         assert response.status_code == 200
         data = response.json()
@@ -393,3 +401,56 @@ class TestCoachEndpoints:
 
         response = test_client.delete("/api/coach/")
         assert response.status_code == 405
+
+
+@pytest.mark.usefixtures("test_env_vars")
+class TestCoachPremiumGating:
+    """Premium gate on coach endpoints: free users are rejected, premium pass."""
+
+    def _coaching_request(self) -> dict:
+        return {
+            "problem": "Find the maximum element in an array",
+            "code": "def max_element(arr):\n    return max(arr)",
+            "language": "python",
+            "message": "Is this efficient?",
+            "mode": "review",
+            "difficulty": "easy",
+        }
+
+    def test_free_user_gets_403_on_coach(self, test_client: TestClient, test_env_vars):
+        with mock_auth(plan="free"):
+            response = test_client.post("/api/coach/", json=self._coaching_request())
+
+        assert response.status_code == 403
+        assert "premium" in response.json()["detail"].lower()
+
+    def test_premium_user_gets_200_on_coach(
+        self, test_client: TestClient, test_env_vars
+    ):
+        with mock_auth(plan="premium"):
+            response = test_client.post("/api/coach/", json=self._coaching_request())
+
+        assert response.status_code == 200
+        assert "response" in response.json()
+
+    def test_free_user_gets_403_on_stream(self, test_client: TestClient, test_env_vars):
+        with mock_auth(plan="free"):
+            response = test_client.post(
+                "/api/coach/stream", json=self._coaching_request()
+            )
+
+        assert response.status_code == 403
+
+    def test_free_user_gets_403_on_modes(self, test_client: TestClient, test_env_vars):
+        with mock_auth(plan="free"):
+            response = test_client.get("/api/coach/modes")
+
+        assert response.status_code == 403
+
+    def test_free_user_gets_403_on_languages(
+        self, test_client: TestClient, test_env_vars
+    ):
+        with mock_auth(plan="free"):
+            response = test_client.get("/api/coach/languages")
+
+        assert response.status_code == 403

--- a/backend/tests/integration/test_coach_usage_endpoints.py
+++ b/backend/tests/integration/test_coach_usage_endpoints.py
@@ -31,6 +31,39 @@ async def _register_user(async_client, username: str):
     return data["user"]["id"], {"Authorization": f"Bearer {data['access_token']}"}
 
 
+async def _register_premium_user(async_client, username: str):
+    uid, headers = await _register_user(async_client, username)
+    await _promote_premium(username)
+    return uid, headers
+
+
+async def _promote_premium(username: str) -> None:
+    """Set a registered user's plan to premium directly in the DB."""
+    import os
+    from urllib.parse import unquote, urlparse
+
+    import pymysql
+
+    parsed = urlparse(
+        os.environ["DATABASE_URL"].replace("mysql+aiomysql://", "mysql://")
+    )
+    conn = pymysql.connect(
+        host=parsed.hostname,
+        port=parsed.port or 3306,
+        user=unquote(parsed.username or ""),
+        password=unquote(parsed.password or ""),
+        database=os.environ["DATABASE_URL"].rsplit("/", 1)[-1],
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE users SET plan='premium' WHERE username=%s", (username,)
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def _coaching_payload():
     return {
         "problem": "Find the maximum element in an array",
@@ -46,7 +79,7 @@ def _coaching_payload():
 class TestUsageHeaders:
     @pytest.mark.asyncio
     async def test_coach_response_includes_usage_headers(self, async_client):
-        _, headers = await _register_user(async_client, "usagehdr")
+        _, headers = await _register_premium_user(async_client, "usagehdr")
         response = await async_client.post(
             "/api/coach/", json=_coaching_payload(), headers=headers
         )
@@ -59,7 +92,7 @@ class TestUsageHeaders:
 
     @pytest.mark.asyncio
     async def test_coach_stream_includes_usage_headers(self, async_client):
-        _, headers = await _register_user(async_client, "usagehdrs")
+        _, headers = await _register_premium_user(async_client, "usagehdrs")
         response = await async_client.post(
             "/api/coach/stream", json=_coaching_payload(), headers=headers
         )
@@ -71,7 +104,7 @@ class TestUsageHeaders:
 class TestDailyCaps:
     @pytest.mark.asyncio
     async def test_cap_exceeded_returns_429(self, async_client, test_db):
-        uid, headers = await _register_user(async_client, "cappeduser")
+        uid, headers = await _register_premium_user(async_client, "cappeduser")
         from app.repositories.sql_usage_repository import SqlUsageRepository
 
         repo = SqlUsageRepository(test_db)
@@ -93,7 +126,7 @@ class TestDailyCaps:
 
     @pytest.mark.asyncio
     async def test_cap_exceeded_stream_returns_429(self, async_client, test_db):
-        uid, headers = await _register_user(async_client, "cappedstream")
+        uid, headers = await _register_premium_user(async_client, "cappedstream")
         from app.repositories.sql_usage_repository import SqlUsageRepository
 
         repo = SqlUsageRepository(test_db)
@@ -134,7 +167,7 @@ class TestPerUserRateLimit:
         app.dependency_overrides[get_redis_cache] = override_get_redis_cache
         monkeypatch.setenv("USER_RATE_LIMIT_PER_MINUTE", "1")
         try:
-            _, headers = await _register_user(async_client, "ratelimited")
+            _, headers = await _register_premium_user(async_client, "ratelimited")
             first = await async_client.post(
                 "/api/coach/", json=_coaching_payload(), headers=headers
             )
@@ -150,7 +183,7 @@ class TestPerUserRateLimit:
     @pytest.mark.asyncio
     async def test_per_user_rate_limit_degrades_open_without_redis(self, async_client):
         # get_redis_cache returns None when Redis is disabled -> no 429
-        _, headers = await _register_user(async_client, "noeredis")
+        _, headers = await _register_premium_user(async_client, "noeredis")
         for _ in range(3):
             response = await async_client.post(
                 "/api/coach/", json=_coaching_payload(), headers=headers
@@ -167,7 +200,7 @@ class TestAuthAndValidation:
 
     @pytest.mark.asyncio
     async def test_coaching_oversized_payload_422(self, async_client):
-        _, headers = await _register_user(async_client, "oversized")
+        _, headers = await _register_premium_user(async_client, "oversized")
 
         cases = [
             {"problem": "x" * 20001},
@@ -217,7 +250,7 @@ class TestAuthAndValidation:
 class TestUsageHeadersReflectUsage:
     @pytest.mark.asyncio
     async def test_headers_reflect_existing_daily_usage(self, async_client, test_db):
-        uid, headers = await _register_user(async_client, "useduser")
+        uid, headers = await _register_premium_user(async_client, "useduser")
         from app.repositories.sql_usage_repository import SqlUsageRepository
 
         repo = SqlUsageRepository(test_db)

--- a/backend/tests/performance/test_load_limits.py
+++ b/backend/tests/performance/test_load_limits.py
@@ -18,8 +18,8 @@ from app.main import app
 
 @contextmanager
 def mock_auth(user_id: str = "test-id", username: str = "testuser"):
-    """Override auth dependency for testing."""
-    from app.api.auth_deps import get_current_user
+    """Override auth dependencies for testing (run + coach endpoints)."""
+    from app.api.auth_deps import get_current_user, require_premium
 
     async def override_get_current_user():
         from app.models.auth_schemas import UserResponse
@@ -30,13 +30,16 @@ def mock_auth(user_id: str = "test-id", username: str = "testuser"):
             email="test@example.com",
             is_active=True,
             created_at="2025-01-01T00:00:00Z",
+            plan="premium",
         )
 
     app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[require_premium] = override_get_current_user
     try:
         yield
     finally:
-        app.dependency_overrides.clear()
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(require_premium, None)
 
 
 class TestLoadLimits:
@@ -279,12 +282,13 @@ while True:
 
         import random
 
-        tasks = []
-        for _ in range(200):
-            endpoint = random.choice(endpoints)
-            tasks.append(async_client.get(endpoint))
+        with mock_auth():
+            tasks = []
+            for _ in range(200):
+                endpoint = random.choice(endpoints)
+                tasks.append(async_client.get(endpoint))
 
-        results = await asyncio.gather(*tasks)
+            results = await asyncio.gather(*tasks)
         assert all(r.status_code == 200 for r in results)
         assert len(results) == 200
 

--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -219,6 +219,57 @@ class TestAuthServiceRegister:
             await service.register(request)
 
 
+class TestAuthServicePlanPropagation:
+    @pytest.mark.asyncio
+    async def test_register_returns_free_plan(self, mock_repo):
+        service = AuthService(repository=mock_repo)
+        request = UserRegisterRequest(
+            username="newuser", email="new@test.com", password="secure123"
+        )
+
+        result = await service.register(request)
+
+        assert result.user.plan == "free"
+
+    @pytest.mark.asyncio
+    async def test_login_returns_user_plan(self, mock_repo):
+        user = UserInDB(
+            id="user-1",
+            username="testuser",
+            email="test@test.com",
+            hashed_password=hash_password("correctpass"),
+            created_at=datetime.now(timezone.utc),
+            is_active=True,
+            plan="premium",
+        )
+        mock_repo.get_by_username = AsyncMock(return_value=user)
+        service = AuthService(repository=mock_repo)
+        request = UserLoginRequest(username="testuser", password="correctpass")
+
+        result = await service.login(request)
+
+        assert result.user.plan == "premium"
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_returns_plan(self, mock_repo):
+        user = UserInDB(
+            id="user-1",
+            username="testuser",
+            email="test@test.com",
+            hashed_password="hash",
+            created_at=datetime.now(timezone.utc),
+            is_active=True,
+            plan="premium",
+        )
+        mock_repo.get_by_id = AsyncMock(return_value=user)
+        service = AuthService(repository=mock_repo)
+
+        token, _ = create_access_token(TokenData(user_id="user-1", username="testuser"))
+        result = await service.get_current_user(token)
+
+        assert result.plan == "premium"
+
+
 class TestAuthServiceLogin:
     @pytest.mark.asyncio
     async def test_login_success(self, mock_repo):

--- a/backend/tests/unit/test_premium_gate.py
+++ b/backend/tests/unit/test_premium_gate.py
@@ -1,0 +1,45 @@
+import pytest
+from fastapi import HTTPException, status
+
+from app.models.auth_schemas import UserResponse
+
+
+def make_user(plan: str = "free") -> UserResponse:
+    return UserResponse(
+        id="user-1",
+        username="testuser",
+        email="test@example.com",
+        is_active=True,
+        created_at="2025-01-01T00:00:00Z",
+        plan=plan,
+    )
+
+
+class TestRequirePremium:
+    @pytest.mark.asyncio
+    async def test_premium_user_passes(self):
+        from app.api.auth_deps import require_premium
+
+        user = make_user(plan="premium")
+        result = await require_premium(user)
+        assert result is user
+
+    @pytest.mark.asyncio
+    async def test_free_user_raises_403(self):
+        from app.api.auth_deps import require_premium
+
+        user = make_user(plan="free")
+        with pytest.raises(HTTPException) as exc:
+            await require_premium(user)
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+        assert "premium" in exc.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_default_plan_is_free(self):
+        from app.api.auth_deps import require_premium
+
+        user = make_user(plan="free")
+        assert user.plan == "free"
+        with pytest.raises(HTTPException) as exc:
+            await require_premium(user)
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/tests/unit/test_sql_user_repository.py
+++ b/backend/tests/unit/test_sql_user_repository.py
@@ -130,6 +130,33 @@ class TestSqlUserRepository:
         await repo.session.rollback()
 
     @pytest.mark.asyncio
+    async def test_add_and_get_plan_defaults_to_free(self, repo, sample_user):
+        await repo.add(sample_user)
+        await repo.session.commit()
+
+        fetched = await repo.get_by_id(sample_user.id)
+        assert fetched is not None
+        assert fetched.plan == "free"
+
+    @pytest.mark.asyncio
+    async def test_add_and_get_premium_plan_roundtrip(self, repo):
+        premium_user = UserInDB(
+            id=str(uuid.uuid4()),
+            username="premiumuser",
+            email="premium@example.com",
+            hashed_password="hash",
+            created_at=datetime.now(timezone.utc),
+            is_active=True,
+            plan="premium",
+        )
+        await repo.add(premium_user)
+        await repo.session.commit()
+
+        fetched = await repo.get_by_id(premium_user.id)
+        assert fetched is not None
+        assert fetched.plan == "premium"
+
+    @pytest.mark.asyncio
     async def test_inactive_user(self, repo):
         user = UserInDB(
             id=str(uuid.uuid4()),

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -125,6 +125,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
                 onClose={() => setSettingsOpen(false)}
                 isAuthenticated={isAuthenticated}
                 onLogout={logout}
+                plan={user?.plan}
               />
             </div>
           </div>

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -207,6 +207,7 @@ export function Header() {
         onClose={() => setShowSettings(false)}
         isAuthenticated={isHydrated && isAuthenticated}
         onLogout={logout}
+        plan={user?.plan}
       />
     </>
   );

--- a/frontend/src/components/layout/elements/AIChatPanelContainer.test.tsx
+++ b/frontend/src/components/layout/elements/AIChatPanelContainer.test.tsx
@@ -1,6 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { AIChatPanelContainer } from "./AIChatPanelContainer";
+
+const mockUseAuth = vi.hoisted(() => vi.fn());
+
+vi.mock("@/providers", () => ({ useAuth: mockUseAuth }));
 
 describe("AIChatPanelContainer", () => {
   const defaultProps = {
@@ -11,6 +15,11 @@ describe("AIChatPanelContainer", () => {
     currentCode: "",
     language: "python" as const,
   };
+
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    mockUseAuth.mockReturnValue({ user: { plan: "premium" }, isHydrated: true });
+  });
 
   it("renders aside with AI Assistant Panel aria label", () => {
     render(<AIChatPanelContainer {...defaultProps} />);
@@ -40,5 +49,16 @@ describe("AIChatPanelContainer", () => {
         "Ask a question or describe your approach...",
       ),
     ).toBeDisabled();
+  });
+
+  it("shows premium upsell instead of the chat panel for free users", () => {
+    mockUseAuth.mockReturnValue({ user: { plan: "free" }, isHydrated: true });
+    render(<AIChatPanelContainer {...defaultProps} />);
+    expect(
+      screen.getByText("AI Coach is a Premium feature"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("Ask a question or describe your approach..."),
+    ).toBeNull();
   });
 });

--- a/frontend/src/components/layout/elements/AIChatPanelContainer.tsx
+++ b/frontend/src/components/layout/elements/AIChatPanelContainer.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { AIChatPanel } from "@/components/chat/AIChatPanel";
+import { PremiumGate } from "@/components/premium/PremiumGate";
 import { ChatMessage, Language } from "@/types";
 
 interface AIChatPanelContainerProps {
@@ -26,15 +27,17 @@ export function AIChatPanelContainer({
       className="h-full flex flex-col flex-none overflow-hidden border-l border-white/[0.04]"
       aria-label="AI Assistant Panel"
     >
-      <AIChatPanel
-        messages={messages}
-        onSendMessage={onSendMessage}
-        onClose={onClose}
-        isTyping={isTyping}
-        selectedQuestion={selectedQuestion}
-        currentCode={currentCode}
-        language={language}
-      />
+      <PremiumGate>
+        <AIChatPanel
+          messages={messages}
+          onSendMessage={onSendMessage}
+          onClose={onClose}
+          isTyping={isTyping}
+          selectedQuestion={selectedQuestion}
+          currentCode={currentCode}
+          language={language}
+        />
+      </PremiumGate>
     </aside>
   );
 }

--- a/frontend/src/components/premium/PremiumGate.test.tsx
+++ b/frontend/src/components/premium/PremiumGate.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PremiumGate } from "./PremiumGate";
+
+const mockUseAuth = vi.hoisted(() => vi.fn());
+
+vi.mock("@/providers", () => ({ useAuth: mockUseAuth }));
+
+describe("PremiumGate", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+  });
+
+  it("renders children when user has premium plan", () => {
+    mockUseAuth.mockReturnValue({
+      user: { plan: "premium" },
+      isHydrated: true,
+    });
+    render(
+      <PremiumGate>
+        <span>premium content</span>
+      </PremiumGate>,
+    );
+    expect(screen.getByText("premium content")).toBeInTheDocument();
+  });
+
+  it("renders upsell when user has free plan", () => {
+    mockUseAuth.mockReturnValue({
+      user: { plan: "free" },
+      isHydrated: true,
+    });
+    render(
+      <PremiumGate>
+        <span>premium content</span>
+      </PremiumGate>,
+    );
+    expect(screen.queryByText("premium content")).toBeNull();
+    expect(
+      screen.getByText("AI Coach is a Premium feature"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders upsell when no user is signed in", () => {
+    mockUseAuth.mockReturnValue({ user: null, isHydrated: true });
+    render(
+      <PremiumGate>
+        <span>premium content</span>
+      </PremiumGate>,
+    );
+    expect(screen.queryByText("premium content")).toBeNull();
+    expect(
+      screen.getByText("AI Coach is a Premium feature"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a custom fallback instead of the default upsell", () => {
+    mockUseAuth.mockReturnValue({ user: { plan: "free" }, isHydrated: true });
+    render(
+      <PremiumGate fallback={<span>custom upsell</span>}>
+        <span>premium content</span>
+      </PremiumGate>,
+    );
+    expect(screen.getByText("custom upsell")).toBeInTheDocument();
+    expect(screen.queryByText("premium content")).toBeNull();
+  });
+});

--- a/frontend/src/components/premium/PremiumGate.tsx
+++ b/frontend/src/components/premium/PremiumGate.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Sparkles } from 'lucide-react';
+import { useAuth } from '@/providers';
+import { Button } from '@/components/ui/button';
+
+interface PremiumGateProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+export function PremiumGate({ children, fallback }: PremiumGateProps) {
+  const { user } = useAuth();
+  const isPremium = user?.plan === 'premium';
+
+  if (isPremium) return <>{children}</>;
+  if (fallback) return <>{fallback}</>;
+
+  return (
+    <div
+      className="flex h-full flex-col items-center justify-center gap-4 p-6 text-center"
+      role="status"
+      aria-label="Premium feature"
+    >
+      <div className="rounded-full bg-primary/10 p-3">
+        <Sparkles className="h-6 w-6 text-primary" />
+      </div>
+      <div>
+        <p className="text-sm font-semibold text-foreground/80">
+          AI Coach is a Premium feature
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground/70 leading-relaxed">
+          Upgrade to Premium to unlock the AI coaching panel with hints,
+          reviews, and debugging help.
+        </p>
+      </div>
+      <Button variant="primary-pill" size="sm" aria-label="Go Premium">
+        Go Premium
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/SettingsModal.test.tsx
+++ b/frontend/src/components/settings/SettingsModal.test.tsx
@@ -107,4 +107,15 @@ describe('SettingsModal', () => {
     render(<SettingsModal {...defaultProps} />);
     expect(screen.queryByRole('button', { name: /sign out/i })).toBeNull();
   });
+
+  it('shows Free plan by default', () => {
+    render(<SettingsModal {...defaultProps} />);
+    expect(screen.getByText('Your plan')).toBeInTheDocument();
+    expect(screen.getByText('Free')).toBeInTheDocument();
+  });
+
+  it('shows Premium plan when plan is premium', () => {
+    render(<SettingsModal {...defaultProps} plan="premium" />);
+    expect(screen.getByText('Premium')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/settings/SettingsModal.tsx
+++ b/frontend/src/components/settings/SettingsModal.tsx
@@ -9,6 +9,7 @@ interface SettingsModalProps {
   onClose: () => void;
   isAuthenticated?: boolean;
   onLogout?: () => void;
+  plan?: string;
 }
 
 export function SettingsModal({
@@ -16,6 +17,7 @@ export function SettingsModal({
   onClose,
   isAuthenticated = false,
   onLogout,
+  plan = 'free',
 }: SettingsModalProps) {
   const inputRef = useRef<HTMLDivElement>(null);
 
@@ -64,6 +66,22 @@ export function SettingsModal({
                     usage is metered per account with daily limits.
                   </p>
                 </div>
+              </div>
+            </div>
+
+            <div className="rounded-2xl bg-white/[0.03] ring-1 ring-white/5 p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-xs font-medium text-foreground/80">Your plan</p>
+                  <p className="text-[10px] text-muted-foreground/60 mt-1 leading-relaxed">
+                    {plan === 'premium'
+                      ? 'Premium — AI Coach and all features unlocked.'
+                      : 'Free — questions and curriculum included. AI Coach requires Premium.'}
+                  </p>
+                </div>
+                <span className="rounded-full bg-primary/10 px-3 py-1 text-[10px] font-medium uppercase tracking-wide text-primary">
+                  {plan === 'premium' ? 'Premium' : 'Free'}
+                </span>
               </div>
             </div>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -138,6 +138,7 @@ export interface User {
   created_at: string;
   is_active: boolean;
   role?: string;
+  plan?: string;
 }
 
 export interface AuthState {


### PR DESCRIPTION
Closes #88

## Summary

Implements the premium tier: **questions + curriculum stay free**, **everything else premium**. AI Coach is the first gated surface; coach rate limiting intentionally deferred (existing limits unchanged).

## Changes

**Backend**
- `users.plan` (free/premium, default free) — ORM, schemas, repo, auth service
- Alembic migration `a5369fbca804` (add `users.plan`, server_default `free`)
- `require_premium` dep (403) applied to all `/api/coach/*` endpoints
- run/submit/questions/courses/progress stay free (auth-gated only)

**Frontend**
- `User.plan?` type
- `PremiumGate` component — upsell for free users
- `AIChatPanelContainer` gated (covers problem workspace + lesson layouts)
- Settings modal shows plan status (wired from header + admin layout)

## Tests
- Backend: premium gate unit tests, plan round-trip, coach gating integration (free→403/premium→200), coach usage tests updated to premium users
- Frontend: PremiumGate component tests, chat panel upsell test, settings plan display
- **764 backend + 471 frontend pass** (only pre-existing env failures: Piston DNS on host, 2 load tests)

## Verification
- Docker rebuilt (`docker compose up -d --build backend frontend`)
- Gate verified live: free→403, premium→200
- ruff + format + typecheck + lint clean
- `graphify update .` run

## Follow-ups
- Real billing/checkout (plan is a DB flag for now)
- Premium rate-limit tiers (deferred)
- Admin UI to set user plan
