### PR TITLE
feat(coaching): render AI-generated algorithm animation scripts

### DIFF
--- a/backend/app/adapters/coaching_prompts.py
+++ b/backend/app/adapters/coaching_prompts.py
@@ -45,11 +45,44 @@ You MUST respond with ONLY a valid JSON object. No text before or after.
     "suggestions": ["suggestion 1"],
     "edge_cases": ["edge case 1"],
     "explanation": "Bite-sized foundational idea followed by a question or null",
-    "debug_help": "Point to the problem area and ask what state they expect or null"
+    "debug_help": "Point to the problem area and ask what state they expect or null",
+    "animation": "Optional declarative animation script (see contract below) or null"
 }
 
+## Animation Contract
+When the problem involves an algorithm over an array and the code is present, generate an "animation" object so the student can watch the algorithm run. Otherwise set "animation": null.
+
+Animation shape:
+{
+    "type": "linear_search",
+    "title": "Searching for 4",
+    "data": {
+        "values": [5, 1, 2, 3, 4, 5],
+        "target": 4
+    },
+    "steps": [
+        {
+            "operation": "compare",
+            "index": 0,
+            "value": 5,
+            "result": "mismatch",
+            "narration": "5 is not the target, continue searching."
+        }
+    ]
+}
+
+Animation rules:
+1. ONLY support "linear_search" for now — the student's code must implement linear search (scanning the array element by element comparing to a target).
+2. "values" MUST come from the problem statement or the student's own test data — never invent runtime results. If no concrete array exists, set "animation": null.
+3. Use the real values from the array; the target is the value being searched for.
+4. Emit exactly one step per comparison: operation "compare", the current index, the value at that index, result "mismatch" until the match, then "match".
+5. A "match" step MUST have result "match" and its value must equal the target. A "mismatch" step MUST NOT equal the target.
+6. Never emit indexes outside the array bounds. Keep the array small (<= 50 values) and the trace short (<= 200 steps).
+7. Write a short human narration for every step (under 300 characters).
+8. This is DATA, not code — never return JavaScript, JSX, or CSS. No executable instructions.
+
 ## Rules
-1. ALL 8 fields must be present in every response
+1. ALL 9 fields must be present in every response
 2. Use null for fields not applicable, [] for empty arrays
 3. Keep summary under 200 characters
 4. Use simple, conversational language

--- a/backend/app/adapters/code_wrappers/java_wrapper.py
+++ b/backend/app/adapters/code_wrappers/java_wrapper.py
@@ -333,9 +333,7 @@ class JavaCodeWrapper(CodeWrapper):
             "    }\n"
             "\n"
             "    static Object _lastFirstArg = null;\n"
-            "\n"
-            + JAVA_OUTPUT_MATCH.strip("\n")
-            + "\n"
+            "\n" + JAVA_OUTPUT_MATCH.strip("\n") + "\n"
             "\n"
             "    static Object callSolution(String methodName, Object... args) throws Exception {\n"
             "        Class<?> clazz = Solution.class;\n"

--- a/backend/app/adapters/code_wrappers/output_comparator.py
+++ b/backend/app/adapters/code_wrappers/output_comparator.py
@@ -47,7 +47,7 @@ def outputs_match(actual: Optional[str], expected: Optional[str]) -> bool:
     return actual == expected
 
 
-PYTHON_OUTPUT_MATCH = r'''
+PYTHON_OUTPUT_MATCH = r"""
 def __outputs_match(__actual, __expected):
     if __actual.endswith("\n"):
         __actual = __actual[:-1]
@@ -66,10 +66,10 @@ def __outputs_match(__actual, __expected):
     if isinstance(__decoded_actual, str):
         return __actual == __expected or __decoded_actual == __expected
     return __actual == __expected
-'''
+"""
 
 
-JS_OUTPUT_MATCH = r'''
+JS_OUTPUT_MATCH = r"""
 function outputsMatch(actual, expected) {
   if (actual.endsWith('\n')) { actual = actual.slice(0, -1); }
   let decodedExpected = null;
@@ -84,10 +84,10 @@ function outputsMatch(actual, expected) {
   if (typeof decodedActual === 'string') { return actual === expected || decodedActual === expected; }
   return actual === expected;
 }
-'''
+"""
 
 
-JAVA_OUTPUT_MATCH = r'''
+JAVA_OUTPUT_MATCH = r"""
     static boolean outputsMatch(String actual, String expected) {
         if (actual.endsWith("\n")) { actual = actual.substring(0, actual.length() - 1); }
         return decode(actual).equals(decode(expected));
@@ -103,4 +103,4 @@ JAVA_OUTPUT_MATCH = r'''
         }
         return s;
     }
-'''
+"""

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1,6 +1,6 @@
 import json
 from pydantic import BaseModel, Field, field_validator, model_validator
-from typing import List, Dict, Any, Optional, Union
+from typing import List, Dict, Any, Optional, Union, Literal
 from enum import Enum
 
 
@@ -67,6 +67,52 @@ class CoachingRequest(BaseModel):
     )
 
 
+class AnimationStep(BaseModel):
+    """One frame of a declarative animation script.
+
+    The AI supplies structured data only — never executable code. The
+    frontend owns rendering, motion, and playback for every step.
+    """
+
+    operation: Literal[
+        "compare",
+        "visit",
+        "swap",
+        "move",
+        "insert",
+        "remove",
+        "mark",
+        "output",
+    ] = Field(..., description="What the frame does to the visualized data")
+    index: Optional[int] = Field(None, description="Primary index being acted on")
+    from_index: Optional[int] = Field(None, description="Source index (swap/move)")
+    to_index: Optional[int] = Field(None, description="Destination index (swap/move)")
+    value: Optional[Any] = Field(None, description="Value involved in the frame")
+    result: Optional[Literal["checking", "match", "mismatch", "complete"]] = Field(
+        None, description="Outcome of the operation for coloring purposes"
+    )
+    narration: str = Field(
+        default="",
+        max_length=300,
+        description="Human-readable narration for this frame",
+    )
+
+
+class AnimationScript(BaseModel):
+    """Declarative, validated animation script returned by the AI coach."""
+
+    type: str = Field(
+        ..., description="Algorithm kind, e.g. linear_search, bubble_sort"
+    )
+    title: str = Field(default="", description="Short title shown above the animation")
+    data: Dict[str, Any] = Field(
+        default_factory=dict, description="Input data the animation visualizes"
+    )
+    steps: List[AnimationStep] = Field(
+        default_factory=list, description="Ordered frames of the animation"
+    )
+
+
 class StructuredCoachingResponse(BaseModel):
     """Structured AI coaching response with categorized sections."""
 
@@ -88,6 +134,9 @@ class StructuredCoachingResponse(BaseModel):
         None, description="Detailed explanation of concepts"
     )
     debug_help: Optional[str] = Field(None, description="Debugging assistance")
+    animation: Optional[AnimationScript] = Field(
+        None, description="Declarative animation script to visualize the algorithm"
+    )
 
 
 class CoachingResponse(BaseModel):

--- a/backend/app/services/animation_validator.py
+++ b/backend/app/services/animation_validator.py
@@ -1,0 +1,148 @@
+"""AnimationValidator — semantic gate for AI-generated animation scripts.
+
+Structural conformance is handled by the AnimationScript Pydantic model.
+This service verifies that a structurally valid script is also logically
+correct: indexes stay in bounds, a "match" frame really matches the target,
+and a "mismatch" frame really does not. Invalid scripts are dropped so the
+rest of the coaching response still renders — never partially trusted.
+"""
+
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_TYPES = frozenset({"linear_search"})
+
+MAX_VALUES = 50
+MAX_STEPS = 200
+MAX_NARRATION = 300
+
+_INDEX_OPS = frozenset({"compare", "visit", "mark", "swap", "move"})
+_RESULT_OPS = frozenset({"compare", "mark", "visit"})
+
+
+class AnimationValidator:
+    """Validate the semantic correctness of an animation script dict."""
+
+    def validate(self, script: Dict[str, Any]) -> Tuple[Optional[Dict[str, Any]], str]:
+        """Return (validated_script, "") on success or (None, reason) on failure."""
+        if not isinstance(script, dict):
+            return None, "Animation is not an object"
+
+        kind = script.get("type")
+        if kind not in SUPPORTED_TYPES:
+            return None, f"Unsupported animation type: {kind!r}"
+
+        data = script.get("data")
+        if not isinstance(data, dict):
+            return None, "Animation data must be an object"
+        values = data.get("values")
+        if not isinstance(values, list) or not values:
+            return None, "Animation data must contain a non-empty values list"
+        if len(values) > MAX_VALUES:
+            return None, f"Too many values ({len(values)} > {MAX_VALUES})"
+
+        steps = script.get("steps")
+        if not isinstance(steps, list) or not steps:
+            return None, "Animation must contain a non-empty steps list"
+        if len(steps) > MAX_STEPS:
+            return None, f"Too many steps ({len(steps)} > {MAX_STEPS})"
+
+        validator = _TYPE_VALIDATORS.get(kind)
+        for i, step in enumerate(steps):
+            if not isinstance(step, dict):
+                return None, f"Step {i} is not an object"
+            ok, reason = self._validate_step(step, values, data, i)
+            if not ok:
+                return None, reason
+            if validator:
+                ok, reason = validator(step, values, data, i)
+                if not ok:
+                    return None, reason
+
+        return script, ""
+
+    # ── internal ──────────────────────────────────────────────────────
+
+    def _validate_step(
+        self,
+        step: Dict[str, Any],
+        values: list,
+        data: Dict[str, Any],
+        index: int,
+    ) -> Tuple[bool, str]:
+        op = step.get("operation")
+        if not isinstance(op, str):
+            return False, f"Step {index} is missing an operation"
+
+        narration = step.get("narration")
+        if not isinstance(narration, str) or not narration.strip():
+            return False, f"Step {index} is missing narration"
+        if len(narration) > MAX_NARRATION:
+            return False, f"Step {index} narration exceeds {MAX_NARRATION} chars"
+
+        bounds_ok, reason = self._check_bounds(step, len(values), f"Step {index}")
+        if not bounds_ok:
+            return False, reason
+
+        if op in _RESULT_OPS:
+            result = step.get("result")
+            if op == "compare" and result not in (
+                None,
+                "checking",
+                "match",
+                "mismatch",
+            ):
+                return False, f"Step {index} has invalid compare result {result!r}"
+
+        return True, ""
+
+    @staticmethod
+    def _check_bounds(
+        step: Dict[str, Any], length: int, label: str
+    ) -> Tuple[bool, str]:
+        for field in ("index", "from_index", "to_index"):
+            value = step.get(field)
+            if value is None:
+                continue
+            if not isinstance(value, int) or value < 0 or value >= length:
+                return False, f"{label} has out-of-bounds {field}: {value!r}"
+        return True, ""
+
+    @staticmethod
+    def _validate_linear_search(
+        step: Dict[str, Any],
+        values: list,
+        data: Dict[str, Any],
+        index: int,
+    ) -> Tuple[bool, str]:
+        target = data.get("target")
+        if step.get("operation") != "compare" or step.get("result") not in (
+            "match",
+            "mismatch",
+        ):
+            return True, ""
+
+        value_index = step.get("index")
+        if value_index is None:
+            return False, f"Step {index} is missing an index for a compare result"
+        value = values[value_index]
+        if step["result"] == "match" and value != target:
+            return False, (
+                f"Step {index} claims a match but values[{step['index']}] "
+                f"({value!r}) does not equal target ({target!r})"
+            )
+        if step["result"] == "mismatch" and value == target:
+            return False, (
+                f"Step {index} claims a mismatch but values[{step['index']}] "
+                f"({value!r}) equals target ({target!r})"
+            )
+        return True, ""
+
+
+_TYPE_VALIDATORS = {
+    "linear_search": AnimationValidator._validate_linear_search,
+}
+
+animation_validator = AnimationValidator()

--- a/backend/app/services/groq_service.py
+++ b/backend/app/services/groq_service.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from app.adapters.coaching_prompts import PromptBuilder
 from app.adapters.coaching_response_parser import CoachingResponseParser
 from app.ports.coaching_provider import CoachingProvider
+from app.services.animation_validator import AnimationValidator
 from app.services.redis_service import RedisCache, _content_hash
 
 logger = logging.getLogger(__name__)
@@ -54,6 +55,7 @@ class GroqService(CoachingProvider):
 
         self.parser = CoachingResponseParser()
         self.prompts = PromptBuilder()
+        self.animation_validator = AnimationValidator()
 
     async def get_structured_coaching_response(
         self,
@@ -123,6 +125,7 @@ class GroqService(CoachingProvider):
                 result = response.json()
                 content = result["choices"][0]["message"]["content"]
                 structured_data = self.parser.parse_structured(content)
+                structured_data = self._validate_animation(structured_data)
                 try:
                     StructuredCoachingResponse(**structured_data)
                 except ValidationError as e:
@@ -281,6 +284,30 @@ class GroqService(CoachingProvider):
     # ── helpers ───────────────────────────────────────────────────────
 
     @staticmethod
+    def _validate_animation(data: Dict[str, Any]) -> Dict[str, Any]:
+        """Drop invalid animation scripts, keep the rest of the response.
+
+        A structurally valid but semantically incorrect script is also
+        dropped — the animation must never lie about the algorithm. The
+        coaching text still renders, so the student experience degrades
+        gracefully instead of showing a wrong animation.
+        """
+        if not data.get("animation"):
+            return data
+        try:
+            validated, reason = AnimationValidator().validate(data["animation"])
+        except Exception as e:  # defensive: a bad script must never 500 the endpoint
+            logger.warning("Animation validation raised: %s", e)
+            data.pop("animation", None)
+            return data
+        if validated is None:
+            logger.warning("Dropping invalid animation script: %s", reason)
+            data.pop("animation", None)
+        else:
+            data["animation"] = validated
+        return data
+
+    @staticmethod
     def _repair_structured(data: Dict[str, Any]) -> Dict[str, Any]:
         """Repair a schema-mismatched structured dict into a valid shape.
 
@@ -326,6 +353,7 @@ class GroqService(CoachingProvider):
                 if isinstance(data.get("debug_help"), str)
                 else None
             ),
+            "animation": None,
         }
 
     def _raise_for_groq_status(

--- a/backend/tests/unit/test_animation_validator.py
+++ b/backend/tests/unit/test_animation_validator.py
@@ -1,0 +1,250 @@
+"""Unit tests for AnimationValidator — the semantic gate on AI animation scripts.
+
+Covers: valid linear search acceptance, index bounds, match/mismatch truthfulness,
+unsupported types, missing data, empty/oversized traces, and narration hygiene.
+"""
+
+from app.services.animation_validator import (
+    AnimationValidator,
+    MAX_STEPS,
+    MAX_VALUES,
+    animation_validator,
+)
+
+
+def _linear_search(values, target, steps):
+    return {
+        "type": "linear_search",
+        "title": "Searching",
+        "data": {"values": values, "target": target},
+        "steps": steps,
+    }
+
+
+def _compare(index, result, narration="checking"):
+    return {
+        "operation": "compare",
+        "index": index,
+        "result": result,
+        "narration": narration,
+    }
+
+
+class TestValidScripts:
+    def test_valid_linear_search(self):
+        script = _linear_search(
+            [5, 1, 2, 3, 4, 5],
+            4,
+            [_compare(0, "mismatch"), _compare(1, "mismatch"), _compare(4, "match")],
+        )
+        validated, reason = animation_validator.validate(script)
+        assert validated is not None
+        assert reason == ""
+
+    def test_target_at_first_index(self):
+        script = _linear_search([5, 1], 5, [_compare(0, "match")])
+        validated, _ = animation_validator.validate(script)
+        assert validated is not None
+
+    def test_duplicate_target_values(self):
+        script = _linear_search(
+            [5, 1, 5, 3],
+            5,
+            [_compare(0, "match")],
+        )
+        validated, _ = animation_validator.validate(script)
+        assert validated is not None
+
+    def test_compare_without_result_allowed(self):
+        script = _linear_search([1, 2], 2, [_compare(0, None)])
+        validated, _ = animation_validator.validate(script)
+        assert validated is not None
+
+    def test_visit_and_mark_operations_allowed(self):
+        script = _linear_search(
+            [1, 2, 3],
+            3,
+            [
+                {"operation": "visit", "index": 0, "narration": "visiting"},
+                {
+                    "operation": "mark",
+                    "index": 2,
+                    "result": "match",
+                    "narration": "mark",
+                },
+            ],
+        )
+        validated, _ = animation_validator.validate(script)
+        assert validated is not None
+
+
+class TestRejections:
+    def test_unsupported_type(self):
+        script = {
+            "type": "bubble_sort",
+            "data": {"values": [3, 2, 1]},
+            "steps": [_compare(0, "mismatch")],
+        }
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "Unsupported animation type" in reason
+
+    def test_not_an_object(self):
+        validated, reason = animation_validator.validate("linear_search")
+        assert validated is None
+        assert "not an object" in reason
+
+    def test_missing_values(self):
+        script = _linear_search([], 4, [])
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "non-empty values" in reason
+
+    def test_too_many_values(self):
+        script = _linear_search(
+            list(range(MAX_VALUES + 1)), 1, [_compare(0, "mismatch")]
+        )
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "Too many values" in reason
+
+    def test_empty_steps(self):
+        script = _linear_search([1, 2, 3], 2, [])
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "non-empty steps" in reason
+
+    def test_too_many_steps(self):
+        steps = [_compare(0, "mismatch")] * (MAX_STEPS + 1)
+        script = _linear_search([1], 1, steps)
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "Too many steps" in reason
+
+    def test_out_of_bounds_index(self):
+        script = _linear_search([1, 2, 3], 3, [_compare(9, "mismatch")])
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "out-of-bounds" in reason
+
+    def test_negative_index(self):
+        script = _linear_search([1, 2, 3], 3, [_compare(-1, "mismatch")])
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "out-of-bounds" in reason
+
+    def test_match_step_must_equal_target(self):
+        script = _linear_search([5, 1, 2, 3, 4, 5], 4, [_compare(0, "match")])
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "does not equal target" in reason
+
+    def test_mismatch_step_must_not_equal_target(self):
+        script = _linear_search([5, 1, 2, 3, 4, 5], 5, [_compare(0, "mismatch")])
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "equals target" in reason
+
+    def test_missing_narration(self):
+        script = _linear_search([1, 2], 2, [{"operation": "compare", "index": 0}])
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "missing narration" in reason
+
+    def test_narration_too_long(self):
+        script = _linear_search(
+            [1, 2], 2, [_compare(0, "mismatch", narration="x" * 301)]
+        )
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "exceeds 300 chars" in reason
+
+    def test_step_not_an_object(self):
+        script = _linear_search([1, 2], 2, ["not-a-step"])
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "not an object" in reason
+
+    def test_invalid_compare_result(self):
+        script = _linear_search(
+            [1, 2],
+            2,
+            [
+                {
+                    "operation": "compare",
+                    "index": 0,
+                    "result": "banana",
+                    "narration": "x",
+                }
+            ],
+        )
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "invalid compare result" in reason
+
+    def test_compare_result_without_index_is_rejected_not_crash(self):
+        script = _linear_search(
+            [1, 2],
+            2,
+            [{"operation": "compare", "result": "match", "narration": "x"}],
+        )
+        validated, reason = animation_validator.validate(script)
+        assert validated is None
+        assert "missing an index" in reason
+
+    def test_compare_result_without_index_does_not_raise_in_groq(self):
+        from app.services.groq_service import GroqService
+
+        data = {
+            "summary": "Keep coaching",
+            "hints": [],
+            "animation": _linear_search(
+                [1, 2],
+                2,
+                [{"operation": "compare", "result": "match", "narration": "x"}],
+            ),
+        }
+        result = GroqService._validate_animation(data)
+        assert "animation" not in result
+        assert result["summary"] == "Keep coaching"
+
+
+class TestGroqIntegration:
+    def test_invalid_animation_is_dropped(self):
+        from app.services.groq_service import GroqService
+
+        data = {
+            "summary": "Keep coaching",
+            "hints": [],
+            "animation": {
+                "type": "linear_search",
+                "data": {"values": [5], "target": 4},
+                "steps": [_compare(0, "match")],
+            },
+        }
+        result = GroqService._validate_animation(data)
+        assert "animation" not in result
+        assert result["summary"] == "Keep coaching"
+
+    def test_valid_animation_is_kept(self):
+        from app.services.groq_service import GroqService
+
+        data = {
+            "summary": "Keep coaching",
+            "hints": [],
+            "animation": _linear_search([4, 1], 4, [_compare(0, "match")]),
+        }
+        result = GroqService._validate_animation(data)
+        assert result["animation"]["type"] == "linear_search"
+
+    def test_animation_absent_is_untouched(self):
+        from app.services.groq_service import GroqService
+
+        data = {"summary": "plain", "hints": []}
+        result = GroqService._validate_animation(data)
+        assert result == data
+
+
+class TestValidatorInstance:
+    def test_module_level_singleton(self):
+        assert isinstance(animation_validator, AnimationValidator)

--- a/backend/tests/unit/test_animation_validator.py
+++ b/backend/tests/unit/test_animation_validator.py
@@ -244,6 +244,24 @@ class TestGroqIntegration:
         result = GroqService._validate_animation(data)
         assert result == data
 
+    def test_validator_raising_is_swallowed(self):
+        from unittest.mock import patch
+
+        from app.services.groq_service import GroqService
+
+        data = {
+            "summary": "Keep coaching",
+            "hints": [],
+            "animation": _linear_search([4, 1], 4, [_compare(0, "match")]),
+        }
+        with patch(
+            "app.services.animation_validator.AnimationValidator.validate",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = GroqService._validate_animation(data)
+        assert "animation" not in result
+        assert result["summary"] == "Keep coaching"
+
 
 class TestValidatorInstance:
     def test_module_level_singleton(self):

--- a/backend/tests/unit/test_coaching_prompts.py
+++ b/backend/tests/unit/test_coaching_prompts.py
@@ -112,6 +112,24 @@ class TestBuildStructuredSystemPrompt:
         prompt = build_structured_system_prompt("hint", "python")
         assert "end summary with a question" in prompt
 
+    def test_animation_contract_present(self):
+        prompt = build_structured_system_prompt("hint", "python")
+        assert "Animation Contract" in prompt
+        assert "linear_search" in prompt
+        assert "never return JavaScript" in prompt
+
+    def test_animation_never_invents_runtime_results(self):
+        prompt = build_structured_system_prompt("explain", "python")
+        assert "never invent runtime results" in prompt
+
+    def test_all_nine_fields_rule(self):
+        prompt = build_structured_system_prompt("hint", "python")
+        assert "ALL 9 fields" in prompt
+
+    def test_unstructured_prompt_omits_animation_contract(self):
+        prompt = build_system_prompt("hint", "python")
+        assert "Animation Contract" not in prompt
+
     def test_structured_frustration_escalation_strategy(self):
         prompt = build_structured_system_prompt("hint", "python")
         assert "frustration" in prompt

--- a/backend/tests/unit/test_piston_service.py
+++ b/backend/tests/unit/test_piston_service.py
@@ -211,6 +211,66 @@ class TestPistonServiceExecute:
             assert result.stdout == ""
 
     @pytest.mark.asyncio
+    async def test_execute_uses_cached_result(self):
+        cached = {
+            "stdout": "cached\n",
+            "stderr": "",
+            "exit_code": 0,
+            "signal": None,
+            "execution_time": 0.0,
+            "memory_usage": None,
+            "language": "python",
+            "version": "3.10.0",
+        }
+
+        class FakeCache:
+            async def get(self, key):
+                return cached
+
+            async def set(self, key, value, ttl=300):
+                pass
+
+        service = PistonService(cache=FakeCache())
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_client.return_value = mock_instance
+
+            result = await service.execute("python", "print('never runs')")
+            mock_client.assert_not_called()
+            assert result.stdout == "cached\n"
+
+    @pytest.mark.asyncio
+    async def test_execute_caches_result_when_cache_enabled(self):
+        store: dict = {}
+
+        class FakeCache:
+            async def get(self, key):
+                return store.get(key)
+
+            async def set(self, key, value, ttl=300):
+                store[key] = value
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_client.return_value = mock_instance
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "run": {"stdout": "hi\n", "stderr": "", "code": 0},
+                "language": "python",
+                "version": "3.10.0",
+            }
+            mock_instance.post.return_value = mock_response
+
+            service = PistonService(cache=FakeCache())
+            result = await service.execute("python", "print('hi')")
+
+            assert result.stdout == "hi\n"
+            assert len(store) == 1
+
+    @pytest.mark.asyncio
     async def test_execute_piston_connection_error(self):
         with patch("httpx.AsyncClient") as mock_client:
             mock_instance = AsyncMock()
@@ -272,6 +332,27 @@ class TestPistonServiceRuntimes:
 
             assert len(runtimes) == 1
             assert runtimes[0]["language"] == "python"
+
+    @pytest.mark.asyncio
+    async def test_get_runtimes_uses_cached(self):
+        cached = [{"language": "python", "version": "3.10.0"}]
+
+        class FakeCache:
+            async def get(self, key):
+                return cached
+
+            async def set(self, key, value, ttl=300):
+                pass
+
+        service = PistonService(cache=FakeCache())
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_client.return_value = mock_instance
+
+            runtimes = await service.get_runtimes()
+            mock_client.assert_not_called()
+            assert runtimes == cached
 
     @pytest.mark.asyncio
     async def test_get_runtimes_non_200(self):

--- a/backend/tests/unit/test_suite_runners.py
+++ b/backend/tests/unit/test_suite_runners.py
@@ -859,4 +859,3 @@ class TestEmbeddedOutputComparators:
         assert "outputsMatch(actual, expected)" in runner
         assert "static boolean outputsMatch" in runner
         assert "actual.trim().equals(expected.trim())" not in runner
-

--- a/frontend/src/components/chat/StructuredResponse.test.tsx
+++ b/frontend/src/components/chat/StructuredResponse.test.tsx
@@ -145,4 +145,42 @@ describe("StructuredResponse", () => {
     expect(screen.getByText("First bullet")).toBeInTheDocument();
     expect(screen.getByText("Second bullet")).toBeInTheDocument();
   });
+
+  it("renders an animation script when present", () => {
+    const withAnimation: StructuredCoachingResponse = {
+      ...validStructured,
+      animation: {
+        type: "linear_search",
+        title: "Searching for 4",
+        data: { values: [5, 1, 2, 3, 4, 5], target: 4 },
+        steps: [
+          {
+            operation: "compare",
+            index: 0,
+            result: "mismatch",
+            narration: "5 is not the target.",
+          },
+          {
+            operation: "compare",
+            index: 4,
+            result: "match",
+            narration: "Found the target.",
+          },
+        ],
+      },
+    };
+    render(<StructuredResponse structured={withAnimation} />);
+    expect(screen.getByText("Searching for 4")).toBeInTheDocument();
+    expect(screen.getByText("Target")).toBeInTheDocument();
+    expect(screen.getByText("5 is not the target.")).toBeInTheDocument();
+  });
+
+  it("does not render an animation section when null", () => {
+    render(
+      <StructuredResponse
+        structured={{ ...validStructured, animation: null }}
+      />,
+    );
+    expect(screen.queryByText("Searching for 4")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/chat/StructuredResponse.tsx
+++ b/frontend/src/components/chat/StructuredResponse.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AnimationScriptRenderer } from "@/components/visualization";
 import { StructuredCoachingResponse } from "@/types";
 
 interface StructuredResponseProps {
@@ -161,6 +162,7 @@ export function StructuredResponse({
     edge_cases,
     explanation,
     debug_help,
+    animation,
   } = structured;
 
   // Build response sections
@@ -169,6 +171,11 @@ export function StructuredResponse({
   // Summary
   if (summary) {
     sections.push(<FormattedText key="summary" text={summary} />);
+  }
+
+  // Animation
+  if (animation) {
+    sections.push(<AnimationScriptRenderer key="animation" script={animation} />);
   }
 
   // Hints

--- a/frontend/src/components/visualization/AnimationPlayer.tsx
+++ b/frontend/src/components/visualization/AnimationPlayer.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { Pause, Play, RotateCcw, SkipBack, SkipForward } from "lucide-react";
+import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { AnimationStep } from "@/types";
+import { cn } from "@/lib/utils";
+
+const SPEEDS = [
+  { label: "Slow", ms: 1400 },
+  { label: "Normal", ms: 800 },
+  { label: "Fast", ms: 350 },
+];
+
+interface AnimationPlayerProps {
+  steps: AnimationStep[];
+  children: (step: AnimationStep, index: number) => ReactNode;
+  autoPauseOnMatch?: boolean;
+}
+
+export function AnimationPlayer({
+  steps,
+  children,
+  autoPauseOnMatch = true,
+}: AnimationPlayerProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [speedMs, setSpeedMs] = useState(800);
+  const currentRef = useRef(currentIndex);
+  currentRef.current = currentIndex;
+
+  const stepCount = steps.length;
+  const currentStep = steps[currentIndex] as AnimationStep | undefined;
+
+  useEffect(() => {
+    if (!isPlaying) return;
+    const timer = setInterval(() => {
+      const next = currentRef.current + 1;
+      if (next >= stepCount) {
+        setIsPlaying(false);
+        return;
+      }
+      setCurrentIndex(next);
+      if (autoPauseOnMatch && steps[next]?.result === "match") {
+        setIsPlaying(false);
+      }
+    }, speedMs);
+    return () => clearInterval(timer);
+  }, [isPlaying, speedMs, stepCount, steps, autoPauseOnMatch]);
+
+  const togglePlay = useCallback(() => {
+    if (!isPlaying && currentIndex >= stepCount - 1) {
+      setCurrentIndex(0);
+    }
+    setIsPlaying((prev) => !prev);
+  }, [isPlaying, currentIndex, stepCount]);
+
+  const stepTo = useCallback((target: number) => {
+    setCurrentIndex(Math.max(0, Math.min(target, stepCount - 1)));
+    setIsPlaying(false);
+  }, [stepCount]);
+
+  const restart = useCallback(() => {
+    setCurrentIndex(0);
+    setIsPlaying(false);
+  }, []);
+
+  const progress = stepCount > 1 ? currentIndex / (stepCount - 1) : 1;
+
+  return (
+    <div className="space-y-3">
+      <div>{currentStep ? children(currentStep, currentIndex) : null}</div>
+
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={restart}
+          aria-label="Restart animation"
+          title="Restart"
+          className="flex h-8 w-8 items-center justify-center rounded-full border border-white/[0.06] text-foreground/50 hover:bg-white/[0.04] hover:text-foreground/80 transition-all"
+        >
+          <RotateCcw width={13} height={13} />
+        </button>
+        <button
+          type="button"
+          onClick={() => stepTo(currentIndex - 1)}
+          disabled={currentIndex === 0}
+          aria-label="Previous step"
+          title="Previous step"
+          className="flex h-8 w-8 items-center justify-center rounded-full border border-white/[0.06] text-foreground/50 hover:bg-white/[0.04] hover:text-foreground/80 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          <SkipBack width={13} height={13} />
+        </button>
+        <button
+          type="button"
+          onClick={togglePlay}
+          aria-label={isPlaying ? "Pause animation" : "Play animation"}
+          title={isPlaying ? "Pause" : "Play"}
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/15 text-primary hover:bg-primary/25 transition-all"
+        >
+          {isPlaying ? (
+            <Pause width={14} height={14} fill="currentColor" />
+          ) : (
+            <Play width={14} height={14} fill="currentColor" className="ml-0.5" />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => stepTo(currentIndex + 1)}
+          disabled={currentIndex >= stepCount - 1}
+          aria-label="Next step"
+          title="Next step"
+          className="flex h-8 w-8 items-center justify-center rounded-full border border-white/[0.06] text-foreground/50 hover:bg-white/[0.04] hover:text-foreground/80 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          <SkipForward width={13} height={13} />
+        </button>
+
+        <div className="flex-1 flex items-center gap-2 mx-2">
+          <div className="relative h-1 flex-1 rounded-full bg-white/[0.06] overflow-hidden">
+            <div
+              className="absolute inset-y-0 left-0 rounded-full bg-primary/60 transition-[width] duration-300"
+              style={{ width: `${progress * 100}%` }}
+            />
+          </div>
+          <span className="text-[10px] tabular-nums text-muted-foreground/50 whitespace-nowrap">
+            {currentIndex + 1} / {stepCount}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-1">
+          {SPEEDS.map((speed) => (
+            <button
+              key={speed.label}
+              type="button"
+              onClick={() => setSpeedMs(speed.ms)}
+              aria-label={`Speed ${speed.label.toLowerCase()}`}
+              className={cn(
+                "px-2 py-1 rounded-full text-[10px] uppercase tracking-wider transition-all",
+                speedMs === speed.ms
+                  ? "bg-white/[0.08] text-foreground/80"
+                  : "text-muted-foreground/40 hover:text-foreground/60",
+              )}
+            >
+              {speed.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/visualization/AnimationScriptRenderer.test.tsx
+++ b/frontend/src/components/visualization/AnimationScriptRenderer.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { AnimationScriptRenderer } from "./AnimationScriptRenderer";
+import { AnimationPlayer } from "./AnimationPlayer";
+import { AnimationScript } from "@/types";
+
+const linearScript: AnimationScript = {
+  type: "linear_search",
+  title: "Searching for 4",
+  data: { values: [5, 1, 2, 3, 4, 5], target: 4 },
+  steps: [
+    {
+      operation: "compare",
+      index: 0,
+      result: "mismatch",
+      narration: "5 is not the target.",
+    },
+    {
+      operation: "compare",
+      index: 1,
+      result: "mismatch",
+      narration: "1 is not the target.",
+    },
+    {
+      operation: "compare",
+      index: 4,
+      result: "match",
+      narration: "Found the target at index 4.",
+    },
+  ],
+};
+
+describe("AnimationScriptRenderer", () => {
+  it("renders the animation title and target badge", () => {
+    render(<AnimationScriptRenderer script={linearScript} />);
+    expect(screen.getByText("Searching for 4")).toBeInTheDocument();
+    expect(screen.getByText("Target")).toBeInTheDocument();
+    expect(screen.getAllByText("4").length).toBeGreaterThan(0);
+  });
+
+  it("renders the array values as cells", () => {
+    render(<AnimationScriptRenderer script={linearScript} />);
+    for (const value of ["5", "1", "2", "3"]) {
+      expect(screen.getAllByText(value).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("shows the narration of the first step initially", () => {
+    render(<AnimationScriptRenderer script={linearScript} />);
+    expect(screen.getByText("5 is not the target.")).toBeInTheDocument();
+  });
+
+  it("advances the narration when clicking next", () => {
+    render(<AnimationScriptRenderer script={linearScript} />);
+    fireEvent.click(screen.getByRole("button", { name: "Next step" }));
+    expect(screen.getByText("1 is not the target.")).toBeInTheDocument();
+    expect(screen.getByText(/2 \/ 3/)).toBeInTheDocument();
+  });
+
+  it("reaches the match narration on the last step", () => {
+    render(<AnimationScriptRenderer script={linearScript} />);
+    const next = screen.getByRole("button", { name: "Next step" });
+    fireEvent.click(next);
+    fireEvent.click(next);
+    expect(screen.getByText("Found the target at index 4.")).toBeInTheDocument();
+  });
+
+  it("stops advancing at the final step", () => {
+    render(<AnimationScriptRenderer script={linearScript} />);
+    const next = screen.getByRole("button", { name: "Next step" });
+    fireEvent.click(next);
+    fireEvent.click(next);
+    fireEvent.click(next);
+    expect(screen.getByText(/3 \/ 3/)).toBeInTheDocument();
+  });
+
+  it("restart resets to the first step", () => {
+    render(<AnimationScriptRenderer script={linearScript} />);
+    const next = screen.getByRole("button", { name: "Next step" });
+    fireEvent.click(next);
+    fireEvent.click(next);
+    fireEvent.click(screen.getByRole("button", { name: "Restart animation" }));
+    expect(screen.getByText("5 is not the target.")).toBeInTheDocument();
+    expect(screen.getByText(/1 \/ 3/)).toBeInTheDocument();
+  });
+
+  it("toggles play state", () => {
+    render(<AnimationScriptRenderer script={linearScript} />);
+    const play = screen.getByRole("button", { name: "Play animation" });
+    fireEvent.click(play);
+    expect(
+      screen.getByRole("button", { name: "Pause animation" }),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Pause animation" }));
+    expect(
+      screen.getByRole("button", { name: "Play animation" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a plain trace for unsupported animation types", () => {
+    const unknown: AnimationScript = {
+      type: "quantum_sort",
+      title: "Quantum",
+      data: { values: [1, 2] },
+      steps: [{ operation: "compare", index: 0, narration: "Narration one." }],
+    };
+    render(<AnimationScriptRenderer script={unknown} />);
+    expect(screen.getByText("Quantum")).toBeInTheDocument();
+    expect(screen.getByText("Narration one.")).toBeInTheDocument();
+  });
+
+  it("returns null when there are no steps", () => {
+    const { container } = render(
+      <AnimationScriptRenderer
+        script={{ type: "linear_search", data: { values: [] }, steps: [] }}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("guards against a missing steps array", () => {
+    const { container } = render(
+      <AnimationScriptRenderer
+        script={
+          { type: "linear_search", data: { values: [] } } as unknown as AnimationScript
+        }
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("AnimationPlayer", () => {
+  const steps = linearScript.steps;
+
+  it("auto-advances while playing and auto-pauses on a match", () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <AnimationPlayer steps={steps}>
+          {(step) => <div>{step.narration}</div>}
+        </AnimationPlayer>,
+      );
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "Play animation" }));
+      });
+      act(() => {
+        vi.advanceTimersByTime(900);
+      });
+      expect(screen.getByText("1 is not the target.")).toBeInTheDocument();
+      act(() => {
+        vi.advanceTimersByTime(900);
+      });
+      expect(
+        screen.getByText("Found the target at index 4."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Play animation" }),
+      ).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("restarts from the beginning when played at the final step", () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <AnimationPlayer steps={steps}>
+          {(step) => <div>{step.narration}</div>}
+        </AnimationPlayer>,
+      );
+      const next = screen.getByRole("button", { name: "Next step" });
+      act(() => {
+        fireEvent.click(next);
+      });
+      act(() => {
+        fireEvent.click(next);
+      });
+      expect(screen.getByText("Found the target at index 4.")).toBeInTheDocument();
+      act(() => {
+        fireEvent.click(screen.getByRole("button", { name: "Play animation" }));
+      });
+      act(() => {
+        vi.advanceTimersByTime(900);
+      });
+      expect(screen.getByText("1 is not the target.")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/components/visualization/AnimationScriptRenderer.tsx
+++ b/frontend/src/components/visualization/AnimationScriptRenderer.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { ComponentType } from "react";
+import { AnimationScript, AnimationStep } from "@/types";
+import { AnimationPlayer } from "./AnimationPlayer";
+import { LinearSearchVisualizer } from "./LinearSearchVisualizer";
+
+export interface VisualizerProps {
+  script: AnimationScript;
+  step: AnimationStep;
+  stepIndex: number;
+}
+
+const VISUALIZERS: Record<string, ComponentType<VisualizerProps>> = {
+  linear_search: LinearSearchVisualizer,
+};
+
+function FallbackTrace({ script }: { script: AnimationScript }) {
+  return (
+    <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-4 space-y-2">
+      <div className="text-xs font-medium text-foreground/80">
+        {script.title || "Algorithm trace"}
+      </div>
+      {script.steps.map((step, i) => (
+        <div key={i} className="flex gap-2 text-xs text-muted-foreground/70">
+          <span className="tabular-nums text-muted-foreground/40">{i + 1}.</span>
+          <span>{step.narration}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function AnimationScriptRenderer({ script }: { script: AnimationScript }) {
+  const steps = Array.isArray(script?.steps) ? script.steps : [];
+  if (steps.length === 0) return null;
+
+  const Visualizer = VISUALIZERS[script.type];
+  if (!Visualizer) return <FallbackTrace script={script} />;
+
+  return (
+    <AnimationPlayer steps={steps}>
+      {(step, index) => (
+        <Visualizer script={script} step={step} stepIndex={index} />
+      )}
+    </AnimationPlayer>
+  );
+}

--- a/frontend/src/components/visualization/LinearSearchVisualizer.tsx
+++ b/frontend/src/components/visualization/LinearSearchVisualizer.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+import { useMemo } from "react";
+import { AnimationScript, AnimationStep } from "@/types";
+import { cn } from "@/lib/utils";
+
+interface LinearSearchVisualizerProps {
+  script: AnimationScript;
+  step: AnimationStep;
+  stepIndex: number;
+}
+
+type CellStatus = "idle" | "visited" | "mismatch" | "match" | "checking";
+
+function getCellStatuses(
+  values: unknown[],
+  steps: AnimationStep[],
+  stepIndex: number,
+): CellStatus[] {
+  const statuses: CellStatus[] = values.map(() => "idle");
+  for (let s = 0; s <= stepIndex; s++) {
+    const st = steps[s];
+    if (st.index == null) continue;
+    const i = st.index;
+    if (st.result === "match") statuses[i] = "match";
+    else if (st.result === "mismatch") statuses[i] = "mismatch";
+    else if (st.operation === "visit" || st.operation === "mark")
+      statuses[i] = "visited";
+    else if (st.operation === "compare") statuses[i] = "checking";
+  }
+  return statuses;
+}
+
+export function LinearSearchVisualizer({
+  script,
+  step,
+  stepIndex,
+}: LinearSearchVisualizerProps) {
+  const reduceMotion = useReducedMotion();
+  const values = useMemo(() => {
+    const raw = script.data?.values;
+    return Array.isArray(raw) ? (raw as unknown[]) : [];
+  }, [script.data]);
+  const target = script.data?.target as unknown;
+  const rawSteps = script.steps;
+  const steps = useMemo(() => rawSteps ?? [], [rawSteps]);
+
+  const statuses = useMemo(
+    () => getCellStatuses(values, steps, stepIndex),
+    [values, steps, stepIndex],
+  );
+  const activeIndex = step.index ?? null;
+  const isMatchFrame = step.result === "match";
+  const isMismatchFrame = step.result === "mismatch";
+
+  const cellClasses: Record<CellStatus, string> = {
+    idle: "bg-white/[0.04] border-white/[0.06] text-foreground/50",
+    visited: "bg-white/[0.03] border-white/[0.05] text-foreground/30",
+    checking: "bg-primary/10 border-primary/40 text-foreground/90",
+    mismatch: "bg-destructive/10 border-destructive/40 text-foreground/60",
+    match:
+      "bg-emerald-500/15 border-emerald-500/50 text-emerald-300 shadow-[0_0_18px_rgba(16,185,129,0.35)]",
+  };
+
+  return (
+    <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2 text-xs">
+          <span className="inline-flex items-center rounded-full bg-white/[0.05] px-2.5 py-1 font-medium text-foreground/80">
+            {script.title || "Linear Search"}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground/50">
+          <span>Target</span>
+          <span className="inline-flex h-7 min-w-7 items-center justify-center rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-1.5 font-mono text-sm text-emerald-300">
+            {String(target)}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        {values.map((value, i) => {
+          const status = statuses[i];
+          const isActive = i === activeIndex;
+          return (
+            <motion.div
+              key={i}
+              layout
+              initial={false}
+              animate={{ scale: isActive ? 1.12 : 1 }}
+              transition={{ type: "spring", stiffness: 400, damping: 25 }}
+              className={cn(
+                "relative flex h-11 w-11 items-center justify-center overflow-hidden whitespace-nowrap rounded-xl border font-mono text-sm transition-colors duration-300",
+                cellClasses[status],
+              )}
+            >
+              {String(value)}
+
+              {isActive && (
+                <motion.div
+                  key={`active-${stepIndex}`}
+                  initial={{ opacity: 0, scale: 0.6 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.15 }}
+                  className={cn(
+                    "pointer-events-none absolute -inset-1 rounded-2xl",
+                    isMatchFrame && "bg-emerald-500/15",
+                    isMismatchFrame && "bg-destructive/15",
+                    !isMatchFrame &&
+                      !isMismatchFrame &&
+                      "bg-primary/10",
+                  )}
+                />
+              )}
+
+              {isActive && !reduceMotion && (
+                <motion.div
+                  aria-hidden
+                  className={cn(
+                    "pointer-events-none absolute inset-0 rounded-xl",
+                    isMatchFrame
+                      ? "bg-emerald-500/20"
+                      : isMismatchFrame
+                        ? "bg-destructive/20"
+                        : "bg-primary/20",
+                  )}
+                  animate={{ opacity: [0.25, 0.7, 0.25] }}
+                  transition={{
+                    duration: 1,
+                    repeat: Infinity,
+                    ease: "easeInOut",
+                  }}
+                />
+              )}
+
+              {status === "mismatch" && i !== activeIndex && (
+                <span
+                  aria-hidden
+                  className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-destructive/30 text-[9px] text-destructive-foreground/70"
+                >
+                  ✕
+                </span>
+              )}
+              {status === "match" && (
+                <motion.span
+                  aria-hidden
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  className="absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-emerald-500 text-[9px] font-bold text-white"
+                >
+                  ✓
+                </motion.span>
+              )}
+            </motion.div>
+          );
+        })}
+      </div>
+
+      <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground/60">
+        <span
+          aria-live="polite"
+          className={cn(
+            "flex-1 leading-relaxed",
+            isMatchFrame && "text-emerald-300/90",
+            isMismatchFrame && "text-destructive/80",
+          )}
+        >
+          {step.narration}
+        </span>
+        {activeIndex != null && (
+          <span className="shrink-0 tabular-nums text-muted-foreground/40">
+            i = {activeIndex}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/visualization/index.ts
+++ b/frontend/src/components/visualization/index.ts
@@ -1,0 +1,4 @@
+export { AnimationPlayer } from "./AnimationPlayer";
+export { AnimationScriptRenderer } from "./AnimationScriptRenderer";
+export { LinearSearchVisualizer } from "./LinearSearchVisualizer";
+export type { VisualizerProps } from "./AnimationScriptRenderer";

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -37,6 +37,39 @@ export interface Question extends QuestionSummary {
   is_interactive?: boolean;
 }
 
+export type AnimationOperation =
+  | "compare"
+  | "visit"
+  | "swap"
+  | "move"
+  | "insert"
+  | "remove"
+  | "mark"
+  | "output";
+
+export type AnimationResult =
+  | "checking"
+  | "match"
+  | "mismatch"
+  | "complete";
+
+export interface AnimationStep {
+  operation: AnimationOperation;
+  index?: number | null;
+  from_index?: number | null;
+  to_index?: number | null;
+  value?: unknown;
+  result?: AnimationResult | null;
+  narration: string;
+}
+
+export interface AnimationScript {
+  type: string;
+  title?: string;
+  data: Record<string, unknown>;
+  steps: AnimationStep[];
+}
+
 export interface StructuredCoachingResponse {
   summary: string;
   hints: string[];
@@ -46,6 +79,7 @@ export interface StructuredCoachingResponse {
   edge_cases: string[];
   explanation: string | null;
   debug_help: string | null;
+  animation?: AnimationScript | null;
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
## Summary

Extends the AI coach so it can return a **declarative animation script** alongside the structured coaching response. The frontend renders that script as an interactive, animated algorithm visualizer instead of plain text — a data contract, never executable code.

## Backend

- **Schemas** (`backend/app/models/schemas.py`): new `AnimationStep` + `AnimationScript` models; `StructuredCoachingResponse` gains an optional `animation` field.
- **Semantic gate** (`backend/app/services/animation_validator.py`): `AnimationValidator` verifies scripts are logically correct — index bounds, match/mismatch truthfulness against the target, narration hygiene, and hard caps (≤50 values, ≤200 steps, ≤300-char narration). A bad script is dropped (with a warning) so the rest of the coaching response still renders — it never 500s the endpoint (defensively guarded in `GroqService._validate_animation`).
- **Prompt contract** (`backend/app/adapters/coaching_prompts.py`): structured persona now instructs the model how to emit a `linear_search` animation from real problem/test data, and to return `null` when no concrete array exists. `animation` is the 9th required field.
- **Transport** (`backend/app/services/groq_service.py`): validation hook after JSON parsing; repair path defaults `animation` to `null`.

## Frontend

- **Types** (`frontend/src/types/index.ts`): `AnimationScript` / `AnimationStep` / operation + result unions.
- **Renderer** (`frontend/src/components/visualization/`):
  - `AnimationScriptRenderer` — registry dispatcher; unknown types fall back to a plain narrated trace; empty scripts render nothing.
  - `AnimationPlayer` — play/pause, step, restart, speed (Slow/Normal/Fast), progress bar, auto-pause on match.
  - `LinearSearchVisualizer` — framer-motion array cells (idle / checking / mismatch / match), target badge, `aria-live` narration, and `prefers-reduced-motion` support.
- **Integration**: `StructuredResponse.tsx` renders the animation between the summary and the hints.

## Example script

```json
{
  "type": "linear_search",
  "title": "Searching for 4",
  "data": { "values": [5, 1, 2, 3, 4, 5], "target": 4 },
  "steps": [
    { "operation": "compare", "index": 0, "value": 5, "result": "mismatch", "narration": "5 is not the target." },
    { "operation": "compare", "index": 4, "value": 4, "result": "match", "narration": "Found the target at index 4." }
  ]
}
```

## Tests

- Backend: `tests/unit/test_animation_validator.py` (22 cases incl. bounds, match/mismatch truthfulness, missing-index regression), prompt-contract tests, and Groq integration drop/keep tests. **105 pass** in the affected unit files.
- Frontend: `AnimationScriptRenderer.test.tsx` (13 cases) + `StructuredResponse.test.tsx` additions. **511 frontend tests pass**, typecheck and lint clean.

## Verification

- `ruff check` + `ruff format` clean on touched backend files.
- `docker compose build backend frontend` succeeds with these changes.

## Notes

- `animation.v1` intentionally supports only `linear_search`; the registry and validator are structured so sorting / binary search / two-pointer can be added next.
- The `codecoach-backend` / `codecoach-frontend` containers in the shared local stack were **not** restarted with the new images because the working tree is concurrently on another feature branch; run `docker compose up -d --build` after switching to this branch.