### PR TITLE
feat(rescue): never-alone rescue contract with solution flow map

### DIFF
--- a/frontend/src/app/problems/[id]/page.tsx
+++ b/frontend/src/app/problems/[id]/page.tsx
@@ -4,11 +4,13 @@ import { Header } from '@/components/header/Header';
 import { AIChatPanelContainer } from '@/components/layout/elements/AIChatPanelContainer';
 import { CodeEditorContainer } from '@/components/layout/elements/CodeEditorContainer';
 import { AIPanelDrawer, useWorkspaceMode } from '@/components/layout/lessons';
+import { RescueIntervention } from '@/components/rescue/RescueIntervention';
 import { QuestionDescriptionPanel } from '@/components/sidebar/QuestionDescriptionPanel';
 import { ResizablePanelGroup } from '@/components/ui/ResizablePanelGroup';
 import { useCoaching } from '@/features/coaching/coaching.hook';
 import { questionService } from '@/features/question/question.service';
 import { useCodeRunner } from '@/features/question/use-code-runner.hook';
+import { useRescueContract } from '@/features/rescue/use-rescue-contract.hook';
 import { Language, Question } from '@/types';
 import { ChevronLeft, Loader2 } from 'lucide-react';
 import Link from 'next/link';
@@ -46,10 +48,26 @@ export default function ProblemWorkspacePage() {
     };
   }, [questionId]);
 
-  const { isRunning, output, executionError, handleRunCode, handleSubmitCode, isAuthenticated } =
-    useCodeRunner({ fullQuestion, language, currentCode });
+  const {
+    isRunning,
+    output,
+    testResults,
+    executionError,
+    lastSubmitResult,
+    handleRunCode,
+    handleSubmitCode,
+    isAuthenticated,
+  } = useCodeRunner({ fullQuestion, language, currentCode });
 
   const { messages, isTyping, sendMessage } = useCoaching();
+
+  const rescue = useRescueContract({
+    questionId,
+    questionTitle: fullQuestion?.title ?? '',
+    testCases: fullQuestion?.test_cases ?? [],
+    lastSubmitResult,
+  });
+  const { registerActivity: rescueActivity } = rescue;
 
   useEffect(() => {
     if (
@@ -67,9 +85,39 @@ export default function ProblemWorkspacePage() {
   const handleSendMessage = useCallback(
     async (message: string, mode: string) => {
       if (!fullQuestion) return;
+      rescueActivity();
       await sendMessage(message, mode as any, fullQuestion.title, currentCode, language);
     },
-    [fullQuestion, currentCode, language, sendMessage],
+    [fullQuestion, currentCode, language, sendMessage, rescueActivity],
+  );
+
+  const handleRunCodeRescue = useCallback(
+    (stdin: string) => {
+      rescueActivity();
+      handleRunCode(stdin);
+    },
+    [handleRunCode, rescueActivity],
+  );
+
+  const handleSubmitCodeRescue = useCallback(() => {
+    rescueActivity();
+    handleSubmitCode();
+  }, [handleSubmitCode, rescueActivity]);
+
+  const handleCodeChangeRescue = useCallback(
+    (code: string) => {
+      rescueActivity();
+      setCurrentCode(code);
+    },
+    [rescueActivity],
+  );
+
+  const handleLanguageChangeRescue = useCallback(
+    (lang: Language) => {
+      rescueActivity();
+      setLanguage(lang);
+    },
+    [rescueActivity],
   );
 
   const { ref: workspaceRef, mode } = useWorkspaceMode();
@@ -78,6 +126,24 @@ export default function ProblemWorkspacePage() {
   useEffect(() => {
     if (mode === 'wide' && drawerOpen) setDrawerOpen(false);
   }, [mode, drawerOpen]);
+
+  // Open the AI chat drawer when the rescue escalates to T2+ so the learner
+  // can take the targeted coach help / re-plan offer.
+  useEffect(() => {
+    if ((rescue.tier === 't2' || rescue.tier === 't3') && mode !== 'wide') {
+      setDrawerOpen(true);
+    }
+  }, [rescue.tier, mode]);
+
+  const requestCoachHelp = useCallback(() => {
+    rescueActivity();
+    if (mode !== 'wide') setDrawerOpen(true);
+  }, [rescueActivity, mode]);
+
+  const requestReplan = useCallback(() => {
+    rescueActivity();
+    if (mode !== 'wide') setDrawerOpen(true);
+  }, [rescueActivity, mode]);
 
   if (loading) {
     return (
@@ -152,11 +218,12 @@ export default function ProblemWorkspacePage() {
           isRunning={isRunning}
           output={output}
           error={executionError || error || ''}
+          testResults={testResults}
           isInteractive={fullQuestion.is_interactive || false}
-          onCodeChange={setCurrentCode}
-          onLanguageChange={setLanguage}
-          onRunCode={handleRunCode}
-          onSubmitCode={handleSubmitCode}
+          onCodeChange={handleCodeChangeRescue}
+          onLanguageChange={handleLanguageChangeRescue}
+          onRunCode={handleRunCodeRescue}
+          onSubmitCode={handleSubmitCodeRescue}
           isAuthenticated={isAuthenticated}
         />
       </div>
@@ -271,6 +338,17 @@ export default function ProblemWorkspacePage() {
               )}
             </>
           )}
+
+          <RescueIntervention
+            tier={rescue.tier}
+            checkpoints={rescue.checkpoints}
+            isSuppressed={rescue.isSuppressed}
+            onLeaveMeAlone={rescue.leaveMeAlone}
+            onResume={rescue.resume}
+            onRequestCoachHelp={requestCoachHelp}
+            onReplan={requestReplan}
+            onContinue={rescueActivity}
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/app/problems/page.tsx
+++ b/frontend/src/app/problems/page.tsx
@@ -2,13 +2,15 @@
 
 import { Header } from "@/components/header/Header";
 import { useQuestion } from "@/features/question/question.hook";
+import { getAbandonedProblems } from "@/features/rescue/rescue.storage";
+import { AbandonedProblem } from "@/features/rescue/rescue.types";
 import { useLocalStorage } from "@/hooks";
 import { getDailySeed, seededShuffle } from "@/lib/shuffle";
 import { cn } from "@/lib/utils";
 import { QuestionSummary } from "@/types";
 import { CheckCircle, Circle, Loader2, XCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 const difficultyStyles: Record<string, string> = {
   easy: "text-green-400 bg-green-500/10",
@@ -23,9 +25,11 @@ export default function ProblemsPage() {
     "user_progress",
     {},
   );
+  const [abandoned, setAbandoned] = useState<AbandonedProblem[]>([]);
 
   useEffect(() => {
     loadQuestions();
+    setAbandoned(getAbandonedProblems());
   }, [loadQuestions]);
 
   const shuffled = useMemo(() => {
@@ -73,6 +77,53 @@ export default function ProblemsPage() {
     <div className="min-h-[100dvh] bg-background text-foreground">
       <Header />
       <main className="max-w-4xl mx-auto px-6 pt-20 pb-32">
+        {abandoned.length > 0 && (
+          <div className="mb-6 flex flex-col rounded-[2rem] bg-white/[0.03] ring-1 ring-amber-500/20 p-1.5">
+            <div className="flex flex-col rounded-[calc(2rem-0.375rem)] bg-card shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] overflow-hidden">
+              <div className="px-6 py-4 border-b border-white/5">
+                <h2 className="text-sm font-semibold tracking-tight text-amber-200">
+                  Pick up where you left off
+                </h2>
+                <p className="text-xs text-muted-foreground/60 mt-0.5">
+                  You were working on these problems — each has a tiny next step.
+                </p>
+              </div>
+              <div className="flex flex-col">
+                {abandoned.map((p) => {
+                  const q = (allQuestions ?? []).find(
+                    (item: QuestionSummary) => item.id === p.questionId,
+                  );
+                  return (
+                    <button
+                      key={p.questionId}
+                      onClick={() => router.push(`/problems/${p.questionId}`)}
+                      className="flex items-center gap-3 px-6 py-3.5 border-b border-white/[0.02] last:border-b-0 hover:bg-white/[0.03] transition-colors text-left"
+                    >
+                      <div className="h-2 w-2 rounded-full bg-amber-400/70 flex-shrink-0" />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-medium text-foreground/80 truncate">
+                          {q?.title || p.title}
+                        </div>
+                        <div className="text-[11px] text-muted-foreground/50 mt-0.5">
+                          {p.stuckCheckpoint
+                            ? `You were stuck at: ${p.stuckCheckpoint}`
+                            : `${p.passedCount}/${p.total} tests passing`}
+                          {p.passedCount > 0 && (
+                            <span> · {p.passedCount}/{p.total} tests passing</span>
+                          )}
+                        </div>
+                      </div>
+                      <span className="text-xs text-muted-foreground/40">
+                        Continue →
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        )}
+
         <div className="flex flex-col rounded-[2rem] bg-white/[0.03] ring-1 ring-white/5 p-1.5">
           <div className="flex flex-col rounded-[calc(2rem-0.375rem)] bg-card shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] overflow-hidden">
             <div className="px-6 py-4 border-b border-white/5">

--- a/frontend/src/components/rescue/ProblemFlowMap.test.tsx
+++ b/frontend/src/components/rescue/ProblemFlowMap.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProblemFlowMap } from "./ProblemFlowMap";
+import { buildRescueCheckpoints } from "@/features/rescue/rescue.checkpoints";
+import { SubmitResponse } from "@/features/code-execution/code-execution.types";
+
+const testCases = [
+  { input: "1", expected_output: "2", description: "Sample A" },
+  { input: "3", expected_output: "4", description: "Sample B" },
+  { input: "5", expected_output: "6", hidden: true },
+];
+
+describe("ProblemFlowMap", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ProblemFlowMap
+        open={false}
+        checkpoints={buildRescueCheckpoints(testCases, null)}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders all checkpoint labels", () => {
+    const checkpoints = buildRescueCheckpoints(testCases, null);
+    render(<ProblemFlowMap checkpoints={checkpoints} />);
+    expect(screen.getByText("Solution Flow Map")).toBeInTheDocument();
+    expect(screen.getByText("Run without error")).toBeInTheDocument();
+    expect(screen.getByText("Sample A")).toBeInTheDocument();
+    expect(screen.getByText("Sample B")).toBeInTheDocument();
+    expect(screen.getByText("Hidden cases → Solved")).toBeInTheDocument();
+  });
+
+  it("marks the first failing test as 'You are here'", () => {
+    const submit: SubmitResponse = {
+      passed: false,
+      total: 2,
+      passed_count: 1,
+      results: [
+        { index: 1, passed: true, input: "1", expected: "2", actual: "2", hidden: false },
+        { index: 2, passed: false, input: "3", expected: "4", actual: "9", hidden: false },
+      ],
+    };
+    const checkpoints = buildRescueCheckpoints(testCases, submit);
+    render(<ProblemFlowMap checkpoints={checkpoints} />);
+    // The second visible test is current and labelled "You are here"
+    const here = screen.getByText("You are here").closest("div");
+    expect(here?.textContent).toContain("Sample B");
+    expect(screen.getByText(/Expected: 4 · Got: 9/)).toBeInTheDocument();
+  });
+
+  it("positions the map at hidden cases when all visible pass", () => {
+    const submit: SubmitResponse = {
+      passed: false,
+      total: 3,
+      passed_count: 2,
+      results: [
+        { index: 1, passed: true, input: "1", expected: "2", actual: "2", hidden: false },
+        { index: 2, passed: true, input: "3", expected: "4", actual: "4", hidden: false },
+        { index: 3, passed: false, input: "5", expected: "6", actual: "x", hidden: true },
+      ],
+    };
+    const checkpoints = buildRescueCheckpoints(testCases, submit);
+    const current = checkpoints.find((c) => c.state === "current");
+    expect(current?.label).toBe("Hidden cases → Solved");
+  });
+});

--- a/frontend/src/components/rescue/ProblemFlowMap.tsx
+++ b/frontend/src/components/rescue/ProblemFlowMap.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { RescueCheckpoint } from "@/features/rescue/rescue.types";
+import { CheckCircle2, Circle, MapPin, XCircle } from "lucide-react";
+
+interface ProblemFlowMapProps {
+  checkpoints: RescueCheckpoint[];
+  open?: boolean;
+}
+
+export function ProblemFlowMap({ checkpoints, open = true }: ProblemFlowMapProps) {
+  if (!open) return null;
+
+  return (
+    <div
+      data-testid="problem-flow-map"
+      className="rounded-lg bg-background/60 ring-1 ring-white/10 p-3"
+    >
+      <div className="text-[10px] font-semibold tracking-wider text-muted-foreground/60 uppercase mb-2">
+        Solution Flow Map
+      </div>
+      <ol className="flex flex-col gap-0">
+        {checkpoints.map((cp) => {
+          const isCurrent = cp.state === "current";
+          const isError = cp.state === "error";
+          return (
+            <li key={cp.id} className="flex gap-2">
+              <div className="flex flex-col items-center">
+                {isCurrent ? (
+                  <span className="flex h-5 w-5 items-center justify-center rounded-full bg-emerald-500/20 ring-1 ring-emerald-400/50">
+                    <MapPin className="h-3 w-3 text-emerald-300" />
+                  </span>
+                ) : cp.state === "passed" ? (
+                  <span className="flex h-5 w-5 items-center justify-center text-emerald-400/80">
+                    <CheckCircle2 className="h-4 w-4" />
+                  </span>
+                ) : isError ? (
+                  <span className="flex h-5 w-5 items-center justify-center text-red-400">
+                    <XCircle className="h-4 w-4" />
+                  </span>
+                ) : (
+                  <span className="flex h-5 w-5 items-center justify-center text-muted-foreground/30">
+                    <Circle className="h-4 w-4" />
+                  </span>
+                )}
+                {cp.id !== checkpoints[checkpoints.length - 1].id && (
+                  <span
+                    className={cn(
+                      "w-px flex-1 min-h-4",
+                      cp.state === "passed"
+                        ? "bg-emerald-400/30"
+                        : "bg-white/10",
+                    )}
+                  />
+                )}
+              </div>
+              <div className="pb-3 min-w-0">
+                <div
+                  className={cn(
+                    "text-xs",
+                    isCurrent
+                      ? "text-emerald-200 font-medium"
+                      : cp.state === "passed"
+                        ? "text-muted-foreground/70 line-through decoration-emerald-400/40"
+                        : "text-muted-foreground/50",
+                  )}
+                >
+                  {isCurrent && (
+                    <span className="mr-1.5 text-[9px] font-bold uppercase tracking-wider text-emerald-300">
+                      You are here
+                    </span>
+                  )}
+                  {cp.label}
+                </div>
+                {cp.detail && isCurrent && (
+                  <div className="mt-0.5 text-[10px] font-mono text-amber-300/90">
+                    {cp.detail}
+                  </div>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}

--- a/frontend/src/components/rescue/RescueIntervention.tsx
+++ b/frontend/src/components/rescue/RescueIntervention.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { RescueCheckpoint, RescueTier } from "@/features/rescue/rescue.types";
+import { ProblemFlowMap } from "./ProblemFlowMap";
+
+interface RescueInterventionProps {
+  tier: RescueTier;
+  checkpoints: RescueCheckpoint[];
+  isSuppressed?: boolean;
+  onLeaveMeAlone: () => void;
+  onResume: () => void;
+  onRequestCoachHelp: () => void;
+  onReplan: () => void;
+  onContinue: () => void;
+}
+
+export function RescueIntervention({
+  tier,
+  checkpoints,
+  isSuppressed = false,
+  onLeaveMeAlone,
+  onResume,
+  onRequestCoachHelp,
+  onReplan,
+  onContinue,
+}: RescueInterventionProps) {
+  if (tier === "none") return null;
+
+  const tierLabel =
+    tier === "t1" ? "It looks like you're stuck" : tier === "t2" ? "Still stuck?" : "Let's rethink";
+
+  const tierDescription =
+    tier === "t1"
+      ? "You've been on this problem for a while. Here's exactly where your code stands."
+      : tier === "t2"
+        ? "Want a targeted hint from the AI coach about the failing test?"
+        : "Maybe a fresh approach will unblock you — or try an easier next step.";
+
+  return (
+    <div
+      data-testid="rescue-intervention"
+      className="fixed bottom-4 right-4 z-50 w-80 max-w-[calc(100vw-2rem)]"
+    >
+      <div className="rounded-2xl bg-card ring-1 ring-white/15 shadow-2xl overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-2.5 border-b border-white/5 bg-white/[0.03]">
+          <div>
+            <div className="text-xs font-semibold text-foreground">
+              {tierLabel}
+            </div>
+            <div className="text-[10px] text-muted-foreground/60">
+              {tierDescription}
+            </div>
+          </div>
+          <button
+            onClick={isSuppressed ? onResume : onLeaveMeAlone}
+            className="text-[10px] text-muted-foreground/50 hover:text-foreground transition-colors px-2 py-1 rounded hover:bg-white/5"
+          >
+            {isSuppressed ? "Resume rescue" : "Leave me alone"}
+          </button>
+        </div>
+
+        <div className="px-4 py-3 max-h-72 overflow-y-auto">
+          <ProblemFlowMap checkpoints={checkpoints} />
+        </div>
+
+        <div className="flex flex-col gap-1.5 px-4 py-3 border-t border-white/5">
+          {tier === "t2" && (
+            <button
+              onClick={onRequestCoachHelp}
+              className="text-xs font-medium text-foreground bg-emerald-500/15 hover:bg-emerald-500/25 ring-1 ring-emerald-500/30 rounded-lg px-3 py-2 transition-colors text-left"
+            >
+              Ask the AI coach about this failing test
+            </button>
+          )}
+          {tier === "t3" && (
+            <button
+              onClick={onReplan}
+              className="text-xs font-medium text-foreground bg-violet-500/15 hover:bg-violet-500/25 ring-1 ring-violet-500/30 rounded-lg px-3 py-2 transition-colors text-left"
+            >
+              Re-plan my path — suggest a smaller next step
+            </button>
+          )}
+          <button
+            onClick={onContinue}
+            className="text-xs font-medium text-muted-foreground bg-white/[0.03] hover:bg-white/[0.07] ring-1 ring-white/10 rounded-lg px-3 py-2 transition-colors text-left"
+          >
+            I&apos;m still working on it
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/question/use-code-runner.hook.ts
+++ b/frontend/src/features/question/use-code-runner.hook.ts
@@ -3,7 +3,10 @@
 import { useCallback } from "react";
 import { Question, Language } from "@/types";
 import { useCodeExecution } from "@/features/code-execution/code-execution.hook";
-import { TestCaseResultView } from "@/features/code-execution/code-execution.types";
+import {
+  SubmitResponse,
+  TestCaseResultView,
+} from "@/features/code-execution/code-execution.types";
 import { useLocalStorage } from "@/hooks";
 import { showToast } from "@/components/ui/Toast";
 import { useAuth } from "@/providers";
@@ -26,6 +29,7 @@ interface UseCodeRunnerReturn {
   isRunning: boolean;
   output: string;
   testResults: TestCaseResultView[] | null;
+  lastSubmitResult: SubmitResponse | null;
   executionError: string | null;
   clearOutput: () => void;
   clearExecutionError: () => void;
@@ -42,6 +46,7 @@ export function useCodeRunner({
     output,
     error: executionError,
     testResults,
+    lastSubmitResult,
     validateCode,
     submitCode,
     runLocalJavaScript,
@@ -145,6 +150,7 @@ export function useCodeRunner({
     isRunning,
     output,
     testResults,
+    lastSubmitResult,
     executionError,
     clearOutput,
     clearExecutionError,

--- a/frontend/src/features/rescue/rescue.checkpoints.ts
+++ b/frontend/src/features/rescue/rescue.checkpoints.ts
@@ -1,0 +1,82 @@
+import { SubmitResponse } from "@/features/code-execution/code-execution.types";
+import { RescueCheckpoint } from "./rescue.types";
+
+interface FlowTestCase {
+  input: string;
+  expected_output: string;
+  description?: string;
+  hidden?: boolean;
+}
+
+/**
+ * Build the "solution flow map" checkpoint list from a question's test cases
+ * and the latest submit result.
+ *
+ * The map renders a vertical flowchart: "Run without error" at the top,
+ * one checkpoint per visible test case, then "Hidden cases" leading to solved.
+ * The first failing test becomes the "You are HERE" checkpoint; every test
+ * before it is passed and everything after is upcoming.
+ */
+export function buildRescueCheckpoints(
+  testCases: FlowTestCase[],
+  lastSubmitResult: SubmitResponse | null,
+): RescueCheckpoint[] {
+  const checkpoints: RescueCheckpoint[] = [];
+
+  const resultsByIndex = new Map(
+    (lastSubmitResult?.results ?? []).map((r) => [r.index, r]),
+  );
+  const anyExecuted = (lastSubmitResult?.results.length ?? 0) > 0;
+
+  checkpoints.push({
+    id: "run",
+    label: "Run without error",
+    state: anyExecuted ? "passed" : "current",
+  });
+
+  let foundCurrent = false;
+  const visiblePositions: number[] = [];
+  testCases.forEach((tc, originalIndex) => {
+    if (tc.hidden) return;
+    const position = originalIndex + 1;
+    visiblePositions.push(position);
+    const result = resultsByIndex.get(position);
+    if (result) {
+      const passed = result.passed;
+      if (!passed && !foundCurrent) {
+        checkpoints.push({
+          id: `test-${position}`,
+          label: tc.description || `Test ${position}`,
+          state: "current",
+          detail: `Expected: ${result.expected} · Got: ${result.actual}`,
+        });
+        foundCurrent = true;
+      } else {
+        checkpoints.push({
+          id: `test-${position}`,
+          label: tc.description || `Test ${position}`,
+          state: passed ? "passed" : "upcoming",
+        });
+      }
+    } else {
+      checkpoints.push({
+        id: `test-${position}`,
+        label: tc.description || `Test ${position}`,
+        state: foundCurrent ? "upcoming" : "current",
+      });
+      if (!foundCurrent) foundCurrent = true;
+    }
+  });
+
+  const allVisiblePassed =
+    visiblePositions.length === 0 ||
+    visiblePositions.every((pos) => resultsByIndex.get(pos)?.passed);
+
+  checkpoints.push({
+    id: "hidden",
+    label: "Hidden cases → Solved",
+    state: allVisiblePassed && anyExecuted ? "current" : "upcoming",
+  });
+
+  return checkpoints;
+}

--- a/frontend/src/features/rescue/rescue.config.ts
+++ b/frontend/src/features/rescue/rescue.config.ts
@@ -1,0 +1,21 @@
+export const RESCUE_CONFIG = {
+  // Idle time before the first (T1) rescue intervention fires.
+  t1IdleMs: 4 * 60 * 1000,
+  // Additional idle time after T1 before the T2 AI coach offer.
+  t2AfterT1Ms: 5 * 60 * 1000,
+  // Additional idle time after T2 before the T3 "re-plan your path" offer.
+  t3AfterT2Ms: 5 * 60 * 1000,
+  // How often the idle timer re-checks while a rescue is pending.
+  checkIntervalMs: 30 * 1000,
+} as const;
+
+export const RESCUE_STORAGE_KEY = "rescue_abandoned_problems";
+
+export const tierThresholds = {
+  t1: RESCUE_CONFIG.t1IdleMs,
+  t2: RESCUE_CONFIG.t1IdleMs + RESCUE_CONFIG.t2AfterT1Ms,
+  t3:
+    RESCUE_CONFIG.t1IdleMs +
+    RESCUE_CONFIG.t2AfterT1Ms +
+    RESCUE_CONFIG.t3AfterT2Ms,
+} as const;

--- a/frontend/src/features/rescue/rescue.storage.ts
+++ b/frontend/src/features/rescue/rescue.storage.ts
@@ -1,0 +1,43 @@
+import { RESCUE_STORAGE_KEY } from "./rescue.config";
+import { AbandonedProblem } from "./rescue.types";
+
+export function getAbandonedProblems(): AbandonedProblem[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(RESCUE_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveAbandonedProblem(problem: AbandonedProblem): void {
+  if (typeof window === "undefined") return;
+  try {
+    const current = getAbandonedProblems();
+    const withoutDuplicate = current.filter(
+      (p) => p.questionId !== problem.questionId,
+    );
+    window.localStorage.setItem(
+      RESCUE_STORAGE_KEY,
+      JSON.stringify([problem, ...withoutDuplicate]),
+    );
+  } catch {
+    // localStorage unavailable — silently ignore
+  }
+}
+
+export function removeAbandonedProblem(questionId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const current = getAbandonedProblems();
+    window.localStorage.setItem(
+      RESCUE_STORAGE_KEY,
+      JSON.stringify(current.filter((p) => p.questionId !== questionId)),
+    );
+  } catch {
+    // localStorage unavailable — silently ignore
+  }
+}

--- a/frontend/src/features/rescue/rescue.types.ts
+++ b/frontend/src/features/rescue/rescue.types.ts
@@ -1,0 +1,17 @@
+export type RescueTier = "none" | "t1" | "t2" | "t3";
+
+export interface RescueCheckpoint {
+  id: string;
+  label: string;
+  state: "passed" | "current" | "upcoming" | "error";
+  detail?: string;
+}
+
+export interface AbandonedProblem {
+  questionId: string;
+  title: string;
+  stuckCheckpoint: string | null;
+  passedCount: number;
+  total: number;
+  abandonedAt: number;
+}

--- a/frontend/src/features/rescue/use-rescue-contract.hook.test.ts
+++ b/frontend/src/features/rescue/use-rescue-contract.hook.test.ts
@@ -1,0 +1,240 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useRescueContract } from "./use-rescue-contract.hook";
+import { tierThresholds } from "./rescue.config";
+import { SubmitResponse } from "@/features/code-execution/code-execution.types";
+
+const testCases = [
+  { input: "1", expected_output: "2", description: "Sample A" },
+  { input: "3", expected_output: "4", hidden: true },
+  { input: "[1]", expected_output: "[]", description: "Edge" },
+];
+
+function makeSubmit(passedCount: number, total: number): SubmitResponse {
+  return {
+    passed: passedCount === total,
+    total,
+    passed_count: passedCount,
+    results: Array.from({ length: total }, (_, i) => ({
+      index: i + 1,
+      passed: i < passedCount,
+      input: String(i),
+      expected: String(i),
+      actual: i < passedCount ? String(i) : "wrong",
+      hidden: false,
+    })),
+  };
+}
+
+describe("useRescueContract", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const baseOptions: {
+    questionId: string;
+    questionTitle: string;
+    testCases: typeof testCases;
+    lastSubmitResult: SubmitResponse | null;
+  } = {
+    questionId: "q1",
+    questionTitle: "Question One",
+    testCases,
+    lastSubmitResult: null,
+  };
+
+  it("does not fire before the T1 threshold", () => {
+    const { result } = renderHook(() => useRescueContract(baseOptions));
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t1 - 1000);
+    });
+    expect(result.current.tier).toBe("none");
+    expect(result.current.isStuck).toBe(false);
+  });
+
+  it("fires T1 once the T1 idle threshold is reached", () => {
+    const { result } = renderHook(() => useRescueContract(baseOptions));
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t1);
+    });
+    expect(result.current.tier).toBe("t1");
+    expect(result.current.isStuck).toBe(true);
+  });
+
+  it("escalates T1 -> T2 -> T3 as idle time grows", () => {
+    const { result } = renderHook(() => useRescueContract(baseOptions));
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t1);
+    });
+    expect(result.current.tier).toBe("t1");
+
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t2 - tierThresholds.t1);
+    });
+    expect(result.current.tier).toBe("t2");
+
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t3 - tierThresholds.t2);
+    });
+    expect(result.current.tier).toBe("t3");
+  });
+
+  it("resets to none on activity", () => {
+    const { result } = renderHook(() => useRescueContract(baseOptions));
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t1);
+    });
+    expect(result.current.tier).toBe("t1");
+
+    act(() => {
+      result.current.registerActivity();
+    });
+    expect(result.current.tier).toBe("none");
+    expect(result.current.isStuck).toBe(false);
+  });
+
+  it("stops escalating when the problem is solved", () => {
+    const { result, rerender } = renderHook(
+      ({ opts }) => useRescueContract(opts),
+      { initialProps: { opts: baseOptions } },
+    );
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t1);
+    });
+    expect(result.current.tier).toBe("t1");
+
+    rerender({
+      opts: { ...baseOptions, lastSubmitResult: makeSubmit(3, 3) },
+    });
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t3);
+    });
+    expect(result.current.tier).toBe("none");
+  });
+
+  it("honors the leave-me-alone toggle", () => {
+    const { result } = renderHook(() => useRescueContract(baseOptions));
+    act(() => {
+      result.current.leaveMeAlone();
+    });
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t3);
+    });
+    expect(result.current.isSuppressed).toBe(true);
+    expect(result.current.tier).toBe("none");
+  });
+
+  it("resumes after leave-me-alone", () => {
+    const { result } = renderHook(() => useRescueContract(baseOptions));
+    act(() => {
+      result.current.leaveMeAlone();
+    });
+    act(() => {
+      result.current.resume();
+    });
+    expect(result.current.isSuppressed).toBe(false);
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t1);
+    });
+    expect(result.current.tier).toBe("t1");
+  });
+
+  it("does not count idle time while the tab is hidden", () => {
+    const setVisibility = (state: "visible" | "hidden") => {
+      Object.defineProperty(document, "visibilityState", {
+        value: state,
+        configurable: true,
+      });
+      document.dispatchEvent(
+        new Event("visibilitychange"),
+      );
+    };
+    setVisibility("hidden");
+    const { result } = renderHook(() => useRescueContract(baseOptions));
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t3);
+    });
+    expect(result.current.tier).toBe("none");
+
+    setVisibility("visible");
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t1);
+    });
+    expect(result.current.tier).toBe("t1");
+  });
+
+  it("builds checkpoints from test cases", () => {
+    const { result } = renderHook(() => useRescueContract(baseOptions));
+    const labels = result.current.checkpoints.map((c) => c.label);
+    expect(labels).toEqual([
+      "Run without error",
+      "Sample A",
+      "Edge",
+      "Hidden cases → Solved",
+    ]);
+  });
+
+  it("marks the failing checkpoint as current from submit results", () => {
+    const { result } = renderHook(() =>
+      useRescueContract({
+        ...baseOptions,
+        lastSubmitResult: {
+          passed: false,
+          total: 3,
+          passed_count: 1,
+          results: [
+            { index: 1, passed: true, input: "1", expected: "2", actual: "2", hidden: false },
+            { index: 2, passed: false, input: "[1]", expected: "[]", actual: "[1]", hidden: true },
+            { index: 3, passed: false, input: "3", expected: "4", actual: "9", hidden: false },
+          ],
+        },
+      }),
+    );
+    const current = result.current.checkpoints.find(
+      (c) => c.state === "current",
+    );
+    expect(current).toBeDefined();
+    // Visible test 1 ("Sample A") passes; visible test 2 ("Edge", position 3)
+    // is the first failing visible checkpoint.
+    expect(current?.label).toBe("Edge");
+    expect(current?.detail).toContain("Expected:");
+  });
+
+  it("captures an abandoned problem on abandon", () => {
+    const { result } = renderHook(() => useRescueContract(baseOptions));
+    act(() => {
+      vi.advanceTimersByTime(tierThresholds.t1);
+    });
+    act(() => {
+      result.current.abandon();
+    });
+    const stored = JSON.parse(
+      localStorage.getItem("rescue_abandoned_problems") || "[]",
+    );
+    expect(stored).toHaveLength(1);
+    expect(stored[0].questionId).toBe("q1");
+  });
+
+  it("does not record an abandoned problem for solved work", () => {
+    const { result, rerender } = renderHook(
+      ({ opts }) => useRescueContract(opts),
+      { initialProps: { opts: baseOptions } },
+    );
+    rerender({
+      opts: { ...baseOptions, lastSubmitResult: makeSubmit(2, 2) },
+    });
+    act(() => {
+      result.current.abandon();
+    });
+    const stored = JSON.parse(
+      localStorage.getItem("rescue_abandoned_problems") || "[]",
+    );
+    expect(stored).toHaveLength(0);
+  });
+});

--- a/frontend/src/features/rescue/use-rescue-contract.hook.ts
+++ b/frontend/src/features/rescue/use-rescue-contract.hook.ts
@@ -1,0 +1,194 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { SubmitResponse } from "@/features/code-execution/code-execution.types";
+import { RESCUE_CONFIG, tierThresholds } from "./rescue.config";
+import { buildRescueCheckpoints } from "./rescue.checkpoints";
+import { AbandonedProblem, RescueCheckpoint, RescueTier } from "./rescue.types";
+import {
+  removeAbandonedProblem,
+  saveAbandonedProblem,
+} from "./rescue.storage";
+
+interface UseRescueContractOptions {
+  questionId: string;
+  questionTitle: string;
+  testCases: Array<{
+    input: string;
+    expected_output: string;
+    description?: string;
+    hidden?: boolean;
+  }>;
+  lastSubmitResult: SubmitResponse | null;
+}
+
+interface UseRescueContractReturn {
+  tier: RescueTier;
+  isStuck: boolean;
+  isSuppressed: boolean;
+  checkpoints: RescueCheckpoint[];
+  registerActivity: () => void;
+  leaveMeAlone: () => void;
+  resume: () => void;
+  abandon: () => void;
+}
+
+/**
+ * The "never-alone rescue contract" for the problem workspace.
+ *
+ * Detects a stuck learner (idle past a threshold on an unsolved problem)
+ * and escalates through intervention tiers:
+ *   - T1: open the solution flow map highlighting the blocked checkpoint
+ *   - T2: offer a targeted AI coach message for the failing test
+ *   - T3: offer "re-plan your path"
+ *
+ * Idle time is not counted while the tab is hidden, and any activity
+ * (code change, run, submit, chat) resets the timer. A "Leave me alone"
+ * toggle silences interventions for the session. Abandoning an unsolved
+ * problem is captured in localStorage and resurfaced on /problems.
+ */
+export function useRescueContract({
+  questionId,
+  questionTitle,
+  testCases,
+  lastSubmitResult,
+}: UseRescueContractOptions): UseRescueContractReturn {
+  const lastActivityRef = useRef<number>(Date.now());
+  const questionIdRef = useRef(questionId);
+  const titleRef = useRef(questionTitle);
+  const tierRef = useRef<RescueTier>("none");
+  const solvedRef = useRef(false);
+
+  const [tier, setTierState] = useState<RescueTier>("none");
+  const [isSuppressed, setSuppressed] = useState(false);
+
+  questionIdRef.current = questionId;
+  titleRef.current = questionTitle;
+
+  const checkpoints = useMemo(
+    () => buildRescueCheckpoints(testCases, lastSubmitResult),
+    [testCases, lastSubmitResult],
+  );
+
+  const setTier = useCallback((next: RescueTier) => {
+    tierRef.current = next;
+    setTierState(next);
+  }, []);
+
+  // Detect when the problem becomes solved (transition into solved state).
+  const prevSolvedRef = useRef(false);
+  useEffect(() => {
+    const solved =
+      !!lastSubmitResult &&
+      lastSubmitResult.total > 0 &&
+      lastSubmitResult.passed_count === lastSubmitResult.total;
+    solvedRef.current = solved;
+    if (solved && !prevSolvedRef.current) {
+      setTier("none");
+      removeAbandonedProblem(questionIdRef.current);
+    }
+    prevSolvedRef.current = solved;
+  }, [lastSubmitResult, questionId, setTier]);
+
+  const resetIdle = useCallback(() => {
+    lastActivityRef.current = Date.now();
+    setTier("none");
+  }, [setTier]);
+
+  const registerActivity = useCallback(() => {
+    resetIdle();
+  }, [resetIdle]);
+
+  // Idle timer: escalate through T1 -> T2 -> T3.
+  useEffect(() => {
+    if (isSuppressed) return;
+    const interval = window.setInterval(() => {
+      if (solvedRef.current) return;
+      // Do not count time while the tab is hidden.
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState === "hidden"
+      ) {
+        return;
+      }
+
+      const idleMs = Date.now() - lastActivityRef.current;
+      if (idleMs >= tierThresholds.t3) {
+        setTier("t3");
+      } else if (idleMs >= tierThresholds.t2) {
+        setTier("t2");
+      } else if (idleMs >= tierThresholds.t1) {
+        setTier("t1");
+      }
+    }, RESCUE_CONFIG.checkIntervalMs);
+    return () => window.clearInterval(interval);
+  }, [isSuppressed, setTier]);
+
+  // Reset the idle clock when the tab becomes visible again (hidden time
+  // must not count toward "stuck").
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") {
+        lastActivityRef.current = Date.now();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, []);
+
+  const buildAbandonedProblem = useCallback((): AbandonedProblem => {
+    return {
+      questionId: questionIdRef.current,
+      title: titleRef.current,
+      stuckCheckpoint:
+        buildRescueCheckpoints(testCases, lastSubmitResult).find(
+          (c) => c.state === "current",
+        )?.label ?? null,
+      passedCount: lastSubmitResult?.passed_count ?? 0,
+      total: lastSubmitResult?.total ?? testCases.length,
+      abandonedAt: Date.now(),
+    };
+  }, [testCases, lastSubmitResult]);
+  const buildAbandonedRef = useRef(buildAbandonedProblem);
+  buildAbandonedRef.current = buildAbandonedProblem;
+
+  // Capture + resurface abandoned problems on unmount (only if unsolved and
+  // the learner actually made an attempt / was at risk of being stuck).
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      if (!solvedRef.current && tierRef.current !== "none") {
+        saveAbandonedProblem(buildAbandonedRef.current());
+      }
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, []);
+
+  const leaveMeAlone = useCallback(() => {
+    setSuppressed(true);
+    setTier("none");
+  }, [setTier]);
+
+  const resume = useCallback(() => {
+    setSuppressed(false);
+    resetIdle();
+  }, [resetIdle]);
+
+  const abandon = useCallback(() => {
+    if (solvedRef.current) return;
+    saveAbandonedProblem(buildAbandonedProblem());
+  }, [buildAbandonedProblem]);
+
+  return {
+    tier,
+    isStuck: tier !== "none",
+    isSuppressed,
+    checkpoints,
+    registerActivity,
+    leaveMeAlone,
+    resume,
+    abandon,
+  };
+}


### PR DESCRIPTION
Closes #87

## Summary
Implements the never-alone rescue contract for the problem workspace (`/problems/[id]`). When a learner is stuck (idle past a threshold on an unsolved problem), the app auto-intervenes with escalating, data-driven scaffolds instead of silent abandonment.

## What's included
- `features/rescue/use-rescue-contract.hook.ts` — stuck detection + escalation state machine:
  - Idle timer reset on any activity (code change, run, submit, chat)
  - Tab-visibility aware (hidden time doesn't count)
  - Escalates T1 (open flow map) → T2 (AI coach offer) → T3 (re-plan path)
  - `Leave me alone` session toggle
  - Captures abandoned unsolved problems to localStorage
- `components/rescue/ProblemFlowMap.tsx` — checkpoint flowchart derived from test cases + last submit result, highlighting the blocked checkpoint with failing input/expected/actual
- `components/rescue/RescueIntervention.tsx` — non-intrusive banner with tier actions
- `app/problems/[id]/page.tsx` — wires activity signals, opens the AI chat drawer at T2+, renders the intervention
- `app/problems/page.tsx` — `Pick up where you left off` section from abandoned problems
- `useCodeRunner` now exposes `lastSubmitResult`

## Tests
- 12 fake-timer hook tests: no-fire before threshold, T1 fires, T1→T2→T3 escalation, reset on activity, stop when solved, leave-me-alone honored, resume, hidden-tab awareness, checkpoint building, failing-checkpoint marking, abandonment capture, solved not abandoned
- 4 `ProblemFlowMap` tests: closed, labels, failing-test positioning, hidden-cases positioning
- Full suite: 521 frontend tests pass, `tsc` clean, lint clean

## Verification
- Frontend Docker image rebuilt: `docker compose up -d --build frontend`
- Caveman-reviewed staged diff before commit