### PR TITLE
feat(results): structured test-case result cards with visible whitespace

### DIFF
--- a/frontend/src/app/learn/lesson/[lessonId]/page.tsx
+++ b/frontend/src/app/learn/lesson/[lessonId]/page.tsx
@@ -10,6 +10,7 @@ import { HydrationGuard } from '@/components/ui/HydrationGuard';
 import { showToast } from '@/components/ui/Toast';
 import { useCoaching } from '@/features/coaching/coaching.hook';
 import { useLesson } from '@/features/curriculum/use-curriculum.hook';
+import { TestCaseResultView } from '@/features/code-execution/code-execution.types';
 import { FetchClient, HttpError } from '@/lib/fetch-client';
 import { useAuth } from '@/providers';
 import { Language, LessonSummary, Question } from '@/types';
@@ -56,6 +57,9 @@ export default function LessonPage() {
   const [isRunning, setIsRunning] = useState(false);
   const [output, setOutput] = useState('');
   const [runError, setRunError] = useState('');
+  const [testResults, setTestResults] = useState<TestCaseResultView[] | null>(
+    null,
+  );
   const [currentCode, setCurrentCode] = useState('');
   const [language, setLanguage] = useState<Language>((lesson?.language as Language) || 'python');
 
@@ -124,6 +128,7 @@ export default function LessonPage() {
   const handleRunCode = async (stdin: string) => {
     setIsRunning(true);
     setRunError('');
+    setTestResults(null);
     try {
       const res = (await api.post('/api/run/', {
         language,
@@ -158,9 +163,27 @@ export default function LessonPage() {
           passed: boolean;
           total: number;
           passed_count: number;
-          results: Array<{ index: number; passed: boolean; actual: string }>;
+          results: Array<{
+            index: number;
+            passed: boolean;
+            actual: string;
+            input: string;
+            expected: string;
+            hidden?: boolean;
+          }>;
         };
 
+        setTestResults(
+          submitRes.results.map((r) => ({
+            index: r.index,
+            passed: r.passed,
+            testName: `Test ${r.index}`,
+            input: r.hidden ? '' : r.input,
+            expected: r.hidden ? '' : r.expected,
+            actual: r.hidden ? '' : r.actual,
+            hidden: r.hidden ?? false,
+          })),
+        );
         const results = submitRes.results.map(
           (r: any) =>
             `Test ${r.index}: ${r.passed ? 'PASSED' : 'FAILED'}${
@@ -191,6 +214,7 @@ export default function LessonPage() {
 
     let passedCount = 0;
     const resultLines: string[] = [];
+    const structuredResults: TestCaseResultView[] = [];
 
     for (let i = 0; i < lessonTestCases.length; i++) {
       const tc = lessonTestCases[i];
@@ -210,12 +234,33 @@ export default function LessonPage() {
             tc.input
           }\n  Expected: ${expected}\n  Actual: ${actual}`,
         );
+        structuredResults.push({
+          index: i + 1,
+          passed,
+          testName: `Test ${i + 1}`,
+          input: tc.input,
+          expected,
+          actual,
+          hidden: false,
+        });
       } catch (err) {
         resultLines.push(
           `Test ${i + 1}: ERROR - ${err instanceof Error ? err.message : 'Execution failed'}`,
         );
+        structuredResults.push({
+          index: i + 1,
+          passed: false,
+          testName: `Test ${i + 1}`,
+          input: tc.input,
+          expected: tc.expected_output,
+          actual: '',
+          error: err instanceof Error ? err.message : 'Execution failed',
+          hidden: false,
+        });
       }
     }
+
+    setTestResults(structuredResults);
 
     const allPassed = passedCount === lessonTestCases.length;
     if (allPassed) {
@@ -284,6 +329,7 @@ export default function LessonPage() {
               isRunning={isRunning}
               output={output}
               error={runError}
+              testResults={testResults}
               isInteractive={linkedQuestion?.is_interactive ?? false}
               messages={messages}
               isTyping={isTyping}

--- a/frontend/src/components/MainWorkspace.tsx
+++ b/frontend/src/components/MainWorkspace.tsx
@@ -41,6 +41,7 @@ export function MainWorkspace() {
   const {
     isRunning,
     output,
+    testResults,
     executionError,
     handleRunCode,
     handleSubmitCode,
@@ -122,6 +123,7 @@ export function MainWorkspace() {
               isRunning={isRunning}
               output={output}
               error={executionError || error || ""}
+              testResults={testResults}
               isInteractive={fullQuestion?.is_interactive || false}
               onCodeChange={setCurrentCode}
               onLanguageChange={setLanguage}

--- a/frontend/src/components/layout/elements/CodeEditorContainer.test.tsx
+++ b/frontend/src/components/layout/elements/CodeEditorContainer.test.tsx
@@ -120,4 +120,58 @@ describe('CodeEditorContainer', () => {
     const editor = screen.getByTestId('mock-code-editor');
     expect(editor).toHaveAttribute('data-is-running', 'true');
   });
+
+  it('renders structured test results when provided', () => {
+    render(
+      <CodeEditorContainer
+        {...defaultProps}
+        output="ignored legacy string"
+        testResults={[
+          {
+            index: 1,
+            passed: true,
+            testName: 'Test 1',
+            input: '1',
+            expected: '1',
+            actual: '1',
+            hidden: false,
+          },
+          {
+            index: 2,
+            passed: false,
+            testName: 'Test 2',
+            input: '2',
+            expected: '3',
+            actual: '2',
+            hidden: false,
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Test Results: 1/2 passed · 1 failed')).toBeInTheDocument();
+    expect(screen.getByText('Test 1')).toBeInTheDocument();
+    expect(screen.getByText('Test 2')).toBeInTheDocument();
+  });
+
+  it('does not render structured results when error is present', () => {
+    render(
+      <CodeEditorContainer
+        {...defaultProps}
+        error="SyntaxError"
+        testResults={[
+          {
+            index: 1,
+            passed: true,
+            testName: 'Test 1',
+            input: '1',
+            expected: '1',
+            actual: '1',
+            hidden: false,
+          },
+        ]}
+      />,
+    );
+    expect(screen.queryByText(/Test Results:/)).not.toBeInTheDocument();
+    expect(screen.getByText('SyntaxError')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/layout/elements/CodeEditorContainer.tsx
+++ b/frontend/src/components/layout/elements/CodeEditorContainer.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useRef, useCallback, useEffect } from "react";
 import { CodeEditor } from "@/components/editor/CodeEditor";
+import { TestCaseResults } from "@/components/results/TestCaseResults";
+import { TestCaseResultView } from "@/features/code-execution/code-execution.types";
 import { Language } from "@/types";
 import { ChevronDown, ChevronUp, GripVertical, Play } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -15,6 +17,7 @@ interface CodeEditorContainerProps {
   isRunning: boolean;
   output: string;
   error: string;
+  testResults?: TestCaseResultView[] | null;
   isInteractive?: boolean;
   onCodeChange: (code: string) => void;
   onLanguageChange: (language: Language) => void;
@@ -30,6 +33,7 @@ export function CodeEditorContainer({
   isRunning,
   output,
   error,
+  testResults = null,
   isInteractive = false,
   onCodeChange,
   onLanguageChange,
@@ -186,6 +190,8 @@ export function CodeEditorContainer({
           <div className="flex-1 overflow-auto p-4">
             {isInteractive ? (
               <TerminalSimulation output={error || output} />
+            ) : testResults && testResults.length > 0 && !error ? (
+              <TestCaseResults results={testResults} />
             ) : (
               <div
                 className={cn(

--- a/frontend/src/components/layout/lessons/ExerciseLessonLayout.tsx
+++ b/frontend/src/components/layout/lessons/ExerciseLessonLayout.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { CodeEditorContainer } from '@/components/layout/elements';
+import { TestCaseResultView } from '@/features/code-execution/code-execution.types';
 import { cn } from '@/lib/utils';
 import { ChatMessage, Language, LessonSummary, Question } from '@/types';
 import { AICoachPane } from './AICoachPane';
@@ -22,6 +23,7 @@ interface ExerciseLessonLayoutProps {
   isRunning: boolean;
   output: string;
   error: string;
+  testResults?: TestCaseResultView[] | null;
   isInteractive: boolean;
   messages: ChatMessage[];
   isTyping: boolean;
@@ -44,6 +46,7 @@ export function ExerciseLessonLayout({
   isRunning,
   output,
   error,
+  testResults = null,
   isInteractive,
   messages,
   isTyping,
@@ -127,6 +130,7 @@ export function ExerciseLessonLayout({
               isRunning={isRunning}
               output={output}
               error={error}
+              testResults={testResults}
               isInteractive={isInteractive}
               onCodeChange={onCodeChange}
               onLanguageChange={onLanguageChange}
@@ -165,6 +169,7 @@ export function ExerciseLessonLayout({
               isRunning={isRunning}
               output={output}
               error={error}
+              testResults={testResults}
               isInteractive={isInteractive}
               onCodeChange={onCodeChange}
               onLanguageChange={onLanguageChange}

--- a/frontend/src/components/results/TestCaseResults.test.tsx
+++ b/frontend/src/components/results/TestCaseResults.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TestCaseResults } from "./TestCaseResults";
+import { TestCaseResultView } from "@/features/code-execution/code-execution.types";
+
+const passing: TestCaseResultView = {
+  index: 1,
+  passed: true,
+  testName: "Test 1",
+  input: '"dlrow"',
+  expected: '"world"',
+  actual: "world",
+  hidden: false,
+};
+
+const failing: TestCaseResultView = {
+  index: 2,
+  passed: false,
+  testName: "Test 2",
+  input: "5",
+  expected: "6",
+  actual: "5",
+  hidden: false,
+};
+
+const errored: TestCaseResultView = {
+  index: 3,
+  passed: false,
+  testName: "Test 3",
+  input: "1",
+  expected: "1",
+  actual: "",
+  error: "IndexError: list index out of range",
+  hidden: false,
+};
+
+const hidden: TestCaseResultView = {
+  index: 4,
+  passed: false,
+  testName: "Test 4",
+  input: "",
+  expected: "",
+  actual: "",
+  hidden: true,
+};
+
+describe("TestCaseResults", () => {
+  it("renders a summary banner with pass/fail counts", () => {
+    render(<TestCaseResults results={[passing, failing]} />);
+    expect(
+      screen.getByRole("status", { name: "1 of 2 tests passed" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Test Results: 1/2 passed · 1 failed")).toBeInTheDocument();
+  });
+
+  it("renders an all-pass summary banner", () => {
+    render(<TestCaseResults results={[passing]} />);
+    expect(
+      screen.getByRole("status", { name: "1 of 1 tests passed" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Test Results: 1/1 passed")).toBeInTheDocument();
+  });
+
+  it("renders input, expected, and actual values per test card", () => {
+    render(<TestCaseResults results={[passing, failing]} />);
+    expect(screen.getByText("Test 1")).toBeInTheDocument();
+    expect(screen.getByText("Test 2")).toBeInTheDocument();
+    // Value cells for the failing case
+    expect(screen.getAllByText("Input").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Expected").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Actual").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("5").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("6").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows an amber error card instead of pass/fail for execution errors", () => {
+    render(<TestCaseResults results={[errored]} />);
+    expect(screen.getAllByText("Error").length).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getByText("IndexError: list index out of range"),
+    ).toBeInTheDocument();
+  });
+
+  it("marks hidden test cases without leaking input/expected/actual", () => {
+    render(<TestCaseResults results={[hidden]} />);
+    expect(screen.getByText("Hidden test case")).toBeInTheDocument();
+    expect(screen.queryByText("Input")).not.toBeInTheDocument();
+  });
+
+  it("renders whitespace-sensitive values in whitespace-pre-wrap cells", () => {
+    const whitespace: TestCaseResultView = {
+      index: 1,
+      passed: false,
+      testName: "Test 1",
+      input: '"123  "',
+      expected: '"123  "',
+      actual: "123",
+      hidden: false,
+    };
+    render(<TestCaseResults results={[whitespace]} />);
+    const pres = document.querySelectorAll("pre");
+    const texts = Array.from(pres).map((p) => p.textContent || "");
+    // whitespace is preserved in the value cells
+    expect(texts.some((t) => t === '"123  "')).toBe(true);
+    expect(texts.some((t) => t === "123")).toBe(true);
+    // all value cells use whitespace-pre-wrap
+    pres.forEach((p) => expect(p.className).toContain("whitespace-pre-wrap"));
+    pres.forEach((p) => expect(p.className).toContain("font-mono"));
+  });
+
+  it("supports a custom title", () => {
+    render(<TestCaseResults results={[passing]} title="Validation" />);
+    expect(screen.getByText("Validation: 1/1 passed")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/results/TestCaseResults.tsx
+++ b/frontend/src/components/results/TestCaseResults.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { CheckCircle2, XCircle, AlertCircle } from "lucide-react";
+import { TestCaseResultView } from "@/features/code-execution/code-execution.types";
+
+interface TestCaseResultsProps {
+  results: TestCaseResultView[];
+  title?: string;
+}
+
+function ValueCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-[10px] font-semibold tracking-wider text-muted-foreground/60 uppercase mb-1">
+        {label}
+      </div>
+      <pre
+        className={cn(
+          "whitespace-pre-wrap break-all rounded-md bg-white/[0.03] ring-1 ring-white/5 px-2 py-1.5 text-[11px] font-mono leading-relaxed",
+          value === ""
+            ? "text-muted-foreground/40 italic"
+            : "text-foreground/90",
+        )}
+      >
+        {value === "" ? "(empty)" : value}
+      </pre>
+    </div>
+  );
+}
+
+export function TestCaseResults({ results, title }: TestCaseResultsProps) {
+  const total = results.length;
+  const passedCount = results.filter((r) => r.passed).length;
+  const failedCount = total - passedCount;
+  const allPassed = total > 0 && failedCount === 0;
+
+  const bannerStyles = allPassed
+    ? "bg-emerald-500/10 ring-emerald-500/30 text-emerald-300"
+    : "bg-red-500/10 ring-red-500/30 text-red-300";
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-lg ring-1 px-3 py-2",
+          bannerStyles,
+        )}
+        role="status"
+        aria-label={`${passedCount} of ${total} tests passed`}
+      >
+        {allPassed ? (
+          <CheckCircle2 className="h-4 w-4" />
+        ) : (
+          <XCircle className="h-4 w-4" />
+        )}
+        <span className="text-xs font-semibold tracking-wide">
+          {title || "Test Results"}: {passedCount}/{total} passed
+          {failedCount > 0 && ` · ${failedCount} failed`}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {results.map((result) => (
+          <div
+            key={result.index}
+            className={cn(
+              "rounded-lg ring-1 border bg-white/[0.02] overflow-hidden",
+              result.passed
+                ? "ring-emerald-500/20 border-emerald-500/10"
+                : result.error
+                  ? "ring-amber-500/30 border-amber-500/20"
+                  : "ring-red-500/25 border-red-500/15",
+            )}
+          >
+            <div className="flex items-center gap-2 px-3 py-2 border-b border-white/5">
+              {result.error ? (
+                <AlertCircle className="h-3.5 w-3.5 text-amber-400" />
+              ) : result.passed ? (
+                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400" />
+              ) : (
+                <XCircle className="h-3.5 w-3.5 text-red-400" />
+              )}
+              <span className="text-xs font-medium text-foreground/80">
+                {result.testName}
+              </span>
+              <span
+                className={cn(
+                  "ml-auto text-[10px] font-semibold tracking-wider uppercase rounded-full px-2 py-0.5",
+                  result.error
+                    ? "bg-amber-500/10 text-amber-300 ring-1 ring-amber-500/30"
+                    : result.passed
+                      ? "bg-emerald-500/10 text-emerald-300 ring-1 ring-emerald-500/30"
+                      : "bg-red-500/10 text-red-300 ring-1 ring-red-500/30",
+                )}
+              >
+                {result.error ? "Error" : result.passed ? "Pass" : "Fail"}
+              </span>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 p-3">
+              {result.error ? (
+                <div className="sm:col-span-2">
+                  <ValueCell label="Error" value={result.error} />
+                </div>
+              ) : result.hidden ? (
+                <div className="sm:col-span-2 text-xs text-muted-foreground/50 italic py-1">
+                  Hidden test case
+                </div>
+              ) : (
+                <>
+                  <ValueCell label="Input" value={result.input} />
+                  <ValueCell label="Expected" value={result.expected} />
+                  <ValueCell label="Actual" value={result.actual} />
+                  {result.stderr ? (
+                    <ValueCell label="Stderr" value={result.stderr} />
+                  ) : null}
+                </>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/code-execution/code-execution.hook.ts
+++ b/frontend/src/features/code-execution/code-execution.hook.ts
@@ -7,6 +7,7 @@ import {
   CodeExecutionFeature,
   SubmitResponse,
   TestCase,
+  TestCaseResultView,
   ValidationResponse,
 } from "./code-execution.types";
 import {
@@ -22,6 +23,9 @@ export function useCodeExecution(): CodeExecutionFeature {
   const [lastResult, setLastResult] = useState<ValidationResponse | null>(null);
   const [lastSubmitResult, setLastSubmitResult] =
     useState<SubmitResponse | null>(null);
+  const [testResults, setTestResults] = useState<TestCaseResultView[] | null>(
+    null,
+  );
 
   const runCode = useCallback(
     async (language: string, code: string, version?: string) => {
@@ -34,6 +38,7 @@ export function useCodeExecution(): CodeExecutionFeature {
           version,
         );
         setOutput(result.stdout || "");
+        setTestResults(null);
         return result;
       } catch (err) {
         const errorMessage =
@@ -65,6 +70,22 @@ export function useCodeExecution(): CodeExecutionFeature {
         lines.push(
           `Run Results: ${result.passed_tests}/${result.total_tests} passed\n`,
         );
+        const structured = result.results.map((r, index) => {
+          const tc = testCases[index];
+          return {
+            index: index + 1,
+            passed: r.passed,
+            testName: r.test_name || `Test ${index + 1}`,
+            input: tc?.input ?? "",
+            expected: tc?.expected_output ?? "",
+            actual: normalizeDisplayJson(r.stdout) || "",
+            error: r.error,
+            stderr: r.stderr,
+            hidden: false,
+          };
+        });
+        setTestResults(structured);
+
         result.results.forEach((r, index) => {
           const tc = testCases[index];
           lines.push(
@@ -110,6 +131,16 @@ export function useCodeExecution(): CodeExecutionFeature {
           code,
         );
         setLastSubmitResult(result);
+        const structured = result.results.map((r) => ({
+          index: r.index,
+          passed: r.passed,
+          testName: `Test ${r.index}`,
+          input: r.hidden ? "" : r.input,
+          expected: r.hidden ? "" : r.expected,
+          actual: r.hidden ? "" : r.actual,
+          hidden: r.hidden,
+        }));
+        setTestResults(structured);
         const outputLines = result.results.map((r) => {
           const status = r.passed ? "Pass" : "Fail";
           let line = `${r.passed ? "✅" : "❌"} Test ${r.index}: ${status}`;
@@ -157,6 +188,7 @@ export function useCodeExecution(): CodeExecutionFeature {
         const result = await executeClientJS(code, question);
         const outputText = formatClientJsOutput(result, question);
         setOutput(outputText);
+        setTestResults(null);
         return outputText;
       } catch (err: unknown) {
         const errorMessage =
@@ -175,6 +207,7 @@ export function useCodeExecution(): CodeExecutionFeature {
 
   const clearOutput = useCallback(() => {
     setOutput("");
+    setTestResults(null);
   }, []);
 
   const clearError = useCallback(() => {
@@ -187,6 +220,7 @@ export function useCodeExecution(): CodeExecutionFeature {
     error,
     lastResult,
     lastSubmitResult,
+    testResults,
     runCode,
     validateCode,
     submitCode,

--- a/frontend/src/features/code-execution/code-execution.types.ts
+++ b/frontend/src/features/code-execution/code-execution.types.ts
@@ -35,6 +35,19 @@ export interface CodeExecutionState {
   error: string | null;
   lastResult: ValidationResponse | null;
   lastSubmitResult: SubmitResponse | null;
+  testResults: TestCaseResultView[] | null;
+}
+
+export interface TestCaseResultView {
+  index: number;
+  passed: boolean;
+  testName: string;
+  input: string;
+  expected: string;
+  actual: string;
+  error?: string;
+  stderr?: string;
+  hidden: boolean;
 }
 
 export interface SubmitResult {

--- a/frontend/src/features/question/use-code-runner.hook.ts
+++ b/frontend/src/features/question/use-code-runner.hook.ts
@@ -3,6 +3,7 @@
 import { useCallback } from "react";
 import { Question, Language } from "@/types";
 import { useCodeExecution } from "@/features/code-execution/code-execution.hook";
+import { TestCaseResultView } from "@/features/code-execution/code-execution.types";
 import { useLocalStorage } from "@/hooks";
 import { showToast } from "@/components/ui/Toast";
 import { useAuth } from "@/providers";
@@ -24,6 +25,7 @@ interface UseCodeRunnerReturn {
   handleSubmitCode: () => Promise<void>;
   isRunning: boolean;
   output: string;
+  testResults: TestCaseResultView[] | null;
   executionError: string | null;
   clearOutput: () => void;
   clearExecutionError: () => void;
@@ -39,6 +41,7 @@ export function useCodeRunner({
     isRunning,
     output,
     error: executionError,
+    testResults,
     validateCode,
     submitCode,
     runLocalJavaScript,
@@ -141,6 +144,7 @@ export function useCodeRunner({
     handleSubmitCode,
     isRunning,
     output,
+    testResults,
     executionError,
     clearOutput,
     clearExecutionError,


### PR DESCRIPTION
Closes #98

## Problem
Test case results were rendered as plain monospace text blobs (built in `code-execution.hook.ts` `validateCode`/`submitCode` and the lesson page) inside a generic `<pre>`. Whitespace-only differences were impossible to inspect (e.g. Expected `"123  "` vs Actual `123`).

## Fix
- New reusable `frontend/src/components/results/TestCaseResults.tsx`:
  - Summary banner with pass/fail count + state colour
  - One card per test case: status icon, description, input, expected, actual
  - Values rendered in `whitespace-pre-wrap` mono cells so trailing/leading spaces are visible
  - Distinct styles for passed / failed / execution-error (amber) cases
  - Hidden cases render a label without leaking input/expected/actual
- The code-execution hook exposes a normalized `testResults` view (built by `validateCode`/`submitCode`, cleared on run/clear); practice workspace and lesson exercises both reuse `TestCaseResults` via `CodeEditorContainer`, removing duplicated text formatting.

## Tests
- 7 `TestCaseResults` tests: summary, all-pass, value cells, error card, hidden redaction, whitespace preservation, custom title
- 2 `CodeEditorContainer` tests for structured-result rendering and error precedence
- Full suite: 505 frontend tests pass, `tsc` clean, lint clean

## Verification
- Frontend Docker image rebuilt: `docker compose up -d --build frontend`
- Caveman-reviewed staged diff before commit