### PR TITLE
fix(editor): restyle language selector with visible container and focus state

### DIFF
--- a/frontend/src/components/editor/CodeEditor.test.tsx
+++ b/frontend/src/components/editor/CodeEditor.test.tsx
@@ -39,7 +39,23 @@ describe("CodeEditor", () => {
 
   it("renders language selector", () => {
     render(<CodeEditor {...defaultProps} />);
-    expect(screen.getByRole("combobox")).toHaveValue("python");
+    const select = screen.getByRole("combobox", { name: /programming language/i });
+    expect(select).toHaveValue("python");
+  });
+
+  it("renders language selector with a visible, labelled, non-clipping control", () => {
+    render(<CodeEditor {...defaultProps} />);
+    const select = screen.getByRole("combobox", { name: /programming language/i });
+    // Visible container + focus affordance instead of a transparent bare select
+    expect(select).toHaveClass("bg-white/[0.04]");
+    expect(select).toHaveClass("ring-1");
+    expect(select).toHaveClass("focus-visible:ring-2");
+    expect(select).toHaveClass("appearance-none");
+    // Sized to avoid clipping on narrow practice panels
+    expect(select).toHaveClass("min-w-[9rem]");
+    expect(select).toHaveClass("truncate");
+    // The labelled control exposes its name to assistive tech
+    expect(screen.getByLabelText(/programming language/i)).toBe(select);
   });
 
   it("renders Reset, Run, and Submit buttons", () => {
@@ -95,7 +111,10 @@ describe("CodeEditor", () => {
       <CodeEditor {...defaultProps} onLanguageChange={onLanguageChange} />,
     );
 
-    await user.selectOptions(screen.getByRole("combobox"), "javascript");
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /programming language/i }),
+      "javascript",
+    );
     expect(onLanguageChange).toHaveBeenCalledWith("javascript");
   });
 

--- a/frontend/src/components/editor/CodeEditor.tsx
+++ b/frontend/src/components/editor/CodeEditor.tsx
@@ -3,7 +3,7 @@
 import { cn } from "@/lib/utils";
 import { Language } from "@/types";
 import dynamic from "next/dynamic";
-import { CheckCircle, Play, RotateCcw } from "lucide-react";
+import { CheckCircle, ChevronDown, Play, RotateCcw } from "lucide-react";
 import { useRef } from "react";
 import { LANGUAGE_OPTIONS } from "./constants";
 
@@ -59,19 +59,19 @@ export function CodeEditor({
   return (
     <div className="flex flex-col h-full">
       <div className="flex items-center justify-between px-3 py-2 border-b border-white/5">
-        <div className="flex items-center gap-1">
-          <div className="rounded-full bg-white/[0.03] ring-1 ring-white/5 p-0.5">
+        <div className="flex items-center gap-1 min-w-0">
+          <label
+            htmlFor="code-editor-language"
+            className="sr-only"
+          >
+            Programming language
+          </label>
+          <div className="relative inline-flex min-w-0 max-w-full">
             <select
+              id="code-editor-language"
               value={language}
               onChange={(e) => handleLanguageChange(e.target.value as Language)}
-              className="px-2.5 py-1 text-[11px] tracking-wide bg-transparent text-foreground/70 focus:outline-none cursor-pointer appearance-none"
-              style={{
-                backgroundImage: `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e")`,
-                backgroundPosition: "right 4px center",
-                backgroundRepeat: "no-repeat",
-                backgroundSize: "16px 12px",
-                paddingRight: "24px",
-              }}
+              className="w-full min-w-[9rem] max-w-[16rem] appearance-none rounded-md bg-white/[0.04] px-2.5 py-1.5 pr-7 text-xs font-medium tracking-wide text-foreground/80 ring-1 ring-white/10 transition-all duration-300 hover:bg-white/[0.07] hover:ring-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/60 cursor-pointer truncate"
             >
               {LANGUAGE_OPTIONS.map((option) => (
                 <option
@@ -84,6 +84,7 @@ export function CodeEditor({
                 </option>
               ))}
             </select>
+            <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/60" />
           </div>
         </div>
 


### PR DESCRIPTION
Closes #97

## Problem
The language selector on the practice/code panel was a bare native `<select>` with a transparent background, tiny `text-[11px]` type, a hardcoded inline SVG chevron, and no visible border or focus state. This caused poor contrast, inconsistent sizing, clipping on narrow panels, and unreliable dropdown rendering.

## Fix
`frontend/src/components/editor/CodeEditor.tsx`:
- Visible container: `bg-white/[0.04]` + `ring-1 ring-white/10`, hover brightening
- Clear focus affordance: `focus-visible:ring-2 ring-emerald-400/60`
- Consistent contrast: `text-xs font-medium text-foreground/80`
- Proper sizing to avoid clipping: `min-w-[9rem] max-w-[16rem] truncate`
- lucide `ChevronDown` icon instead of inline SVG (pointer-events-none, centered)
- `sr-only` label + `htmlFor` association for assistive tech

Language-change behavior (starter-code swapping) is unchanged.

## Tests
- Updated `CodeEditor.test.tsx`: selector renders with value; added a test asserting the labelled, visible, non-clipping control (ring, focus ring, min-width, truncate, accessible name)
- 496 frontend unit tests pass, typecheck clean, lint has only pre-existing warnings

## Verification
- Frontend Docker image rebuilt: `docker compose up -d --build frontend`
- Caveman-reviewed staged diff before commit