### PR TITLE
feat(db): DB-backed admin seeding, Postgres-primary script defaults

### DIFF
--- a/backend/scripts/migrate_to_sql.py
+++ b/backend/scripts/migrate_to_sql.py
@@ -4,7 +4,7 @@
 Usage:
     python scripts/migrate_to_sql.py [--url DATABASE_URL]
 
-Defaults to DATABASE_URL from .env or sqlite+aiosqlite:///./codecoach.db
+Defaults to DATABASE_URL from .env or the local PostgreSQL instance.
 """
 
 import asyncio
@@ -35,7 +35,7 @@ from app.models.schemas import Question
 def _get_database_url() -> str:
     url = os.getenv("DATABASE_URL")
     if not url:
-        url = "mysql+aiomysql://codecoach:codecoach@host.docker.internal:3306/codecoach"
+        url = "postgresql+asyncpg://codecoach:codecoach@host.docker.internal:5432/codecoach"
     return url
 
 

--- a/backend/scripts/seed_admin.py
+++ b/backend/scripts/seed_admin.py
@@ -1,13 +1,32 @@
-"""Seed admin and super_admin users into the database/users.json."""
+#!/usr/bin/env python3
+"""Seed admin and super_admin users into the database.
 
-import json
+The app is fully DB-backed (PostgreSQL/Supabase primary); this script writes
+directly to the ``users`` table instead of the legacy ``data/users.json`` file.
+
+Usage:
+    DATABASE_URL=postgresql://... python scripts/seed_admin.py
+"""
+
+import asyncio
+import os
+import sys
 import uuid
-import bcrypt
 from datetime import datetime, timezone
 from pathlib import Path
 
-DATA_DIR = Path(__file__).resolve().parent.parent / "data"
-USERS_FILE = DATA_DIR / "users.json"
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import bcrypt
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import (
+    create_async_engine,
+    AsyncSession,
+    async_sessionmaker,
+)
+from sqlalchemy.pool import NullPool
+
+from app.models.orm import UserORM
 
 
 def hash_password(password: str) -> str:
@@ -30,46 +49,54 @@ ADMIN_USERS = [
 ]
 
 
-def seed():
-    if not USERS_FILE.exists():
-        users = []
-    else:
-        with open(USERS_FILE, "r") as f:
-            users = json.load(f)
+def _get_database_url() -> str:
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        url = "postgresql+asyncpg://codecoach:codecoach@host.docker.internal:5432/codecoach"
+    if url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    return url
 
-    existing_usernames = {u["username"] for u in users}
-    now = datetime.now(timezone.utc).isoformat()
+
+async def seed(session: AsyncSession) -> None:
+    now = datetime.now(timezone.utc)
 
     for au in ADMIN_USERS:
-        if au["username"] in existing_usernames:
-            # Update role if user already exists
-            for u in users:
-                if u["username"] == au["username"]:
-                    u["role"] = au["role"]
-                    print(f"  Updated role for '{au['username']}' to '{au['role']}'")
-                    break
+        result = await session.execute(
+            select(UserORM).where(UserORM.username == au["username"])
+        )
+        user = result.scalar_one_or_none()
+        if user is not None:
+            user.role = au["role"]
+            print(f"  Updated role for '{au['username']}' to '{au['role']}'")
         else:
-            users.append(
-                {
-                    "id": str(uuid.uuid4()),
-                    "username": au["username"],
-                    "email": au["email"],
-                    "hashed_password": hash_password(au["password"]),
-                    "created_at": now,
-                    "is_active": True,
-                    "oauth_provider": None,
-                    "oauth_id": None,
-                    "role": au["role"],
-                }
+            session.add(
+                UserORM(
+                    id=str(uuid.uuid4()),
+                    username=au["username"],
+                    email=au["email"],
+                    hashed_password=hash_password(au["password"]),
+                    created_at=now,
+                    is_active=1,
+                    role=au["role"],
+                )
             )
             print(f"  Created user '{au['username']}' with role '{au['role']}'")
-        existing_usernames.add(au["username"])
 
-    with open(USERS_FILE, "w") as f:
-        json.dump(users, f, indent=2)
+    await session.commit()
 
-    print(f"\nDone. Users file: {USERS_FILE}")
+
+async def _main() -> None:
+    engine = create_async_engine(_get_database_url(), poolclass=NullPool)
+    try:
+        async with async_sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )() as session:
+            await seed(session)
+    finally:
+        await engine.dispose()
+    print("\nDone. Admin users seeded into the database.")
 
 
 if __name__ == "__main__":
-    seed()
+    asyncio.run(_main())


### PR DESCRIPTION
Closes #92

## Context
The Supabase/PostgreSQL migration core was already merged in main (commit `4dd63fe` — Postgres-primary config + asyncpg driver, `sync_database` tool with FK-safe flush/copy and count validation, Postgres CI). This PR closes the remaining scope item: **replace file-based seeding with DB-backed**.

## Changes
- `backend/scripts/seed_admin.py`: now seeds admin/super_admin users directly into the `users` table via async SQLAlchemy (upsert-by-username), instead of writing to the dead `data/users.json` file. The runtime is fully DB-backed and `users.json` is untracked + gitignored.
- `backend/scripts/migrate_to_sql.py`: default URL updated from `mysql+aiomysql://...3306` to `postgresql+asyncpg://...5432`, and the docstring corrected (it claimed a sqlite default).

The MySQL `aiomysql` path remains only in `sync_database.py`/`database_sync_adapters.py` where it is intentionally the **source** side of local-MySQL → Supabase migration.

## Verification
- ruff clean on both scripts
- `seed_admin.py` import + bcrypt hash + Postgres URL smoke-tested
- `test_database_sync.py` unit tests pass (14)
- Backend Docker image rebuilt: `docker compose up -d --build backend`
- Caveman-reviewed staged diff before commit