### PR TITLE
feat(animate): animation viewer controls, canonical-solution pipeline, UX polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,39 @@
 # AGENTS.md
 
+## MANDATORY: Production-First Engineering
+
+**Hard rule — Do NOT skip.** This is a production project. Every decision is made
+along production lines: reliable, maintainable, observable, and safe to operate.
+
+- **Production over hacks:** prefer reliable, maintainable solutions over quick
+  patches, shortcuts, or workarounds that trade long-term health for speed.
+- **Contract stability:** preserve existing API contracts, schemas, and data
+  semantics unless a change is explicitly requested and reviewed. Breaking
+  changes require migration and rollout planning.
+- **Security & secrets:** validate input at boundaries, never log or commit
+  secrets, follow least privilege, and review auth/authz on every change that
+  touches user data. Security findings are release-blocking.
+- **Scalability & failure handling:** design for load and for failure. Never
+  block hot paths on slow external calls; degrade gracefully and fail safe.
+- **Observability:** changes that affect behavior must remain observable —
+  structured logs, request correlation, and metric-friendly paths where they
+  already exist.
+- **Quality gates:** lint, typecheck, and tests must pass before committing.
+  Rebuild affected Docker images after code changes (see Docker section below).
+- **Migration & deployment impact:** review schema/migration, Docker, and
+  deployment impact before modifying infrastructure. Prefer idempotent,
+  re-runnable operations.
+- **No speculative work:** don't add features, abstractions, or
+  backward-compatibility layers without a concrete, current need.
+- **Document decisions:** significant architectural or operational decisions are
+  recorded so the rationale survives the session.
+- **Ask before destructive action:** before making destructive, irreversible,
+  or contract-breaking changes (drops, deletes, force-pushes, secret rotation,
+  breaking API changes), confirm with the user first.
+
+**Standard workflow:** inspect → plan → failing test → implement → verify →
+production-readiness review.
+
 ## MANDATORY: TDD (Test-Driven Development) Always
 
 **Hard rule — Do NOT skip.** Every code change must be driven by a failing test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,43 @@
 # AGENTS.md
 
-## MANDATORY: Database Is the Single Source of Truth
+## MANDATORY: TDD (Test-Driven Development) Always
 
-**Hard rule — Do NOT skip.** The database (PostgreSQL/Supabase) is the ONLY
-source of truth for all application data: questions, courses, modules,
-lessons, users, progress, admin, usage.
+**Hard rule — Do NOT skip.** Every code change must be driven by a failing test
+first. The only way code enters this repo is red → green → refactor.
 
-- **No local data files.** Do not create, read, or re-introduce local JSON
-  data files (e.g. question banks, curriculum files, `users.json`) as data
-  stores. Runtime repositories are SQL-backed only (`app/repositories/`).
-- **No file-repository work.** Never add or migrate a file-backed repository
-  into the codebase. Seed/bootstrap operations write to the database.
-- **TDD always.** Every code change must be driven by a failing test first
-  (red → green), with tests asserting the DB-backed behavior.
-- If a local JSON export is ever used to bootstrap content, it must be
-  transient and deleted after the database sync (see
-  `backend/scripts/sync_local_to_db.py`), never kept as a runtime store.
+- **Red:** Write a failing test that asserts the new behavior. Run it and watch
+  it fail for the right reason.
+- **Green:** Implement the smallest change that makes the test pass.
+- **Refactor:** Clean up the implementation while keeping the tests green.
+- **Bugs are regressions:** A bug fix starts with a test that reproduces the bug
+  and fails before the fix. No test → no fix.
+- **Coverage gates:** Never weaken an existing assertion to make a test pass.
+  Keep the whole suite green before finishing any change.
+- If a task is genuinely test-only or docs-only, say so explicitly; otherwise
+  the TDD loop applies to **all** source changes (backend, frontend, scripts,
+  configs that affect behavior).
+
+## MANDATORY: Supabase Is the Only Database
+
+**Hard rule — Do NOT skip.** Supabase (managed PostgreSQL) is the ONLY database
+used by this application. No other database may be introduced, connected,
+migrated, or shipped — for production, development, or tests.
+
+- **Allowed:** Supabase-hosted PostgreSQL (`postgresql://` / `postgresql+asyncpg://`
+  against the Supabase project). Migrations and schema live on Supabase.
+- **Forbidden:** MySQL, MariaDB, SQLite, local/self-hosted PostgreSQL, DynamoDB,
+  MongoDB, or any other store. Do not add new `mysql://` / `sqlite://` URLs,
+  drivers, or dialect branches. Legacy MySQL-compatibility code paths are dead
+  weight and must be removed, not extended.
+- **Forbidden as runtime stores:** local JSON files, filesystem directories,
+  in-memory caches that persist business data. Runtime repositories are SQL-only
+  (`app/repositories/`) against Supabase.
+- **Tests:** use an isolated Supabase schema (e.g. `codecoach_test`) pointed at
+  by `DATABASE_URL` + `DATABASE_SEARCH_PATH`. Tests never read/write the
+  production schema.
+- **Seeding / bootstrap:** one-off scripts write to the database, never to
+  runtime files. Local JSON is at most a transient bootstrap source and is
+  deleted after the sync (see `backend/scripts/sync_local_to_db.py`).
 
 ## MANDATORY: Graphify-First Codebase Exploration
 
@@ -67,6 +89,63 @@ on the staged diff, fix ALL findings (bug:, risk:, and nit:), and re-stage befor
 - Applies to ALL commits — source code, configs, tests, everything
 - Pre-commit hooks (ruff, prettier, standard hygiene) run automatically on `git commit` — fix any hook failures before force-committing
 
+## Engineering Best Practices
+
+Follow the existing layered architecture and conventions of this codebase:
+
+- **Layers:** API (`app/api/`) → services (`app/services/`) → repository ports
+  (`app/ports/`) → SQL implementations (`app/repositories/sql_*`). Persistence
+  stays behind repository ports; business logic lives in services, not routes.
+- **Dependency injection:** resolve services/repositories via `app/api/dependencies.py`
+  dependency functions; do not reach into singletons or globals from routes.
+- **Schemas:** request/response models are Pydantic schemas (`app/models/`);
+  validate at the boundary. Keep ORM models and API schemas distinct.
+- **Async SQL:** use the async engine / `async_session_maker` in
+  `app/core/database.py`. Never open blocking DB connections on the event loop.
+- **Never block on external AI/code-execution calls synchronously in hot paths;**
+  use the existing service wrappers (e.g. `groq_service`, `piston_service`) and
+  degrade gracefully when providers fail.
+- **Config:** read settings from `app/core/config.py` (`get_settings()`); no
+  hard-coded secrets, URLs, or API keys in source. Secrets come from `.env` /
+  environment only and are never committed or logged.
+- **Idempotent mutations:** seed/sync/upsert operations must be safe to re-run
+  and never destroy unrelated rows.
+- **Small, focused changes:** keep PRs reviewable; preserve API contracts and
+  error semantics (HTTPException → 4xx, 5xx handled by the global handler).
+
+## Testing & Quality Gates
+
+The full suite must pass before any commit. Run the same gates CI runs.
+
+**Backend (`backend/`):**
+
+- Install: `pip install -r requirements.txt -r tests/test_requirements.txt`
+- Lint + format: `ruff check .` and `ruff format . --check`
+- Unit: `python -m pytest tests/unit`
+- Integration: `python -m pytest tests/integration` (needs `DATABASE_URL` pointed
+  at an isolated Supabase schema; see `tests/conftest.py`)
+- Contract: `python -m pytest tests/contract` (OpenAPI response contracts)
+- Security: `python -m pytest tests/security`
+- Performance: `python -m pytest tests/performance`
+- Migrations: `python -m pytest tests/migrations`
+
+**Frontend (`frontend/`):**
+
+- Install: `pnpm install`
+- Lint: `pnpm lint`
+- Typecheck: `pnpm typecheck` (`tsc --noEmit`)
+- Unit/component tests: `pnpm test:run` (Vitest + Testing Library + MSW)
+- E2E: `pnpm test:e2e` (Playwright)
+
+**Process:**
+
+- TDD first (see above). No new code without a new or extended test.
+- Coverage floors are enforced by `qa/enforce_coverage_budget.py` in CI —
+  don't ship changes that drop module coverage below budget.
+- Flaky tests are quarantined via `backend/tests/enforce_flaky_quarantine.py`;
+  a test that fails intermittently belongs in the quarantine manifest, not the
+  committed suite.
+
 ## graphify
 
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
@@ -81,174 +160,19 @@ Rules:
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
 
-## Session Context — May 26, 2026
+## Current Architecture (reference)
 
-### Phase 2 Complete (Steps 1–9)
+- **Backend:** FastAPI + async SQLAlchemy against Supabase/PostgreSQL. Pydantic
+  schemas, repository ports with `sql_*` implementations, service layer,
+  dependency-injected routes in `app/api/`. Auth via Supabase + JWT; code
+  execution via Piston; AI coaching via Groq/NIM.
+- **Frontend:** Next.js 14 (App Router) + TypeScript + Tailwind, shadcn-style
+  components, Supabase client auth, Vitest + Testing Library + MSW for unit tests,
+  Playwright for E2E. Cloudflare Workers deployment via OpenNext.
+- **Infra:** Docker Compose (backend, frontend, redis, piston), GitHub Actions CI
+  running lint/format + all test tiers + coverage budget enforcement.
+- **Data:** questions, courses/modules/lessons, users, progress, usage/rate-limit
+  events, and admin data all live in Supabase. See `backend/docs/CURRICULUM_DEPLOYMENT.md`.
 
-Programming language curriculum (C, Python, Java) for CodeCoach AI:
-
-**Backend:**
-
-- Course/Module/Lesson schemas (`course_schemas.py`), ports, file repos, service layer
-- REST APIs: courses list/detail, lesson detail, progress tracking
-- Seed data: 3 courses, 9 modules, 27 lessons (18 theory + 9 exercises with test cases)
-- AI coaching: `lesson_context` injected into NIM system prompts (6 new tests)
-
-**Frontend:**
-
-- `/learn` dashboard, `/[courseId]` module tree, `/lesson/[lessonId]` viewer
-- Monaco editor for exercises, AI Coach panel with lesson-aware prompts
-- Header "Learn" nav link (desktop + mobile)
-- Hooks: `useCurriculum`, `useCourse`, `useLesson`
-
-**Content Pipeline:**
-
-- `generate_curriculum.py` — NIM-powered generation (tested)
-- `verify_curriculum.py` — 3-round AI quality gate (8 tests)
-
-**Testing:** 40 tests total across coaching prompts, generator, verifier.
-
-### Phase 1 Cleanup Complete (May 26, 2026)
-
-1. Patched `verify_and_populate.py` with `--rejected` flag for `rejected_questions.json` format
-2. Re-evaluated 87 rejected questions through 4-round AI quality gate — **0 passed** >90 threshold
-3. Fixed Python 3.14 bytes serialization bug in `app/main.py:47`
-4. Fixed outdated test assertion in `test_generate_questions.py` ("EXACTLY 20" → "EXACTLY 12")
-5. Added 2 new tests for `load_existing_questions` rejected_key support (48→50 script tests)
-6. Expanded E2E tests from 10 to **19 tests** across 4 Playwright spec files
-
-### Phase 2 Step 10 Complete
-
-- E2E testing: 19 Playwright tests (auth-flow, homepage, user-flow, curriculum-flow)
-- All suites passing: 264 backend unit, 50 script, 297 frontend, 19 E2E, TypeScript clean
-
-### Session Context — May 28, 2026 (Afternoon)
-
-- **Question Generation:** 18 questions across 12/14 DSA topics (API timeouts limited generation)
-- **Graphify Updated:** 2689 nodes, 4558 edges, 265 communities
-- **Documentation:** Updated Progress.md, README.md, Phase1.md with current question counts
-- **Status:** Generation pipeline working but API-bound (~20-30s per question with 70B model)
-
-### Bug Fix Session — Questions Not Loading (May 28, 2026)
-
-**Problem:** Newly AI-generated questions weren't appearing in the frontend. Backend returned empty list.
-
-**Root cause:** 3 interacting bugs:
-
-1. `@lru_cache()` on `get_questions_service()` cached stale data — never re-read from disk
-2. No try/except in `FileQuestionRepository._load()` — one malformed question crashed all 18
-3. Pydantic schemas too strict for NIM generator output (dict values where strings expected)
-
-**Fixes:**
-
-- Removed `@lru_cache()` from questions API — fresh service per request
-- Added try/except per question in `_load()` — malformed questions skipped, valid ones load
-- Made `TestCase`, `Example`, `StarterCode`, `Question` schemas accept `Union[str, Dict, List, int, None]` with auto-conversion to string
-- Fixed pre-existing bugs: HTTPException swallowed by generic handler (400→500), test asserting non-existent company names
-
-**Result:** All 18 questions load successfully. Backend: 296 tests pass (1 pre-existing async client error). Frontend now displays all questions.
-
-**Created:** `Issues.md` documenting all 5 issues (I1-I5).
-
-**Key lesson:** NIM generator and Pydantic schemas were developed independently — need schema validation tests for generated output to catch drift early.
-
-### Session Context — May 28, 2026 (Google Gemini Question Generation)
-
-**Problem:** NVIDIA NIM API kept timing out (120s+ for 70B model), limiting generation to 18 questions.
-
-**Solution:** Switched to Google Gemini as primary provider with model fallback chain.
-
-**Changes to `backend/scripts/generate_questions.py`:**
-
-- Added `call_google_async()` with JSON mode (`responseMimeType: application/json`)
-- Added `RateLimiter` class (15 RPM default for free tier)
-- Refactored into single clean async function (removed duplicate `generate_questions`, fixed `completed_labels` tracking, added provider dispatch)
-- Made `httpx` import module-level (was local in sync function)
-- Added model fallback chain on 429/errors: `gemini-2.5-flash-lite` → `gemini-3.1-flash-lite` → `gemini-3.5-flash`
-- Relaxed pre-validation thresholds: 8 test cases / 3 hidden / 2 constraints (was 12/4/3) — lite models output slightly fewer
-
-**Results:**
-
-- Generated 18 new questions (6 easy + 7 medium + 5 hard) across 14 topics — 36 total in bank
-- Generation time: ~5-10s per batch (vs 120s+ for NVIDIA NIM)
-- Fallback chain works: `gemini-2.5-flash-lite` exhausted → auto-falls to `gemini-3.1-flash-lite`
-
-**Key insight:** Different models have separate quota buckets. Using a fallback chain (comma-separated `--model`) maximises free tier throughput. Threshold: 90 questions (currently 36).
-
-**Usage:** `python generate_questions.py --provider google --concurrency 2 --questions-per-topic 6`
-
-### Session Context — May 29, 2026 (Suite Runner Bug Fixes)
-
-**Problem:** 4 root-cause bugs in `piston_service.py` causing suite-runner failures:
-
-1. **In-place functions** (`rotate-image`, `next-permutation`): return `None` → runner compares `"None"` to expected matrix → always fails.
-2. **5-param AI question** (`e42b2609-...`): JSON dict fed but function expects 5 positional args → `TypeError`.
-3. **Signal 6 crash**: `_parse_suite_output` ignored `exec_result.signal`; SIGABRT silenced.
-4. **JS `fs` redeclaration**: Both runner template and `JavaScriptCodeWrapper.wrap()` add `const fs = require('fs')` → `SyntaxError`.
-
-**Fixes:**
-
-- `__run_test` returns `(output, input_value)` tuple; `None` → serialize input_value
-- AI question inputs converted to `\n`-separated 5-line format; `*parsed_args` / `...parsedArgs` spread
-- Added `signal_info` to `_parse_suite_output` error paths
-- Removed `const fs` from JS runner template; added `process.stdout.write` to wrapper bypass list
-- **Bonus fixes:** Java `json.dumps` bare generator → list comprehension; `stdout=None` guard
-
-**Tests added:** 62 new tests across 5 files (32 suite_runners, +28 code_wrappers, +15 piston_service, +4 formatter, +18 submit_endpoints).
-
-**Graphify Updated:** 3149 nodes, 5391 edges, 311 communities.
-
-**Relevant files:**
-
-- `backend/app/services/piston_service.py` — all 4 bugs fixed; `stdout=None` guard; `process.stdout.write` bypass
-- `backend/questions/sample_questions.json` — AI question inputs converted to multi-line
-- `backend/tests/unit/test_suite_runners.py` — 49 new tests (runners + parser + integration)
-- `backend/tests/unit/test_code_wrappers.py` — +28 tests
-- `backend/tests/unit/test_piston_service.py` — +15 tests
-- `backend/tests/unit/test_execution_result_formatter.py` — +4 tests
-- `backend/tests/integration/test_submit_endpoints.py` — +18 tests
-
-### Session Context — June 27, 2026 (Admin Panel Bug Fixes)
-
-**Problem:** Admin panel showed empty data (0 users, 0 questions) and some pages loading forever.
-
-**Root causes (2 interacting bugs):**
-
-1. **Token format mismatch:** `AuthProvider` stores token with `JSON.stringify()` but admin pages read with bare `localStorage.getItem()` (no `JSON.parse()`) → JWT had literal surrounding quotes → backend rejected with 401 → silent catch blocks → empty UI. Fixed by replacing all `localStorage.getItem('auth_token')` with `token` from `useAuth()` context across 9 admin pages plus adding `token` to relevant dependency arrays.
-
-2. **Next.js rewrite resolution in Docker:** `next.config.js` rewrites `http://localhost:8000/api/:path*` → `localhost:8000` resolves to the frontend container itself inside Docker (not the backend). Next.js serializes rewrite destinations at **build time** into `routes-manifest.json`, so runtime `API_URL` env var was ignored. Fixed by adding `ENV API_URL=http://backend:8000` to Dockerfile **before** `npm run build`.
-
-**Other fixes:**
-
-- `file_admin_repository.py: _load_courses()`: routes `course.json`→courses, `modules.json(items)`→modules, `lessons.json(items)`→lessons (was dumping all JSON files into courses array)
-- `admin.py: get_course_tree()`: removed double-wrap `{"courses": tree}` → returns `tree` directly
-- Settings page: `setSettings(await res.json())` instead of `setSettings((await res.json()).settings || {})`
-- Removed Generation and Feature Flags nav items + unused `Play`/`Shield` icons from `AdminSidebar.tsx`
-- Deleted `backend/data/courses/` directory (preserved `users.json`, `user_progress.json`)
-- Added `API_URL=http://backend:8000` runtime env to `docker-compose.yml` frontend service
-
-**Validation:** `curl http://localhost:3000/api/admin/stats` returns valid JSON with correct user question counts. All admin pages return HTTP 200.
-
-**Key lesson:** Next.js serializes rewrite destinations from `next.config.js` at build time into `routes-manifest.json`. Runtime `process.env` values are not used for rewrites after build. Dockerfile must set `ENV API_URL=http://backend:8000` before `npm run build`.
-
-### Session Context — July 8, 2026 (Bug Fix Sprint — 17 failures → 0)
-
-**Fixes applied (5 bugs + 1 infrastructure):**
-
-1. **`get_adjacent_lessons` returning 500 instead of 404** (`courses.py`): The `except Exception` catch-all was swallowing the `HTTPException(404)` raised for nonexistent lessons. Added `except HTTPException: raise` before the generic handler.
-
-2. **`ExecutionResult` calls `model_dump()` on a dataclass** (`piston_service.py`): `ExecutionResult` is a dataclass, not a Pydantic model. Replaced `result.model_dump()` with `dataclasses.asdict(result)`; added `import dataclasses`.
-
-3. **`validate_code` references wrong variable** (`run.py`): Used `request.language.value` where `request` is the FastAPI `Request` object (for rate limiting), not the `CodeExecutionRequest`. Fixed to `execution_request.language.value`.
-
-4. **`app.dependency_overrides.clear()` nukes all overrides globally** (7 test files): Using `clear()` in one test's `finally` block removes overrides set by other tests' `mock_auth()` contextmanagers, causing 401s/breakage in subsequent tests. Replaced all `clear()` with `pop(specific_key, None)` across 7 files (coach, run, submit, auth, questions, question_validation, admin curriculum endpoints).
-
-5. **Rate limit exceeded in coach tests** (`rate_limit.py`): `COACH_RATE_LIMIT` was evaluated at import time as a static string. Test env var override ran too late (after module import). Changed to lazy callable via `_rate_limit(env_key, default)` — reads `os.getenv` at request time instead of import time. Tests updated to call `COACH_RATE_LIMIT()`.
-
-6. **Redis cache raises on connection error** (`redis_service.py`): `aioredis.RedisError` didn't catch `OSError` (socket-level `getaddrinfo` failures). Changed all `except aioredis.RedisError` to `except Exception` and `logger.warning` to `logger.debug` so Redis failures degrade silently. Wrapped `await client.aclose()` in `try/except`.
-
-**Graphify Updated:** (N/A — no structural changes)
-
-**Test results:** 669/669 pass (0 failures). Full suite: backend unit + integration + performance + security.
-
-**Key lesson:** `app.dependency_overrides` is a global mutable dict shared across all tests in a session. Never use `clear()` — always `pop()` the specific key you added. Rate limit config strings should be lazy (callables or `@limiter.limit` with deferred resolution) when env vars are set by test fixtures that run after module import.
+**Historical session notes** from older phases have been removed from this file;
+if you need the project's changelog, see `Progress.md`, `Phase1.md`, and `Issues.md`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,6 +7,7 @@ GROQ_API_KEY=your_groq_api_key_here
 # GROQ_MODEL_MEDIUM=llama-3.3-70b-versatile
 # GROQ_MODEL_HARD=llama-3.3-70b-versatile
 # GROQ_MODEL_STREAM=llama-3.1-8b-instant
+# GROQ_MODEL_ANIMATE=llama-3.3-70b-versatile
 
 # Per-user daily token caps (optional — defaults shown)
 # DAILY_TOKEN_INPUT_CAP=250000

--- a/backend/app/adapters/coaching_prompts.py
+++ b/backend/app/adapters/coaching_prompts.py
@@ -5,7 +5,7 @@ selection, and lesson context injection are internal details.
 """
 
 import json
-from typing import Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 
 # ── Constants (internal) ──────────────────────────────────────────────
@@ -50,36 +50,29 @@ You MUST respond with ONLY a valid JSON object. No text before or after.
 }
 
 ## Animation Contract
-When the problem involves an algorithm over an array and the code is present, generate an "animation" object so the student can watch the algorithm run. Otherwise set "animation": null.
+When the problem involves an algorithm and the code is present, generate an "animation" object so the student can watch the algorithm run. Otherwise set "animation": null.
 
-Animation shape:
+The animation is a fully data-driven declarative scene — no fixed animation types. Author the subject AND the algorithm visuals yourself for the question in the input:
+
 {
-    "type": "linear_search",
     "title": "Searching for 4",
-    "data": {
-        "values": [5, 1, 2, 3, 4, 5],
-        "target": 4
-    },
+    "data": { "values": [5, 1, 2, 3, 4, 5], "target": 4 },
     "steps": [
         {
-            "operation": "compare",
-            "index": 0,
-            "value": 5,
-            "result": "mismatch",
-            "narration": "5 is not the target, continue searching."
+            "narration": "5 is not the target, continue searching.",
+            "shapes": [ { "id": "cell_0", "type": "rect", "x": -240, "y": 0, "width": 88, "height": 88, "radius": 12, "fill": "#1e293b", "stroke": "#334155" } ],
+            "motion": [ { "target": "cell_0", "op": "appear", "duration": 0.3 } ]
         }
     ]
 }
 
 Animation rules:
-1. ONLY support "linear_search" for now — the student's code must implement linear search (scanning the array element by element comparing to a target).
-2. "values" MUST come from the problem statement or the student's own test data — never invent runtime results. If no concrete array exists, set "animation": null.
-3. Use the real values from the array; the target is the value being searched for.
-4. Emit exactly one step per comparison: operation "compare", the current index, the value at that index, result "mismatch" until the match, then "match".
-5. A "match" step MUST have result "match" and its value must equal the target. A "mismatch" step MUST NOT equal the target.
-6. Never emit indexes outside the array bounds. Keep the array small (<= 50 values) and the trace short (<= 200 steps).
-7. Write a short human narration for every step (under 300 characters).
-8. This is DATA, not code — never return JavaScript, JSX, or CSS. No executable instructions.
+1. Shapes are vector primitives with a unique "id" and a "type" of: "rect" (needs width/height), "ellipse" (needs width/height), "line" or "polygon" (need points), or "text" (needs text and fontSize). Optional: x/y (between -960..960 / -540..540), fill/stroke (#rrggbb hex), lineWidth, opacity, radius.
+2. Motion ops have a "target" (a shape id), an "op" of: appear, disappear, move ([x,y]), fill or stroke (hex), scale, rotate, plus a "duration" (0.1-5s).
+3. "values" MUST come from the problem statement or the student's own test data — never invent runtime results. If no concrete data exists, set "animation": null.
+4. Build the scene step by step so the student watches the algorithm solve the question: cells appear, a pointer moves, colors change, matches highlight. Write a short narration for every step (under 300 characters).
+5. At most 100 steps, 60 shapes total, 20 shapes and 30 motion ops per step.
+6. This is DATA, not code — never return JavaScript, JSX, SVG markup, or CSS. No executable instructions.
 
 ## Rules
 1. ALL 9 fields must be present in every response
@@ -155,7 +148,108 @@ _MODE_SECTIONS = {
 - summary: Main answer
 - Use other fields as appropriate for the question""",
     },
+    "animate": {
+        "unstructured": """### 6. Animate (mode: animate)
+- Produce a step-by-step animation of the OPTIMAL SOLUTION solving the problem
+- Always animate the intended optimal solution for the question — never the student's typed code
+- Return declarative animation data only — never executable code""",
+        "structured": """**animate mode:**
+- summary: Brief description of the animation that follows
+- animation: REQUIRED — follow the Animate Mode Contract below
+- Other fields: null or []""",
+    },
 }
+
+_ANIMATE_CONTRACT = """## Animate Mode Contract
+The user pressed "Animate". The response MUST include a non-null "animation" object — returning "animation": null is FORBIDDEN in animate mode. Build a fully data-driven declarative scene: the animation VISUALLY SOLVES the problem for the question in the input, so the student watches how the algorithm works. Every scene is generated fresh from THIS question — real values from its examples/test cases, real target, and a vector subject that reflects what the question is about.
+
+NON-NEGOTIABLE OUTPUT RULE: You MUST include a non-null "animation" object. The animation always shows the OPTIMAL solution for the question — the student's typed code is never inspected, compared, or animated. "animation": null is a hard error.
+
+### Generic Scene Contract
+The "animation" is declarative VECTOR data. The viewer builds shapes from this data and plays the motion timeline step by step. There are NO predefined animation types or subject catalogs — you author the subject and the algorithm visuals yourself for each question.
+
+WORKED EXAMPLE — a linear search for 4 in [5,1,2,3,4]. Study how the pointer MOVES every step; this is the shape your output must take:
+{
+    "title": "Searching for 4",
+    "data": { "values": [5, 1, 2, 3, 4], "target": 4 },
+    "steps": [
+        {
+            "narration": "Start at index 0 — the value is 5.",
+            "shapes": [
+                { "id": "cell_0", "type": "rect", "x": -240, "y": 0, "width": 88, "height": 88, "radius": 12, "fill": "#1e293b", "stroke": "#334155", "text": "5" },
+                { "id": "cell_1", "type": "rect", "x": -120, "y": 0, "width": 88, "height": 88, "radius": 12, "fill": "#1e293b", "stroke": "#334155", "text": "1" },
+                { "id": "cell_2", "type": "rect", "x": 0, "y": 0, "width": 88, "height": 88, "radius": 12, "fill": "#1e293b", "stroke": "#334155", "text": "2" },
+                { "id": "cell_3", "type": "rect", "x": 120, "y": 0, "width": 88, "height": 88, "radius": 12, "fill": "#1e293b", "stroke": "#334155", "text": "3" },
+                { "id": "cell_4", "type": "rect", "x": 240, "y": 0, "width": 88, "height": 88, "radius": 12, "fill": "#1e293b", "stroke": "#334155", "text": "4" },
+                { "id": "ptr", "type": "polygon", "points": [[-12, -30], [0, -60], [12, -30]], "x": -240, "y": -80, "fill": "#facc15" }
+            ],
+            "motion": [
+                { "target": "cell_0", "op": "appear", "duration": 0.2 },
+                { "target": "cell_1", "op": "appear", "duration": 0.2 },
+                { "target": "cell_2", "op": "appear", "duration": 0.2 },
+                { "target": "cell_3", "op": "appear", "duration": 0.2 },
+                { "target": "cell_4", "op": "appear", "duration": 0.2 },
+                { "target": "ptr", "op": "appear", "duration": 0.2 }
+            ]
+        },
+        {
+            "narration": "5 is not the target — move the pointer to index 1.",
+            "motion": [ { "target": "ptr", "op": "move", "to": [-120, -80], "duration": 0.4 } ]
+        },
+        {
+            "narration": "1 is not the target — move the pointer to index 2.",
+            "motion": [
+                { "target": "cell_1", "op": "fill", "to": "#334155", "duration": 0.2 },
+                { "target": "ptr", "op": "move", "to": [0, -80], "duration": 0.4 }
+            ]
+        },
+        {
+            "narration": "2 is not the target — move the pointer to index 3.",
+            "motion": [ { "target": "ptr", "op": "move", "to": [120, -80], "duration": 0.4 } ]
+        },
+        {
+            "narration": "3 is not the target — move the pointer to index 4.",
+            "motion": [ { "target": "ptr", "op": "move", "to": [240, -80], "duration": 0.4 } ]
+        },
+        {
+            "narration": "Found 4 at index 4 — highlight the match.",
+            "motion": [
+                { "target": "cell_4", "op": "fill", "to": "#14532d", "duration": 0.3 },
+                { "target": "cell_4", "op": "stroke", "to": "#22c55e", "duration": 0.3 }
+            ]
+        }
+    ]
+}
+Notice: every step after the first moves the pointer or recolors a cell — never just fade a shape in and stop.
+
+### Shapes (add to a step's "shapes" list)
+Each shape has an "id" (unique across the whole animation) and a "type":
+- "rect": requires "width" and "height"; optional "radius" for rounded corners; optional "text" to render a value inside the cell.
+- "ellipse": requires "width" and "height".
+- "line": requires "points" = [[x, y], [x, y], ...] (at least 2).
+- "polygon": requires "points" = [[x, y], [x, y], ...] (at least 2, a closed shape).
+- "text": requires "text" (non-empty string) and "fontSize".
+Every shape takes optional "x"/"y" (center position), "fill"/"stroke" (#rrggbb hex), "lineWidth", "opacity" (0-1).
+
+### Motion ops (add to a step's "motion" list)
+Each op has "target" (a shape id added in this step or an earlier step), "op", optional "to", and "duration" (0.1-5 seconds):
+- "appear": fade the shape in. "disappear": fade it out.
+- "move": "to" = [x, y] new position.
+- "fill": "to" = #rrggbb hex fill color. "stroke": "to" = #rrggbb hex stroke color.
+- "scale": "to" = positive number. "rotate": "to" = degrees.
+
+### Scene rules
+1. Coordinates: x between -960 and 960, y between -540 and 540. Point offsets within -2000 and 2000.
+2. Use the REAL data from the question input: values from its examples or test cases, the real target, the real subject the question describes (e.g. cars for a Car Fleet question, an array of cells for a Two Sum question, two code panels for a code comparison). Never invent runtime results.
+3. Build the scene step by step so each step advances the algorithm: cells appear, a pointer moves, colors change (e.g. checking → match), values highlight. Write narration that explains each step.
+4. Richness floor: produce at least 3 steps (aim for 5-10). Every step must move the algorithm forward — show the real data values from the examples/test cases and advance a pointer, scan index, or loop position each step. A static frame, a single shape, or a step with no motion is a failure.
+5. Always animate the OPTIMAL solution for the question. Never compare against the student's typed code — it is irrelevant to the animation.
+6. Caps: at most 100 steps, 60 shapes total, 20 shapes and 30 motion ops per step, 64 chars per id.
+7. This is DATA, not code — never return JavaScript, JSX, SVG markup, or CSS. Shapes and motions are plain JSON objects only.
+8. Define every shape exactly once — in the step where it first appears. Never repeat a shape id in a later step. Later steps only animate existing shapes via motion ops (move/fill/stroke/scale/rotate).
+9. A step that ONLY appears/disappears shapes is a static frame and is REJECTED by the validator. Every step after the first MUST include at least one transform op — move, fill, stroke, scale, or rotate — on an existing shape, so the animation visibly moves forward. Fading a shape in is not animation.
+10. Include a dedicated pointer or scan-marker shape (e.g. a small triangle or highlighted cell) that MOVES to each position the algorithm visits. The viewer must see motion every step: a pointer sliding, a cell changing color, a shape scaling. If your scene has no moving pointer or changing colors, it is a failure.
+"""
 
 
 # ── Deep module ───────────────────────────────────────────────────────
@@ -174,10 +268,21 @@ class PromptBuilder:
         message: str,
         structured: bool = False,
         lesson_context: Optional[str] = None,
+        initial_code: Optional[str] = None,
+        question: Optional[Dict[str, Any]] = None,
     ) -> Tuple[str, str]:
         """Return (system_prompt, user_prompt) for the given coaching request."""
         system = self._build_system(mode, language, structured, lesson_context)
-        user = self._build_user(problem, code, message, mode, structured, language)
+        user = self._build_user(
+            problem,
+            code,
+            message,
+            mode,
+            structured,
+            language,
+            initial_code,
+            question,
+        )
         return system, user
 
     # ── Internal: system prompt ───────────────────────────────────────
@@ -208,6 +313,10 @@ class PromptBuilder:
             parts.append(ctx)
 
         parts.append(_GENERAL_GUIDELINES)
+
+        if structured and mode == "animate":
+            parts.append(_ANIMATE_CONTRACT)
+
         return "\n\n".join(parts)
 
     def _mode_section(self, mode: str, structured: bool) -> str:
@@ -238,6 +347,8 @@ Connect the student's current struggle back to the lesson's main objective."""
         mode: str,
         structured: bool,
         language: str = "",
+        initial_code: Optional[str] = None,
+        question: Optional[Dict[str, Any]] = None,
     ) -> str:
         if structured:
             user_data = {
@@ -248,6 +359,15 @@ Connect the student's current struggle back to the lesson's main objective."""
             }
             if language:
                 user_data["language"] = language
+            if initial_code is not None:
+                user_data["initial_code"] = initial_code
+            if question:
+                # Hidden test cases are curriculum secrets and must never reach
+                # a third-party model. Keep the visible context (title,
+                # description, examples, constraints) the scene needs.
+                prompt_question = dict(question)
+                prompt_question.pop("test_cases", None)
+                user_data["question"] = prompt_question
             return json.dumps(user_data, indent=2)
         suffix = "Please provide helpful coaching feedback."
         return f"""Problem: {problem}

--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
+from pydantic import ValidationError
 from typing import AsyncIterator, Optional
 import asyncio
 import json
@@ -7,14 +8,23 @@ import logging
 import os
 import time
 
-from app.models.schemas import CoachingRequest, CoachingResponse, CoachingMode, Language
+from app.models.schemas import (
+    CoachingRequest,
+    CoachingResponse,
+    CoachingMode,
+    Language,
+    AnimateRequest,
+    AnimateResponse,
+)
 from app.ports.coaching_provider import CoachingProvider
+from app.ports.code_executor import CodeExecutor
 from app.services.groq_service import GroqService
 from app.services.redis_service import RedisCache
 from app.services.usage_service import UsageService, check_caps, usage_headers
+from app.services.solution_animation_service import SolutionAnimationService
 from app.api.auth_deps import require_premium
 from app.api.daily_limits import enforce_daily_request_cap
-from app.api.dependencies import get_redis_cache, get_usage_service
+from app.api.dependencies import get_redis_cache, get_usage_service, get_executor
 from app.models.auth_schemas import UserResponse
 from app.middleware.rate_limit import limiter, COACH_RATE_LIMIT
 
@@ -123,6 +133,7 @@ async def get_coaching(
             difficulty=coaching_request.difficulty.value,
             lesson_context=coaching_request.lesson_context,
             chat_history=chat_history_list,
+            initial_code=coaching_request.initial_code,
         )
 
         raw_response = _format_structured_as_text(structured_data)
@@ -152,6 +163,92 @@ async def get_coaching(
         logger.error("=======================")
         raise HTTPException(
             status_code=500, detail=f"Error generating coaching response: {str(e)}"
+        )
+
+
+@router.post("/animate", response_model=AnimateResponse)
+@limiter.limit(COACH_RATE_LIMIT)
+async def get_animation(
+    request: Request,
+    response: Response,
+    animate_request: AnimateRequest,
+    provider: CoachingProvider = Depends(get_coaching_provider),
+    executor: CodeExecutor = Depends(get_executor),
+    user: UserResponse = Depends(require_premium),
+    _usage_guard: None = Depends(check_daily_token_cap),
+    _rate_guard: None = Depends(enforce_user_rate_limit),
+    _daily_guard: None = Depends(enforce_daily_request_cap),
+):
+    """
+    Generate a visual algorithm animation for the standalone Animate viewer.
+
+    Unlike /api/coach/, this endpoint returns only a validated animation
+    script — never a chat response. The animation is generated from the
+    canonical optimal solution for the question (executed against the first
+    public example), never from the user's typed code. The frontend plays it
+    back as a Motion Canvas animation in a dedicated window, completely
+    separate from the AI Coach chat panel.
+    """
+    try:
+        # Preferred path: execute the question's canonical optimal solution
+        # against examples[0].input and compile its trace into the animation.
+        # The user's code is never used here.
+        animation = None
+        if animate_request.question is not None:
+            try:
+                animation = await SolutionAnimationService(
+                    executor=executor
+                ).build_animation(
+                    question=animate_request.question.model_dump(),
+                )
+            except Exception as e:  # defensive: trace path must never 500
+                logger.warning("Trace animation failed, using fallback: %s", e)
+
+        # Fallback for questions without a curated canonical solution.
+        if animation is None:
+            animation = await provider.get_animation_script(
+                problem=animate_request.problem,
+                code=animate_request.code,
+                language=animate_request.language.value,
+                difficulty=animate_request.difficulty.value,
+                lesson_context=animate_request.lesson_context,
+                initial_code=animate_request.initial_code,
+                question=(
+                    animate_request.question.model_dump()
+                    if animate_request.question
+                    else None
+                ),
+            )
+        if not animation:
+            raise HTTPException(
+                status_code=502,
+                detail="Failed to generate a valid animation for this problem.",
+            )
+
+        response.headers.update(getattr(request.state, "usage_headers", {}))
+        response.headers.update(getattr(request.state, "daily_limit_headers", {}))
+
+        try:
+            return AnimateResponse(animation=animation)
+        except ValidationError as exc:
+            # A scene that passed structural checks but fails the response
+            # schema is not renderable — treat it like any other failed
+            # generation (502) instead of surfacing a 500 with schema
+            # internals.
+            logger.warning("Animation failed response validation: %s", exc)
+            raise HTTPException(
+                status_code=502,
+                detail="Failed to generate a valid animation for this problem.",
+            ) from exc
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("=== COACH ANIMATE API ERROR ===")
+        logger.error(f"Error type: {type(e).__name__}")
+        logger.error(f"Error message: {str(e)}")
+        logger.error("===============================")
+        raise HTTPException(
+            status_code=500, detail=f"Error generating animation: {str(e)}"
         )
 
 
@@ -260,6 +357,7 @@ async def get_coaching_stream(
                 difficulty=coaching_request.difficulty.value,
                 lesson_context=coaching_request.lesson_context,
                 chat_history=chat_history_list,
+                initial_code=coaching_request.initial_code,
             ):
                 chunk_count += 1
                 # Format as SSE
@@ -312,6 +410,7 @@ async def get_coaching_modes(
             CoachingMode.EXPLAIN.value: "Get explanations of concepts or approaches",
             CoachingMode.DEBUG.value: "Get help debugging your code",
             CoachingMode.FREEFORM.value: "Ask any question and get a natural response",
+            CoachingMode.ANIMATE.value: "Animate the optimal solution for the problem",
         },
     }
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     GROQ_MODEL_MEDIUM: str = "llama-3.3-70b-versatile"
     GROQ_MODEL_HARD: str = "llama-3.3-70b-versatile"
     GROQ_MODEL_STREAM: str = "llama-3.1-8b-instant"
+    GROQ_MODEL_ANIMATE: str = "llama-3.3-70b-versatile"
 
     # Per-user token metering (daily caps)
     DAILY_TOKEN_INPUT_CAP: int = 250_000

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -22,6 +22,7 @@ class CoachingMode(str, Enum):
     EXPLAIN = "explain"
     DEBUG = "debug"
     FREEFORM = "freeform"
+    ANIMATE = "animate"
 
 
 class Language(str, Enum):
@@ -65,48 +66,98 @@ class CoachingRequest(BaseModel):
         max_length=20,
         description="Previous conversation messages for context",
     )
+    initial_code: Optional[str] = Field(
+        None,
+        max_length=50000,
+        description="Starter code the user began with, used to detect edits for animation",
+    )
+
+
+class SceneShape(BaseModel):
+    """One declarative vector shape in an animation scene (data, never code).
+
+    The AI supplies structured geometry only — the viewer instantiates Motion
+    Canvas nodes from this data and animates them per the motion timeline.
+    """
+
+    id: str = Field(
+        ..., max_length=64, description="Unique shape id referenced by motion ops"
+    )
+    type: Literal["rect", "ellipse", "line", "polygon", "text"] = Field(
+        ..., description="Kind of vector primitive to draw"
+    )
+    x: float = Field(0, description="Center/left x position")
+    y: float = Field(0, description="Center/top y position")
+    width: Optional[float] = Field(None, gt=0, description="Width (rect/ellipse)")
+    height: Optional[float] = Field(None, gt=0, description="Height (rect/ellipse)")
+    radius: Optional[float] = Field(None, ge=0, description="Corner radius (rect)")
+    points: Optional[List[List[float]]] = Field(
+        None, description="Vertex list (line/polygon)"
+    )
+    text: Optional[str] = Field(None, max_length=200, description="Text content (text)")
+    fontSize: Optional[float] = Field(None, gt=0, description="Font size (text)")
+    fill: Optional[str] = Field(
+        None, pattern=r"^#[0-9a-fA-F]{6}$", description="Hex fill color"
+    )
+    stroke: Optional[str] = Field(
+        None, pattern=r"^#[0-9a-fA-F]{6}$", description="Hex stroke color"
+    )
+    lineWidth: Optional[float] = Field(None, gt=0, description="Stroke width")
+    opacity: Optional[float] = Field(None, ge=0, le=1, description="Base opacity")
+
+
+class MotionOp(BaseModel):
+    """One tween applied to a shape in a step's timeline."""
+
+    target: str = Field(..., max_length=64, description="Shape id this op animates")
+    op: Literal[
+        "appear",
+        "disappear",
+        "move",
+        "fill",
+        "stroke",
+        "scale",
+        "rotate",
+        "label",
+    ] = Field(..., description="What the op does to the shape")
+    to: Optional[Any] = Field(
+        None,
+        description="Target: [x, y] for move, hex color for fill/stroke, number for scale/rotate",
+    )
+    duration: float = Field(0.3, gt=0, le=5, description="Tween duration in seconds")
 
 
 class AnimationStep(BaseModel):
-    """One frame of a declarative animation script.
+    """One frame of a declarative animation scene."""
 
-    The AI supplies structured data only — never executable code. The
-    frontend owns rendering, motion, and playback for every step.
-    """
-
-    operation: Literal[
-        "compare",
-        "visit",
-        "swap",
-        "move",
-        "insert",
-        "remove",
-        "mark",
-        "output",
-    ] = Field(..., description="What the frame does to the visualized data")
-    index: Optional[int] = Field(None, description="Primary index being acted on")
-    from_index: Optional[int] = Field(None, description="Source index (swap/move)")
-    to_index: Optional[int] = Field(None, description="Destination index (swap/move)")
-    value: Optional[Any] = Field(None, description="Value involved in the frame")
-    result: Optional[Literal["checking", "match", "mismatch", "complete"]] = Field(
-        None, description="Outcome of the operation for coloring purposes"
-    )
     narration: str = Field(
         default="",
         max_length=300,
         description="Human-readable narration for this frame",
     )
+    shapes: List[SceneShape] = Field(
+        default_factory=list, description="Shapes created in this step"
+    )
+    motion: List[MotionOp] = Field(
+        default_factory=list, description="Tweens applied to shapes this step"
+    )
 
 
 class AnimationScript(BaseModel):
-    """Declarative, validated animation script returned by the AI coach."""
+    """Declarative, validated animation scene returned by the AI coach.
 
-    type: str = Field(
-        ..., description="Algorithm kind, e.g. linear_search, bubble_sort"
+    A fully generic, data-driven scene: the model authors the subject and the
+    algorithm visuals as primitives (shapes) plus a per-step motion timeline.
+    No algorithm-type or subject-kind catalogs exist — every scene adapts to
+    the question that produced it.
+    """
+
+    title: str = Field(
+        default="", max_length=200, description="Short title shown above the animation"
     )
-    title: str = Field(default="", description="Short title shown above the animation")
     data: Dict[str, Any] = Field(
-        default_factory=dict, description="Input data the animation visualizes"
+        default_factory=dict,
+        description="Optional input data the scene references",
     )
     steps: List[AnimationStep] = Field(
         default_factory=list, description="Ordered frames of the animation"
@@ -146,6 +197,85 @@ class CoachingResponse(BaseModel):
     )
     mode: CoachingMode = Field(..., description="Coaching mode used")
     language: Language = Field(..., description="Programming language")
+
+
+class QuestionInput(BaseModel):
+    """Curated subset of a question sent to the animation generator.
+
+    The full question context (description, examples, test cases, constraints)
+    lets the model build scenes that reflect the actual problem — real values,
+    real target, real-world subject — instead of guessing from a title.
+    """
+
+    title: Optional[str] = Field(None, max_length=500, description="Question title")
+    description: Optional[str] = Field(
+        None, max_length=20000, description="Full problem description"
+    )
+    category: Optional[str] = Field(
+        None, max_length=100, description="Question category"
+    )
+    difficulty: Optional[str] = Field(
+        None, max_length=20, description="Question difficulty"
+    )
+    id: Optional[str] = Field(
+        None,
+        max_length=100,
+        description="Stable question id so the animation resolver pins the exact algorithm",
+    )
+    examples: List[Dict[str, Any]] = Field(
+        default_factory=list, description="Example test cases"
+    )
+    test_cases: List[Dict[str, Any]] = Field(
+        default_factory=list, description="Hidden test cases"
+    )
+    constraints: List[str] = Field(
+        default_factory=list, description="Problem constraints"
+    )
+    starter: Optional[Dict[str, Any]] = Field(
+        None, description="Starter code per language"
+    )
+
+
+class AnimateRequest(BaseModel):
+    """Request for the standalone algorithm-animation endpoint.
+
+    Unlike CoachingRequest this never carries chat history: the Animate
+    viewer is independent of the AI Coach conversation, so nothing from the
+    chat context is reused here.
+    """
+
+    problem: str = Field(
+        ..., max_length=20000, description="The coding problem description"
+    )
+    code: str = Field(..., max_length=50000, description="User's current code attempt")
+    language: Language = Field(..., description="Programming language")
+    difficulty: Difficulty = Field(
+        default=Difficulty.MEDIUM, description="Problem difficulty"
+    )
+    lesson_context: Optional[str] = Field(
+        None, max_length=2000, description="Lesson context for scoped animation"
+    )
+    initial_code: Optional[str] = Field(
+        None,
+        max_length=50000,
+        description="Starter code the user began with, used to detect edits for animation",
+    )
+    question: Optional[QuestionInput] = Field(
+        None,
+        description="Full question context so the scene reflects the actual problem",
+    )
+
+
+class AnimateResponse(BaseModel):
+    """Visual algorithm animation for the standalone Animate viewer.
+
+    This response intentionally has no chat text — it is played back as a
+    Motion Canvas animation in a dedicated window, never as a chat message.
+    """
+
+    animation: AnimationScript = Field(
+        ..., description="Validated visual algorithm animation"
+    )
 
 
 class CodeExecutionRequest(BaseModel):

--- a/backend/app/ports/coaching_provider.py
+++ b/backend/app/ports/coaching_provider.py
@@ -21,6 +21,7 @@ class CoachingProvider(ABC):
         difficulty: str = "medium",
         lesson_context: Optional[str] = None,
         chat_history: Optional[list] = None,
+        initial_code: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Return a structured coaching response as a dict."""
         ...
@@ -36,6 +37,26 @@ class CoachingProvider(ABC):
         difficulty: str = "medium",
         lesson_context: Optional[str] = None,
         chat_history: Optional[list] = None,
+        initial_code: Optional[str] = None,
     ) -> AsyncIterator[str]:
         """Yield streaming text chunks from the coaching backend."""
         ...  # pragma: no cover
+
+    async def get_animation_script(
+        self,
+        problem: str,
+        code: str,
+        language: str,
+        difficulty: str = "medium",
+        lesson_context: Optional[str] = None,
+        initial_code: Optional[str] = None,
+        question: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Return a standalone visual algorithm animation script.
+
+        Unlike get_structured this returns only the validated animation (no
+        chat text) for the dedicated Animate viewer. Returns None when a
+        valid animation could not be generated. Adapters that only support
+        text coaching may leave this unimplemented.
+        """
+        raise NotImplementedError  # pragma: no cover

--- a/backend/app/services/animation_compiler.py
+++ b/backend/app/services/animation_compiler.py
@@ -1,0 +1,537 @@
+"""Universal trace → scene compiler (the animation mechanism).
+
+Deterministically converts an ordered execution trace (from the canonical
+optimal solution) plus the array values into the generic AnimationScript
+contract the Motion Canvas viewer already renders. The mechanism is
+algorithm-agnostic: the model/AI never authors geometry — it only produces
+semantic events (compare/swap/pointer/write/mark/return) at runtime, and this
+module owns layout, colors, pointer arrows, swap crossings and narration.
+
+The output is always structurally validated by AnimationValidator so a bad
+compile can never reach the viewer. compile_animation returns None when the
+trace is unusable (no init event, empty, values too large to render).
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from app.services.trace_parser import TraceEvent
+
+logger = logging.getLogger(__name__)
+
+# ── layout ───────────────────────────────────────────────────────────────
+ROW_Y = 0.0
+PTR_DY = -78.0
+CELL = 88.0
+GAP = 12.0
+MAX_HALF_WIDTH = 900.0  # keep well inside the ±960 canvas bounds
+MIN_CELL = 24.0
+
+MAX_CELLS = 48  # 48 cells + 48 labels + ≤3 pointers stays under the 120-shape cap
+MAX_POINTERS = 3
+
+# ── colors ───────────────────────────────────────────────────────────────
+IDLE_FILL = "#1e293b"
+IDLE_STROKE = "#334155"
+CHECK_FILL = "#1d4ed8"
+CHECK_STROKE = "#3b82f6"
+SWAP_FILL = "#713f12"
+SWAP_STROKE = "#facc15"
+SORTED_FILL = "#14532d"
+SORTED_STROKE = "#22c55e"
+CHOSEN_FILL = "#3b0764"
+CHOSEN_STROKE = "#a855f7"
+WINDOW_FILL = "#1e3a8a"
+ACTIVE_FILL = "#312e81"
+TEXT_FILL = "#e2e8f0"
+
+# Pointer triangle drawn above the array, pointing down at a cell.
+PTR_POINTS = [[-14, -36], [0, -66], [14, -36]]
+
+
+class AnimationCompiler:
+    """Deterministic compiler from a normalized trace to an AnimationScript."""
+
+    def __init__(self, n: Optional[int] = None):
+        # Layout is derived from the number of cells; a pre-seeded n is allowed
+        # for tests that compute cell positions without running a full trace.
+        self._n = n
+        self._cell = CELL
+        self._spacing = CELL + GAP
+        if n is not None:
+            self._fit_cells(n)
+
+    def _fit_cells(self, n: int) -> None:
+        """Shrink cells so `n` of them fit inside the canvas half-width."""
+        available = 2 * MAX_HALF_WIDTH
+        cell = min(CELL, (available - (n - 1) * GAP) / n)
+        self._cell = max(cell, MIN_CELL)
+        self._spacing = self._cell + GAP
+
+    @property
+    def n(self) -> int:
+        return self._n or 0
+
+    def cell_x(self, index: int) -> float:
+        """Canvas x for the center of cell `index` (0-based, array centered)."""
+        total = self.n * self._cell + (self.n - 1) * GAP
+        start = -total / 2 + self._cell / 2
+        return round(start + index * self._spacing, 2)
+
+    def _fit_for_values(self, values: List[Any]) -> bool:
+        n = len(values)
+        if not 0 < n <= MAX_CELLS:
+            return False
+        self._n = n
+        self._fit_cells(n)
+        return True
+
+    # ── scene assembly ──────────────────────────────────────────────────
+
+    def _intro_steps(self, values: List[Any], pointers: List[str]) -> List[dict]:
+        """Appear cells + value labels + pointer arrows.
+
+        Intro is split into chunks so no step exceeds the per-step shape cap.
+        Chunks after the first also scale their shapes to 1.0 so every step
+        after the first carries a transform op (validator rule), while the
+        shapes pop in rather than fade.
+        """
+        shapes = []
+        for i in range(len(values)):
+            x = self.cell_x(i)
+            shapes.append(
+                {
+                    "id": f"cell_{i}",
+                    "type": "rect",
+                    "x": x,
+                    "y": ROW_Y,
+                    "width": self._cell,
+                    "height": self._cell,
+                    "radius": 10,
+                    "fill": IDLE_FILL,
+                    "stroke": IDLE_STROKE,
+                    "lineWidth": 2,
+                }
+            )
+            shapes.append(
+                {
+                    "id": f"val_{i}",
+                    "type": "text",
+                    "x": x,
+                    "y": ROW_Y,
+                    "text": self._display(values[i]),
+                    "fontSize": self._label_font_size(),
+                    "fill": TEXT_FILL,
+                }
+            )
+        for name in pointers:
+            shapes.append(
+                {
+                    "id": f"ptr_{name}",
+                    "type": "polygon",
+                    "x": self.cell_x(0),
+                    "y": ROW_Y + PTR_DY,
+                    "points": PTR_POINTS,
+                    "fill": "#facc15",
+                }
+            )
+
+        # Split into chunks of at most 20 shapes per intro step.
+        chunk_size = 20
+        chunks = [shapes[k : k + chunk_size] for k in range(0, len(shapes), chunk_size)]
+        steps = []
+        for idx, chunk in enumerate(chunks):
+            step = {
+                "narration": (
+                    f"Starting with {values}."
+                    if idx == 0
+                    else "Setting up the rest of the array."
+                ),
+                "shapes": chunk,
+                "motion": [
+                    {"target": shape["id"], "op": "appear", "duration": 0.25}
+                    for shape in chunk
+                ],
+            }
+            if idx > 0:
+                # Later intro steps must still carry a transform op (validator
+                # rule): a single scale on the first shape satisfies it while
+                # keeping the step under the motion-op cap.
+                step["motion"].append(
+                    {
+                        "target": chunk[0]["id"],
+                        "op": "scale",
+                        "to": 1.0,
+                        "duration": 0.25,
+                    }
+                )
+            steps.append(step)
+        return steps
+
+    def _label_font_size(self) -> float:
+        return max(22.0, min(36.0, self._cell * 0.4))
+
+    @staticmethod
+    def _display(value: Any) -> str:
+        """Text for a cell label; whitespace-only values get a visible dot."""
+        text = str(value)
+        return "·" if not text or not text.strip() else text
+
+    def _clamp_i(self, index: int) -> int:
+        """Clamp an index into the rendered array (guards off-range pointers)."""
+        return max(0, min(int(index), self.n - 1))
+
+    def _make_step(self, narration: str, motion: List[dict]) -> dict:
+        return {"narration": narration[:300], "shapes": [], "motion": motion}
+
+    # ── compile ─────────────────────────────────────────────────────────
+
+    def compile(
+        self, events: List[TraceEvent], title: str = ""
+    ) -> Optional[Dict[str, Any]]:
+        if not events:
+            return None
+        init = next((e for e in events if e.kind == "init"), None)
+        if init is None:
+            return None
+        values = list(init.fields.get("values") or [])
+        if not self._fit_for_values(values):
+            logger.warning(
+                "Cannot render %d values in the animation canvas", len(values)
+            )
+            return None
+
+        pointer_names = []
+        for e in events:
+            if e.kind == "pointer" and e.has("name"):
+                name = str(e.fields["name"])
+                if name not in pointer_names and len(pointer_names) < MAX_POINTERS:
+                    pointer_names.append(name)
+
+        steps: List[dict] = self._intro_steps(values, pointer_names)
+
+        # cell_to_label[i] = id of the label shape currently over cell i.
+        cell_to_label = [f"val_{i}" for i in range(len(values))]
+        state = list(values)
+
+        # Coalesce pointer events into the following event's step so arrows
+        # move at the same moment the next operation happens. Multiple
+        # pointers may be pending before one operation (e.g. low/high).
+        pending_pointers: List[TraceEvent] = []
+
+        for e in events:
+            if e.kind == "init":
+                continue
+
+            if e.kind == "pointer":
+                pending_pointers.append(e)
+                continue
+
+            motion: List[dict] = []
+            narration = ""
+
+            for p in pending_pointers:
+                name = str(p.fields["name"])
+                index = self._clamp_i(p.fields["index"])
+                motion.append(
+                    {
+                        "target": f"ptr_{name}",
+                        "op": "move",
+                        "to": [self.cell_x(index), ROW_Y + PTR_DY],
+                        "duration": 0.35,
+                    }
+                )
+            pending_pointers = []
+
+            if e.kind == "compare":
+                i = self._clamp_i(e.i)
+                j = e.fields.get("j")
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "fill",
+                        "to": CHECK_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "stroke",
+                        "to": CHECK_STROKE,
+                        "duration": 0.25,
+                    }
+                )
+                if j is not None:
+                    j = self._clamp_i(j)
+                    motion.append(
+                        {
+                            "target": f"cell_{j}",
+                            "op": "fill",
+                            "to": CHECK_FILL,
+                            "duration": 0.25,
+                        }
+                    )
+                    motion.append(
+                        {
+                            "target": f"cell_{j}",
+                            "op": "stroke",
+                            "to": CHECK_STROKE,
+                            "duration": 0.25,
+                        }
+                    )
+                    narration = f"Compare index {e.i} and {e.fields['j']}: {state[i]} vs {state[j]}."
+                else:
+                    narration = f"Compare index {e.i}: {state[i]}."
+
+            elif e.kind == "swap":
+                i, j = self._clamp_i(e.i), self._clamp_i(e.j)
+                li, lj = cell_to_label[i], cell_to_label[j]
+                xj = self.cell_x(j)
+                xi = self.cell_x(i)
+                motion.append(
+                    {"target": li, "op": "move", "to": [xj, ROW_Y], "duration": 0.45}
+                )
+                motion.append(
+                    {"target": lj, "op": "move", "to": [xi, ROW_Y], "duration": 0.45}
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "fill",
+                        "to": SWAP_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{j}",
+                        "op": "fill",
+                        "to": SWAP_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                narration = f"Index {i} and {j}: {state[i]} and {state[j]} are out of order — swap them."
+                cell_to_label[i], cell_to_label[j] = lj, li
+                state[i], state[j] = state[j], state[i]
+
+            elif e.kind == "write":
+                i = self._clamp_i(e.i)
+                value = e.fields.get("value")
+                label = cell_to_label[i]
+                motion.append(
+                    {
+                        "target": label,
+                        "op": "label",
+                        "to": self._display(value),
+                        "duration": 0.3,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "fill",
+                        "to": CHECK_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                narration = f"values[{e.i}] becomes {value}."
+                state[i] = value
+
+            elif e.kind == "mark":
+                i = self._clamp_i(e.i)
+                state_name = str(e.fields.get("state", ""))
+                if state_name == "sorted":
+                    motion.append(
+                        {
+                            "target": f"cell_{i}",
+                            "op": "fill",
+                            "to": SORTED_FILL,
+                            "duration": 0.35,
+                        }
+                    )
+                    motion.append(
+                        {
+                            "target": f"cell_{i}",
+                            "op": "stroke",
+                            "to": SORTED_STROKE,
+                            "duration": 0.35,
+                        }
+                    )
+                    narration = f"Index {i} is in its final position."
+                else:
+                    motion.append(
+                        {
+                            "target": f"cell_{i}",
+                            "op": "fill",
+                            "to": CHECK_FILL,
+                            "duration": 0.3,
+                        }
+                    )
+                    narration = f"values[{i}] marked {state_name}."
+
+            elif e.kind == "return":
+                result = e.fields.get("result")
+                narration = (
+                    f"Finished. Result: {result}."
+                    if result is not None
+                    else "Finished."
+                )
+                # Give the closing step a real transform so it is never
+                # dropped by the empty-motion guard or the validator.
+                motion.append(
+                    {"target": "cell_0", "op": "scale", "to": 1.0, "duration": 0.25}
+                )
+
+            elif e.kind == "visit":
+                i = self._clamp_i(e.i)
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "fill",
+                        "to": CHECK_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "stroke",
+                        "to": CHECK_STROKE,
+                        "duration": 0.25,
+                    }
+                )
+                narration = f"Visiting index {i}: {state[i]}."
+
+            elif e.kind == "read":
+                i = self._clamp_i(e.i)
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "fill",
+                        "to": ACTIVE_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                narration = f"Read values[{i}] = {state[i]}."
+
+            elif e.kind == "choose":
+                i = self._clamp_i(e.i)
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "fill",
+                        "to": CHOSEN_FILL,
+                        "duration": 0.3,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "stroke",
+                        "to": CHOSEN_STROKE,
+                        "duration": 0.3,
+                    }
+                )
+                narration = f"Choose index {i}: {state[i]}."
+
+            elif e.kind == "backtrack":
+                i = self._clamp_i(e.i)
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "fill",
+                        "to": IDLE_FILL,
+                        "duration": 0.3,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "stroke",
+                        "to": IDLE_STROKE,
+                        "duration": 0.3,
+                    }
+                )
+                narration = f"Backtrack from index {i}."
+
+            elif e.kind == "window":
+                left, right = e.l, e.r
+                for idx in range(left, min(right + 1, left + 26, len(state))):
+                    motion.append(
+                        {
+                            "target": f"cell_{idx}",
+                            "op": "fill",
+                            "to": WINDOW_FILL,
+                            "duration": 0.25,
+                        }
+                    )
+                narration = f"Active window covers indices {left}..{right}."
+
+            elif e.kind == "partition":
+                i = self._clamp_i(e.i)
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "stroke",
+                        "to": SWAP_STROKE,
+                        "duration": 0.25,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "fill",
+                        "to": SWAP_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                narration = f"Partition boundary at index {i}."
+
+            elif e.kind == "dp_update":
+                # 1-D DP: treat as a value write into the tracked label.
+                i = self._clamp_i(e.i)
+                value = e.fields.get("value")
+                label = cell_to_label[i]
+                motion.append(
+                    {
+                        "target": label,
+                        "op": "label",
+                        "to": self._display(value),
+                        "duration": 0.3,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{i}",
+                        "op": "fill",
+                        "to": SORTED_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                narration = f"DP[{i}] becomes {value}."
+                state[i] = value
+
+            elif e.kind == "edge":
+                # Edge activation has no array visual; skip quietly.
+                continue
+
+            if not motion:
+                continue
+            steps.append(self._make_step(narration, motion))
+
+        if len(steps) < 3:
+            return None
+
+        return {
+            "title": title,
+            "data": {"values": values},
+            "steps": steps,
+        }
+
+
+def compile_animation(
+    events: List[TraceEvent], title: str = ""
+) -> Optional[Dict[str, Any]]:
+    """Compile a trace into a validated AnimationScript dict, or None."""
+    return AnimationCompiler().compile(events, title=title)

--- a/backend/app/services/animation_inputs.py
+++ b/backend/app/services/animation_inputs.py
@@ -1,0 +1,145 @@
+"""Normalization of question example inputs into canonical solution kwargs.
+
+DB questions store example inputs in many shapes: `nums = [2,7,11,15], target =
+9`, bare arrays, bare strings, matrices, level-order tree arrays, and multiline
+test inputs. The animation pipeline feeds the canonical traced solution the same
+real example the user sees, so this module turns any of those shapes into the
+kwargs dict the canonical function expects.
+
+Parsing is safe (JSON/literal evaluation only — never exec) and graded:
+
+1. Already-structured values (dicts) pass through.
+2. Whole-string JSON/literal parse (arrays, objects, strings, numbers).
+3. `key = value, key = value` assignment form, split at top-level commas.
+4. Multiline inputs map each line to the signature in order.
+5. A raw-string fallback for values that are not evaluable (e.g. bit strings
+   like `00000000000000000000000000001011` for a binary-number argument).
+"""
+
+import ast
+import json
+from typing import Any, Dict, List, Optional
+
+
+def _eval_value(raw: str) -> Any:
+    """Parse a single value with JSON first (null/true) then literal eval."""
+    stripped = raw.strip()
+    try:
+        return json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        pass
+    try:
+        return ast.literal_eval(stripped)
+    except (ValueError, SyntaxError):
+        return stripped
+
+
+def _split_top_level(raw: str) -> List[str]:
+    """Split on commas at bracket/brace/quote depth 0."""
+    parts: List[str] = []
+    depth = 0
+    quote: Optional[str] = None
+    current = ""
+    i = 0
+    while i < len(raw):
+        ch = raw[i]
+        if quote is not None:
+            current += ch
+            if ch == quote and raw[i - 1] != "\\":
+                quote = None
+        elif ch in "\"'":
+            quote = ch
+            current += ch
+        elif ch in "[{(":
+            depth += 1
+            current += ch
+        elif ch in "]})":
+            depth -= 1
+            current += ch
+        elif ch == "," and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += ch
+        i += 1
+    parts.append(current)
+    return parts
+
+
+def _parse_assignment_form(raw: str, signature: List[str]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    # Each line may hold one or more `key = value` assignments (the min-stack
+    # example puts `operations = [...]` and `values = [...]` on separate lines).
+    for line in raw.splitlines():
+        for part in _split_top_level(line):
+            if not part.strip():
+                continue
+            if "=" not in part:
+                continue
+            key, _, value = part.partition("=")
+            key = key.strip()
+            if not key:
+                continue
+            out[key] = _eval_value(value)
+    # Bare assignment-less values should not happen here, but if nothing was
+    # extracted, fall through to the whole-string parse.
+    if not out:
+        raise ValueError("no assignments found")
+    return out
+
+
+def parse_input_kwargs(
+    raw_input: Any, signature: Optional[List[str]] = None
+) -> Dict[str, Any]:
+    """Return the kwargs dict for a canonical solution call.
+
+    ``signature`` lists the canonical function's parameter names in order; a
+    positional input (bare array/string/number) maps onto the first parameter.
+    """
+    signature = signature or []
+    if raw_input is None:
+        return {}
+    if isinstance(raw_input, dict):
+        return dict(raw_input)
+    if not isinstance(raw_input, str):
+        return {signature[0]: raw_input} if signature else {}
+
+    stripped = raw_input.strip()
+    if not stripped:
+        return {}
+
+    # Whole-value parse first (bare array / object / quoted string / number).
+    try:
+        parsed = _eval_value(stripped)
+        if isinstance(parsed, dict):
+            return parsed
+        if signature and not isinstance(parsed, str):
+            return {signature[0]: parsed}
+        if signature and isinstance(parsed, str) and stripped.startswith(('"', "'")):
+            # A genuinely quoted string value, e.g. '"()"' → {"s": "()"}.
+            return {signature[0]: parsed}
+    except Exception:  # noqa: BLE001 - fall through to assignment form
+        pass
+
+    # `key = value, key = value` form.
+    try:
+        return _parse_assignment_form(stripped, signature)
+    except (ValueError, TypeError):
+        pass
+
+    # Multiline positional input: each line is one positional argument.
+    lines = [line.strip() for line in stripped.splitlines() if line.strip()]
+    if len(lines) > 1 and signature:
+        values = []
+        for line in lines:
+            try:
+                values.append(_eval_value(line))
+            except Exception:  # noqa: BLE001
+                values.append(line)
+        return dict(zip(signature, values))
+
+    # Raw-string fallback (e.g. a bit-string argument like `n = 000...11` has
+    # already been handled by the assignment form; bare words land here).
+    if signature:
+        return {signature[0]: _eval_value(stripped)}
+    return {}

--- a/backend/app/services/animation_validator.py
+++ b/backend/app/services/animation_validator.py
@@ -1,47 +1,67 @@
-"""AnimationValidator — semantic gate for AI-generated animation scripts.
+"""Structural gate for generic declarative animation scenes.
 
-Structural conformance is handled by the AnimationScript Pydantic model.
-This service verifies that a structurally valid script is also logically
-correct: indexes stay in bounds, a "match" frame really matches the target,
-and a "mismatch" frame really does not. Invalid scripts are dropped so the
-rest of the coaching response still renders — never partially trusted.
+A scene is fully data-driven: the AI authors the subject AND the algorithm
+visuals as vector primitives (shapes) plus a per-step motion timeline. There
+are no algorithm-type or subject-kind catalogs — every scene is validated
+against the same structural rules so a bad script can never reach the viewer.
+
+The validator enforces the cross-cutting rules (bounds, uniqueness, caps,
+motion-target resolution). Field-level shape typing is handled by the
+AnimationScript Pydantic model downstream.
 """
 
 import logging
+import re
 from typing import Any, Dict, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_TYPES = frozenset({"linear_search"})
-
-MAX_VALUES = 50
-MAX_STEPS = 200
+MAX_STEPS = 100
+MAX_SHAPES = 120
+MAX_SHAPES_PER_STEP = 40
+MAX_MOTIONS_PER_STEP = 30
+MAX_SHAPE_ID = 64
 MAX_NARRATION = 300
+MAX_TEXT_LENGTH = 200
 
-_INDEX_OPS = frozenset({"compare", "visit", "mark", "swap", "move"})
-_RESULT_OPS = frozenset({"compare", "mark", "visit"})
+MIN_STEPS = 3
+MIN_SHAPES_TOTAL = 2
+
+BOUND_X = 960.0  # canvas is 1920 wide, center origin
+BOUND_Y = 540.0  # canvas is 1080 tall, center origin
+BOUND_POINT = 2000.0  # relative vertex offsets from the node origin
+
+MIN_DURATION = 0.1
+MAX_DURATION = 5.0
+
+SHAPE_TYPES = frozenset({"rect", "ellipse", "line", "polygon", "text"})
+MOTION_OPS = frozenset(
+    {
+        "appear",
+        "disappear",
+        "move",
+        "fill",
+        "stroke",
+        "scale",
+        "rotate",
+        "label",
+    }
+)
+# Ops that change an existing shape's geometry/color/content — appearing or
+# disappearing a shape is not animation by itself, so every step must include
+# at least one of these.
+TRANSFORM_OPS = frozenset({"move", "fill", "stroke", "scale", "rotate", "label"})
+
+HEX_COLOR = re.compile(r"^#[0-9a-fA-F]{6}$")
 
 
 class AnimationValidator:
-    """Validate the semantic correctness of an animation script dict."""
+    """Validate the structural correctness of an animation scene dict."""
 
     def validate(self, script: Dict[str, Any]) -> Tuple[Optional[Dict[str, Any]], str]:
         """Return (validated_script, "") on success or (None, reason) on failure."""
         if not isinstance(script, dict):
             return None, "Animation is not an object"
-
-        kind = script.get("type")
-        if kind not in SUPPORTED_TYPES:
-            return None, f"Unsupported animation type: {kind!r}"
-
-        data = script.get("data")
-        if not isinstance(data, dict):
-            return None, "Animation data must be an object"
-        values = data.get("values")
-        if not isinstance(values, list) or not values:
-            return None, "Animation data must contain a non-empty values list"
-        if len(values) > MAX_VALUES:
-            return None, f"Too many values ({len(values)} > {MAX_VALUES})"
 
         steps = script.get("steps")
         if not isinstance(steps, list) or not steps:
@@ -49,100 +69,230 @@ class AnimationValidator:
         if len(steps) > MAX_STEPS:
             return None, f"Too many steps ({len(steps)} > {MAX_STEPS})"
 
-        validator = _TYPE_VALIDATORS.get(kind)
+        known_ids: set[str] = set()
+        total_shapes = 0
+        no_transform_step: Optional[int] = None
         for i, step in enumerate(steps):
             if not isinstance(step, dict):
                 return None, f"Step {i} is not an object"
-            ok, reason = self._validate_step(step, values, data, i)
-            if not ok:
-                return None, reason
-            if validator:
-                ok, reason = validator(step, values, data, i)
+
+            narration = step.get("narration")
+            if narration is not None and (
+                not isinstance(narration, str) or len(narration) > MAX_NARRATION
+            ):
+                return None, f"Step {i} narration must be under {MAX_NARRATION} chars"
+
+            shapes = step.get("shapes") or []
+            if not isinstance(shapes, list):
+                return None, f"Step {i} shapes must be a list"
+            if len(shapes) > MAX_SHAPES_PER_STEP:
+                return (
+                    None,
+                    f"Step {i} has too many shapes "
+                    f"({len(shapes)} > {MAX_SHAPES_PER_STEP})",
+                )
+
+            for j, shape in enumerate(shapes):
+                if not isinstance(shape, dict):
+                    return None, f"Step {i} shape {j} is not an object"
+                ok, reason = self._validate_shape(shape, f"Step {i} shape {j}")
                 if not ok:
                     return None, reason
+                sid = shape.get("id")
+                if not isinstance(sid, str) or not sid.strip():
+                    return None, f"Step {i} shape {j} is missing an id"
+                if len(sid) > MAX_SHAPE_ID:
+                    return (
+                        None,
+                        f"Step {i} shape {j} id exceeds {MAX_SHAPE_ID} chars",
+                    )
+                if sid in known_ids:
+                    return None, f"Duplicate shape id {sid!r}"
+                known_ids.add(sid)
+
+            total_shapes += len(shapes)
+
+            motion = step.get("motion") or []
+            if not isinstance(motion, list):
+                return None, f"Step {i} motion must be a list"
+            if not motion:
+                return (
+                    None,
+                    f"Step {i} has no motion ops (every step must animate the "
+                    "algorithm forward)",
+                )
+            if len(motion) > MAX_MOTIONS_PER_STEP:
+                return (
+                    None,
+                    f"Step {i} has too many motion ops "
+                    f"({len(motion)} > {MAX_MOTIONS_PER_STEP})",
+                )
+
+            for k, op in enumerate(motion):
+                if not isinstance(op, dict):
+                    return None, f"Step {i} motion {k} is not an object"
+                ok, reason = self._validate_motion(
+                    op, known_ids, f"Step {i} motion {k}"
+                )
+                if not ok:
+                    return None, reason
+
+            # The first step may legitimately set up the initial state by
+            # appearing shapes, but every later step must visibly transform an
+            # existing shape — fading shapes in/out is not animation. Record the
+            # violation here and report it after the hard caps so a caps error
+            # takes precedence.
+            if (
+                i > 0
+                and no_transform_step is None
+                and not any(op.get("op") in TRANSFORM_OPS for op in motion)
+            ):
+                no_transform_step = i
+
+        if total_shapes > MAX_SHAPES:
+            return None, f"Too many shapes ({total_shapes} > {MAX_SHAPES})"
+        if total_shapes < MIN_SHAPES_TOTAL:
+            return None, f"Too few shapes ({total_shapes} < {MIN_SHAPES_TOTAL})"
+        if len(steps) < MIN_STEPS:
+            return None, f"Too few steps ({len(steps)} < {MIN_STEPS})"
+        if no_transform_step is not None:
+            return (
+                None,
+                f"Step {no_transform_step} has no transform op "
+                "(appearing/disappearing shapes is not animation — "
+                "move/fill/stroke/scale/rotate an existing shape)",
+            )
 
         return script, ""
 
     # ── internal ──────────────────────────────────────────────────────
 
-    def _validate_step(
-        self,
-        step: Dict[str, Any],
-        values: list,
-        data: Dict[str, Any],
-        index: int,
-    ) -> Tuple[bool, str]:
-        op = step.get("operation")
-        if not isinstance(op, str):
-            return False, f"Step {index} is missing an operation"
-
-        narration = step.get("narration")
-        if not isinstance(narration, str) or not narration.strip():
-            return False, f"Step {index} is missing narration"
-        if len(narration) > MAX_NARRATION:
-            return False, f"Step {index} narration exceeds {MAX_NARRATION} chars"
-
-        bounds_ok, reason = self._check_bounds(step, len(values), f"Step {index}")
-        if not bounds_ok:
-            return False, reason
-
-        if op in _RESULT_OPS:
-            result = step.get("result")
-            if op == "compare" and result not in (
-                None,
-                "checking",
-                "match",
-                "mismatch",
-            ):
-                return False, f"Step {index} has invalid compare result {result!r}"
-
-        return True, ""
-
     @staticmethod
-    def _check_bounds(
-        step: Dict[str, Any], length: int, label: str
-    ) -> Tuple[bool, str]:
-        for field in ("index", "from_index", "to_index"):
-            value = step.get(field)
+    def _validate_shape(shape: Dict[str, Any], label: str) -> Tuple[bool, str]:
+        kind = shape.get("type")
+        if kind not in SHAPE_TYPES:
+            return False, f"{label} has unsupported type {kind!r}"
+
+        for field, bound in (("x", BOUND_X), ("y", BOUND_Y)):
+            value = shape.get(field, 0)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                return False, f"{label} {field} must be a number"
+            if not -bound <= value <= bound:
+                return False, f"{label} {field} out of range ({value!r})"
+
+        if kind in ("rect", "ellipse"):
+            if shape.get("width") is None or shape.get("height") is None:
+                return False, f"{label} {kind} requires width and height"
+
+        if kind in ("line", "polygon"):
+            points = shape.get("points")
+            if not isinstance(points, list) or len(points) < 2:
+                return False, f"{label} {kind} requires at least 2 points"
+            for point in points:
+                if (
+                    not isinstance(point, (list, tuple))
+                    or len(point) != 2
+                    or any(
+                        isinstance(c, bool) or not isinstance(c, (int, float))
+                        for c in point
+                    )
+                ):
+                    return False, f"{label} has an invalid point {point!r}"
+                if any(abs(c) > BOUND_POINT for c in point):
+                    return False, f"{label} has an out-of-range point"
+
+        if kind == "text":
+            text = shape.get("text")
+            if not isinstance(text, str) or not text.strip():
+                return False, f"{label} text requires a non-empty text string"
+            if len(text) > MAX_TEXT_LENGTH:
+                return False, f"{label} text exceeds {MAX_TEXT_LENGTH} chars"
+
+        for size_field in ("width", "height", "fontSize", "lineWidth"):
+            value = shape.get(size_field)
             if value is None:
                 continue
-            if not isinstance(value, int) or value < 0 or value >= length:
-                return False, f"{label} has out-of-bounds {field}: {value!r}"
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or value <= 0
+            ):
+                return False, f"{label} {size_field} must be a positive number"
+
+        radius = shape.get("radius")
+        if radius is not None:
+            if (
+                isinstance(radius, bool)
+                or not isinstance(radius, (int, float))
+                or radius < 0
+            ):
+                return False, f"{label} radius must be a non-negative number"
+
+        for color_field in ("fill", "stroke"):
+            value = shape.get(color_field)
+            if value is None:
+                continue
+            if not isinstance(value, str) or not HEX_COLOR.match(value):
+                return False, f"{label} {color_field} must be a #rrggbb hex color"
+
+        opacity = shape.get("opacity")
+        if opacity is not None:
+            if (
+                isinstance(opacity, bool)
+                or not isinstance(opacity, (int, float))
+                or not 0 <= opacity <= 1
+            ):
+                return False, f"{label} opacity must be between 0 and 1"
+
         return True, ""
 
     @staticmethod
-    def _validate_linear_search(
-        step: Dict[str, Any],
-        values: list,
-        data: Dict[str, Any],
-        index: int,
+    def _validate_motion(
+        op: Dict[str, Any], known_ids: set[str], label: str
     ) -> Tuple[bool, str]:
-        target = data.get("target")
-        if step.get("operation") != "compare" or step.get("result") not in (
-            "match",
-            "mismatch",
-        ):
-            return True, ""
+        op_name = op.get("op")
+        if op_name not in MOTION_OPS:
+            return False, f"{label} has unsupported op {op_name!r}"
 
-        value_index = step.get("index")
-        if value_index is None:
-            return False, f"Step {index} is missing an index for a compare result"
-        value = values[value_index]
-        if step["result"] == "match" and value != target:
-            return False, (
-                f"Step {index} claims a match but values[{step['index']}] "
-                f"({value!r}) does not equal target ({target!r})"
-            )
-        if step["result"] == "mismatch" and value == target:
-            return False, (
-                f"Step {index} claims a mismatch but values[{step['index']}] "
-                f"({value!r}) equals target ({target!r})"
-            )
+        target = op.get("target")
+        if not isinstance(target, str) or target not in known_ids:
+            return False, f"{label} targets unknown shape id {target!r}"
+
+        duration = op.get("duration", 0.3)
+        if (
+            isinstance(duration, bool)
+            or not isinstance(duration, (int, float))
+            or not MIN_DURATION <= duration <= MAX_DURATION
+        ):
+            return False, f"{label} duration out of range ({duration!r})"
+
+        to = op.get("to")
+        if op_name == "move":
+            if (
+                not isinstance(to, (list, tuple))
+                or len(to) != 2
+                or any(
+                    isinstance(c, bool) or not isinstance(c, (int, float)) for c in to
+                )
+            ):
+                return False, f"{label} move requires an [x, y] target"
+            if abs(to[0]) > BOUND_X or abs(to[1]) > BOUND_Y:
+                return False, f"{label} move target out of range"
+        elif op_name in ("fill", "stroke"):
+            if not isinstance(to, str) or not HEX_COLOR.match(to):
+                return False, f"{label} {op_name} requires a #rrggbb hex color"
+        elif op_name in ("scale", "rotate"):
+            if isinstance(to, bool) or not isinstance(to, (int, float)):
+                return False, f"{label} {op_name} requires a number"
+            if op_name == "scale" and to <= 0:
+                return False, f"{label} scale must be positive"
+        elif op_name == "label":
+            if not isinstance(to, str) or not to:
+                return False, f"{label} label requires a non-empty text string"
+            if len(to) > MAX_TEXT_LENGTH:
+                return False, f"{label} label text exceeds {MAX_TEXT_LENGTH} chars"
+
         return True, ""
 
-
-_TYPE_VALIDATORS = {
-    "linear_search": AnimationValidator._validate_linear_search,
-}
 
 animation_validator = AnimationValidator()

--- a/backend/app/services/family_compilers.py
+++ b/backend/app/services/family_compilers.py
@@ -1,0 +1,1189 @@
+"""Family compilers — turn a semantic trace into a validated generic scene.
+
+One compiler per visualization family, each deterministically producing the
+generic AnimationScript contract the Motion Canvas viewer already renders.
+The canonical traced solution only emits semantic events at runtime
+(push/pop, visit, edge, dp_update, choose/backtrack, compare/swap/...); this
+module owns every visual: layout, colors, arrows, containers and narration.
+
+All output is structurally validated by AnimationValidator before returning,
+so a bad compile can never reach the viewer. ``compile_family`` returns None
+when the trace is unusable (no init event, empty, structure too large).
+"""
+
+import logging
+import math
+from typing import Any, Dict, List, Optional
+
+from app.services.trace_parser import TraceEvent
+from app.services.animation_compiler import AnimationCompiler
+
+logger = logging.getLogger(__name__)
+
+# ── shared palette ──────────────────────────────────────────────────────────
+IDLE_FILL = "#1e293b"
+IDLE_STROKE = "#334155"
+CHECK_FILL = "#1d4ed8"
+CHECK_STROKE = "#3b82f6"
+SWAP_FILL = "#713f12"
+SWAP_STROKE = "#facc15"
+DONE_FILL = "#14532d"
+DONE_STROKE = "#22c55e"
+ACTIVE_FILL = "#3b0764"
+ACTIVE_STROKE = "#a855f7"
+TEXT_FILL = "#e2e8f0"
+MUTED_FILL = "#0f172a"
+
+MAX_SHAPES_TOTAL = 60
+MAX_STEP_SHAPES = 40
+MAX_STEP_MOTIONS = 30
+
+PTR_POINTS = [[-14, -36], [0, -66], [14, -36]]
+
+
+def _rect(sid: str, x: float, y: float, w: float, h: float, **kw) -> dict:
+    shape = {
+        "id": sid,
+        "type": "rect",
+        "x": round(x, 2),
+        "y": round(y, 2),
+        "width": round(w, 2),
+        "height": round(h, 2),
+        "radius": kw.get("radius", 8),
+        "fill": kw.get("fill", IDLE_FILL),
+        "stroke": kw.get("stroke", IDLE_STROKE),
+        "lineWidth": kw.get("lineWidth", 2),
+    }
+    if kw.get("opacity") is not None:
+        shape["opacity"] = kw["opacity"]
+    return shape
+
+
+def _ellipse(sid: str, x: float, y: float, w: float, h: float, **kw) -> dict:
+    shape = {
+        "id": sid,
+        "type": "ellipse",
+        "x": round(x, 2),
+        "y": round(y, 2),
+        "width": round(w, 2),
+        "height": round(h, 2),
+        "fill": kw.get("fill", IDLE_FILL),
+        "stroke": kw.get("stroke", IDLE_STROKE),
+        "lineWidth": kw.get("lineWidth", 2),
+    }
+    return shape
+
+
+def _text(sid: str, x: float, y: float, content: str, size: float, **kw) -> dict:
+    return {
+        "id": sid,
+        "type": "text",
+        "x": round(x, 2),
+        "y": round(y, 2),
+        "text": str(content)[:200],
+        "fontSize": round(size, 2),
+        "fill": kw.get("fill", TEXT_FILL),
+    }
+
+
+def _line(sid: str, points: List[List[float]], **kw) -> dict:
+    return {
+        "id": sid,
+        "type": "line",
+        "points": [[round(p[0], 2), round(p[1], 2)] for p in points],
+        "stroke": kw.get("stroke", IDLE_STROKE),
+        "lineWidth": kw.get("lineWidth", 2),
+    }
+
+
+def _polygon(sid: str, x: float, y: float, points: List[List[float]], **kw) -> dict:
+    return {
+        "id": sid,
+        "type": "polygon",
+        "x": round(x, 2),
+        "y": round(y, 2),
+        "points": points,
+        "fill": kw.get("fill", "#facc15"),
+    }
+
+
+def _step(
+    narration: str, motion: List[dict], shapes: Optional[List[dict]] = None
+) -> dict:
+    return {"narration": narration[:300], "shapes": shapes or [], "motion": motion}
+
+
+def _split_intro(shapes: List[dict], first_narration: str) -> List[dict]:
+    """Chunked appear intro; later chunks carry a scale transform (validator).
+
+    Chunked at 15 shapes so each intro step stays under the 30-motion cap even
+    for grids that create two shapes per cell.
+    """
+    steps = []
+    for idx in range(0, len(shapes), 15):
+        chunk = shapes[idx : idx + 15]
+        motion = [
+            {"target": shape["id"], "op": "appear", "duration": 0.25} for shape in chunk
+        ]
+        if idx > 0:
+            motion.append(
+                {"target": chunk[0]["id"], "op": "scale", "to": 1.0, "duration": 0.25}
+            )
+        steps.append(
+            _step(
+                first_narration
+                if idx == 0
+                else "Setting up the rest of the structure.",
+                motion,
+                chunk,
+            )
+        )
+    return steps
+
+
+def _clamp(total: int, max_total: int) -> int:
+    return max(0, min(total, max_total))
+
+
+def _init_events(events: List[TraceEvent]) -> List[TraceEvent]:
+    return [e for e in events if e.kind == "init"]
+
+
+# ── array / backtrack (delegates to the array compiler) ─────────────────────
+def _compile_array(events: List[TraceEvent], title: str) -> Optional[Dict[str, Any]]:
+    return AnimationCompiler().compile(events, title=title)
+
+
+# ── stack ───────────────────────────────────────────────────────────────────
+STACK_BOX_W = 110.0
+STACK_BOX_H = 240.0
+STACK_ITEM_H = 34.0
+STACK_MAX_ITEMS = 10
+STACK_MAX_OPS = 14
+
+
+def _compile_stack(events: List[TraceEvent], title: str) -> Optional[Dict[str, Any]]:
+    init = _init_events(events)
+    if not init:
+        return None
+    data = init[0].fields.get("data")
+    ops = list(data) if isinstance(data, (list, str)) else []
+    if not ops:
+        return None
+    ops = [str(v) for v in ops][:STACK_MAX_OPS]
+
+    n_ops = len(ops)
+    cell_w = min(64.0, 2 * 380.0 / max(n_ops, 1))
+    total_w = n_ops * cell_w + (n_ops - 1) * 8
+    start_x = -total_w / 2 + cell_w / 2
+    ops_y = -180.0
+    box_x = 250.0
+    box_y = 40.0
+
+    shapes: List[dict] = []
+    for i, op in enumerate(ops):
+        x = round(start_x + i * (cell_w + 8), 2)
+        shapes.append(_rect(f"op_{i}", x, ops_y, cell_w, 40, radius=6))
+        shapes.append(_text(f"op_val_{i}", x, ops_y, op, 20))
+    shapes.append(_rect("stack_box", box_x, box_y, STACK_BOX_W, STACK_BOX_H, radius=10))
+
+    steps: List[dict] = _split_intro(shapes, f"Starting with operations {ops}.")
+
+    stack_count = 0
+    item_seq = 0
+    stack_ids: List[int] = []
+    for e in events:
+        if e.kind in ("init", "pointer"):
+            continue
+        motion: List[dict] = []
+        narration = ""
+        if e.kind == "visit":
+            i = int(e.i)
+            if 0 <= i < n_ops:
+                motion.append(
+                    {
+                        "target": f"op_{i}",
+                        "op": "fill",
+                        "to": CHECK_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"op_{i}",
+                        "op": "stroke",
+                        "to": CHECK_STROKE,
+                        "duration": 0.25,
+                    }
+                )
+            narration = f"Process operation {i}: {ops[i] if 0 <= i < n_ops else ''}."
+        elif e.kind == "push":
+            value = e.fields.get("value")
+            new_shapes: List[dict] = []
+            if stack_count < STACK_MAX_ITEMS:
+                item_y = box_y + STACK_BOX_H - STACK_ITEM_H * (stack_count + 1)
+                item_w = STACK_BOX_W - 20
+                seq = item_seq
+                item_seq += 1
+                sid = f"stack_cell_{seq}"
+                vid = f"stack_item_{seq}"
+                stack_ids.append(seq)
+                new_shapes.append(
+                    _rect(
+                        sid,
+                        box_x,
+                        box_y + STACK_BOX_H + 40,
+                        item_w,
+                        STACK_ITEM_H - 8,
+                        radius=6,
+                        fill=ACTIVE_FILL,
+                        stroke=ACTIVE_STROKE,
+                    )
+                )
+                new_shapes.append(
+                    _text(vid, box_x, box_y + STACK_BOX_H + 40, str(value), 20)
+                )
+                motion.append({"target": sid, "op": "appear", "duration": 0.2})
+                motion.append({"target": vid, "op": "appear", "duration": 0.2})
+                motion.append(
+                    {
+                        "target": sid,
+                        "op": "move",
+                        "to": [box_x, item_y + (STACK_ITEM_H - 8) / 2],
+                        "duration": 0.4,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": vid,
+                        "op": "move",
+                        "to": [box_x, item_y + (STACK_ITEM_H - 8) / 2],
+                        "duration": 0.4,
+                    }
+                )
+                stack_count += 1
+            narration = f"Push {value} onto the stack."
+            if not motion:
+                continue
+            steps.append(_step(narration, motion, new_shapes))
+            continue
+        elif e.kind == "pop":
+            value = e.fields.get("value")
+            if stack_count > 0 and stack_ids:
+                stack_count -= 1
+                seq = stack_ids.pop()
+                sid = f"stack_cell_{seq}"
+                vid = f"stack_item_{seq}"
+                motion.append(
+                    {
+                        "target": sid,
+                        "op": "move",
+                        "to": [box_x, box_y + STACK_BOX_H + 70],
+                        "duration": 0.4,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": vid,
+                        "op": "move",
+                        "to": [box_x, box_y + STACK_BOX_H + 70],
+                        "duration": 0.4,
+                    }
+                )
+                motion.append({"target": sid, "op": "disappear", "duration": 0.2})
+                motion.append({"target": vid, "op": "disappear", "duration": 0.2})
+                for k, bottom_seq in enumerate(stack_ids):
+                    item_y = box_y + STACK_BOX_H - STACK_ITEM_H * (k + 1)
+                    motion.append(
+                        {
+                            "target": f"stack_cell_{bottom_seq}",
+                            "op": "move",
+                            "to": [box_x, item_y + (STACK_ITEM_H - 8) / 2],
+                            "duration": 0.3,
+                        }
+                    )
+                    motion.append(
+                        {
+                            "target": f"stack_item_{bottom_seq}",
+                            "op": "move",
+                            "to": [box_x, item_y + (STACK_ITEM_H - 8) / 2],
+                            "duration": 0.3,
+                        }
+                    )
+            narration = f"Pop {value} off the stack."
+        elif e.kind == "mark":
+            i = int(e.i)
+            state = str(e.fields.get("state", ""))
+            if 0 <= i < n_ops:
+                motion.append(
+                    {
+                        "target": f"op_{i}",
+                        "op": "fill",
+                        "to": DONE_FILL,
+                        "duration": 0.3,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"op_{i}",
+                        "op": "stroke",
+                        "to": DONE_STROKE,
+                        "duration": 0.3,
+                    }
+                )
+            narration = f"Operation {i} marked {state}."
+        elif e.kind == "return":
+            result = e.fields.get("result")
+            narration = (
+                f"Finished. Result: {result}." if result is not None else "Finished."
+            )
+            motion.append(
+                {"target": "stack_box", "op": "scale", "to": 1.0, "duration": 0.25}
+            )
+        if not motion:
+            continue
+        steps.append(_step(narration, motion))
+
+    if len(steps) < 3:
+        return None
+    return {"title": title, "data": {"ops": ops, "family": "stack"}, "steps": steps}
+
+
+# ── linked list ─────────────────────────────────────────────────────────────
+LIST_MAX_NODES = 14
+LIST_PTR_DY = -70.0
+
+
+def _compile_linked_list(
+    events: List[TraceEvent], title: str
+) -> Optional[Dict[str, Any]]:
+    init = _init_events(events)
+    if not init:
+        return None
+    data = init[0].fields.get("data")
+    values = list(data) if isinstance(data, (list, str)) else []
+    values = values[:LIST_MAX_NODES]
+    if not 0 < len(values) <= LIST_MAX_NODES:
+        return None
+
+    n = len(values)
+    cell = min(88.0, (2 * 820.0 - (n - 1) * 12) / n)
+    spacing = cell + 12.0
+    total = n * cell + (n - 1) * 12
+    start = -total / 2 + cell / 2
+
+    def node_x(i: int) -> float:
+        return round(start + i * spacing, 2)
+
+    shapes: List[dict] = []
+    for i, v in enumerate(values):
+        x = node_x(i)
+        shapes.append(_rect(f"node_{i}", x, 0, cell, cell, radius=10))
+        shapes.append(_text(f"val_{i}", x, 0, str(v), max(20, min(30, cell * 0.38))))
+    for i in range(n - 1):
+        x1 = node_x(i) + cell / 2
+        x2 = node_x(i + 1) - cell / 2
+        shapes.append(
+            _line(
+                f"arrow_{i}",
+                [[x1, 0], [x1 + 10, 0], [x2, 0], [x2 - 8, -6], [x2 - 8, 6], [x2, 0]],
+                stroke="#64748b",
+                lineWidth=2,
+            )
+        )
+    null_x = node_x(n - 1) + spacing
+    shapes.append(
+        _rect(
+            "null_node",
+            null_x,
+            0,
+            cell,
+            cell,
+            radius=10,
+            fill=MUTED_FILL,
+            stroke="#475569",
+        )
+    )
+    shapes.append(_text("null_val", null_x, 0, "null", 22))
+
+    pointer_names: List[str] = []
+    for e in events:
+        if e.kind == "pointer" and e.has("name"):
+            name = str(e.fields["name"])
+            if name not in pointer_names and len(pointer_names) < 3:
+                pointer_names.append(name)
+    for name in pointer_names:
+        shapes.append(_polygon(f"ptr_{name}", node_x(0), LIST_PTR_DY, PTR_POINTS))
+
+    steps: List[dict] = _split_intro(shapes, f"Starting with the linked list {values}.")
+
+    cell_to_label = [f"val_{i}" for i in range(n)]
+    state = list(values)
+    pending: List[TraceEvent] = []
+    for e in events:
+        if e.kind == "init":
+            continue
+        if e.kind == "pointer":
+            pending.append(e)
+            continue
+        motion: List[dict] = []
+        narration = ""
+        for p in pending:
+            name = str(p.fields["name"])
+            idx = p.fields["index"]
+            tx = node_x(idx) if isinstance(idx, int) and 0 <= idx < n else null_x
+            motion.append(
+                {
+                    "target": f"ptr_{name}",
+                    "op": "move",
+                    "to": [tx, LIST_PTR_DY],
+                    "duration": 0.35,
+                }
+            )
+        pending = []
+        if e.kind == "visit":
+            i = int(e.i)
+            motion.append(
+                {
+                    "target": f"node_{i}",
+                    "op": "fill",
+                    "to": CHECK_FILL,
+                    "duration": 0.25,
+                }
+            )
+            motion.append(
+                {
+                    "target": f"node_{i}",
+                    "op": "stroke",
+                    "to": CHECK_STROKE,
+                    "duration": 0.25,
+                }
+            )
+            narration = f"Visiting node {i}: {state[i]}."
+        elif e.kind == "swap":
+            i, j = int(e.i), int(e.j)
+            li, lj = cell_to_label[i], cell_to_label[j]
+            motion.append(
+                {"target": li, "op": "move", "to": [node_x(j), 0], "duration": 0.45}
+            )
+            motion.append(
+                {"target": lj, "op": "move", "to": [node_x(i), 0], "duration": 0.45}
+            )
+            motion.append(
+                {"target": f"node_{i}", "op": "fill", "to": SWAP_FILL, "duration": 0.25}
+            )
+            motion.append(
+                {"target": f"node_{j}", "op": "fill", "to": SWAP_FILL, "duration": 0.25}
+            )
+            narration = f"Swap values at positions {i} and {j}."
+            cell_to_label[i], cell_to_label[j] = lj, li
+            state[i], state[j] = state[j], state[i]
+        elif e.kind == "write":
+            i = int(e.i)
+            value = e.fields.get("value")
+            motion.append(
+                {
+                    "target": cell_to_label[i],
+                    "op": "label",
+                    "to": str(value),
+                    "duration": 0.3,
+                }
+            )
+            motion.append(
+                {
+                    "target": f"node_{i}",
+                    "op": "fill",
+                    "to": CHECK_FILL,
+                    "duration": 0.25,
+                }
+            )
+            narration = f"Position {i} becomes {value}."
+            state[i] = value
+        elif e.kind == "mark":
+            i = int(e.i)
+            motion.append(
+                {"target": f"node_{i}", "op": "fill", "to": DONE_FILL, "duration": 0.35}
+            )
+            motion.append(
+                {
+                    "target": f"node_{i}",
+                    "op": "stroke",
+                    "to": DONE_STROKE,
+                    "duration": 0.35,
+                }
+            )
+            narration = f"Node {i} marked {e.fields.get('state', '')}."
+        elif e.kind == "return":
+            result = e.fields.get("result")
+            narration = (
+                f"Finished. Result: {result}." if result is not None else "Finished."
+            )
+            motion.append(
+                {"target": "node_0", "op": "scale", "to": 1.0, "duration": 0.25}
+            )
+        if not motion:
+            continue
+        steps.append(_step(narration, motion))
+
+    if len(steps) < 3:
+        return None
+    return {
+        "title": title,
+        "data": {"values": values, "family": "linked_list"},
+        "steps": steps,
+    }
+
+
+# ── tree ────────────────────────────────────────────────────────────────────
+TREE_MAX_NODES = 14
+TREE_LEVEL_H = 96.0
+TREE_WIDTH = 620.0
+TREE_TOP = -240.0
+TREE_PTR_DY = 30.0
+
+
+def _tree_layout(n: int) -> List[Dict[str, float]]:
+    """Return [{x, y}] positions for level-order indices 0..n-1."""
+    positions = []
+    for i in range(n):
+        level = int(math.floor(math.log2(i + 1)))
+        pos_in_level = i - (2**level - 1)
+        slots = 2**level
+        x = -TREE_WIDTH / 2 + (pos_in_level + 0.5) * (TREE_WIDTH / slots)
+        y = TREE_TOP + level * TREE_LEVEL_H
+        positions.append({"x": round(x, 2), "y": round(y, 2)})
+    return positions
+
+
+def _compile_tree(events: List[TraceEvent], title: str) -> Optional[Dict[str, Any]]:
+    init = _init_events(events)
+    if not init:
+        return None
+    data = init[0].fields.get("data")
+    raw = list(data) if isinstance(data, (list, str)) else []
+    raw = raw[:TREE_MAX_NODES]
+    present = [i for i, v in enumerate(raw) if v is not None]
+    if not present:
+        return None
+    positions = _tree_layout(max(present) + 1)
+    cell = 44.0
+
+    shapes: List[dict] = []
+    for i in present:
+        pos = positions[i]
+        parent = (i - 1) // 2
+        if parent >= 0 and parent in present:
+            pp = positions[parent]
+            shapes.append(
+                _line(
+                    f"tree_edge_{i}",
+                    [[pp["x"], pp["y"] + cell / 2], [pos["x"], pos["y"] - cell / 2]],
+                    stroke="#475569",
+                    lineWidth=2,
+                )
+            )
+    for i in present:
+        pos = positions[i]
+        shapes.append(_rect(f"node_{i}", pos["x"], pos["y"], cell, cell, radius=10))
+        shapes.append(_text(f"val_{i}", pos["x"], pos["y"], str(raw[i]), 18))
+
+    pointer_names: List[str] = []
+    for e in events:
+        if e.kind == "pointer" and e.has("name"):
+            name = str(e.fields["name"])
+            if name not in pointer_names and len(pointer_names) < 3:
+                pointer_names.append(name)
+    first_pos = positions[present[0]]
+    for name in pointer_names:
+        shapes.append(
+            _polygon(
+                f"ptr_{name}",
+                first_pos["x"],
+                first_pos["y"] + TREE_PTR_DY,
+                [[-10, -18], [0, 6], [10, -18]],
+                fill="#facc15",
+            )
+        )
+
+    steps: List[dict] = _split_intro(shapes, f"Starting with the tree {raw}.")
+
+    pending: List[TraceEvent] = []
+    for e in events:
+        if e.kind == "init":
+            continue
+        if e.kind == "pointer":
+            pending.append(e)
+            continue
+        motion: List[dict] = []
+        narration = ""
+        for p in pending:
+            name = str(p.fields["name"])
+            idx = p.fields["index"]
+            if isinstance(idx, int) and 0 <= idx <= max(present):
+                pos = positions[idx]
+                motion.append(
+                    {
+                        "target": f"ptr_{name}",
+                        "op": "move",
+                        "to": [pos["x"], pos["y"] + TREE_PTR_DY],
+                        "duration": 0.35,
+                    }
+                )
+        pending = []
+        if e.kind == "visit":
+            i = int(e.i)
+            if i in present:
+                motion.append(
+                    {
+                        "target": f"node_{i}",
+                        "op": "fill",
+                        "to": CHECK_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"node_{i}",
+                        "op": "stroke",
+                        "to": CHECK_STROKE,
+                        "duration": 0.25,
+                    }
+                )
+            narration = f"Visiting node {i}: {raw[i] if i < len(raw) else ''}."
+        elif e.kind == "mark":
+            i = int(e.i)
+            if i in present:
+                motion.append(
+                    {
+                        "target": f"node_{i}",
+                        "op": "fill",
+                        "to": DONE_FILL,
+                        "duration": 0.35,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"node_{i}",
+                        "op": "stroke",
+                        "to": DONE_STROKE,
+                        "duration": 0.35,
+                    }
+                )
+            narration = f"Node {i} marked {e.fields.get('state', '')}."
+        elif e.kind == "return":
+            result = e.fields.get("result")
+            narration = (
+                f"Finished. Result: {result}." if result is not None else "Finished."
+            )
+            motion.append(
+                {
+                    "target": f"node_{present[0]}",
+                    "op": "scale",
+                    "to": 1.0,
+                    "duration": 0.25,
+                }
+            )
+        if not motion:
+            continue
+        steps.append(_step(narration, motion))
+
+    if len(steps) < 3:
+        return None
+    return {"title": title, "data": {"values": raw, "family": "tree"}, "steps": steps}
+
+
+# ── grid (matrix / DP table) ────────────────────────────────────────────────
+GRID_MAX_CELLS = 20
+GRID_CELL = 60.0
+GRID_GAP = 8.0
+GRID_Y = -80.0
+
+
+def _compile_grid(events: List[TraceEvent], title: str) -> Optional[Dict[str, Any]]:
+    init = _init_events(events)
+    if not init:
+        return None
+    data = init[0].fields.get("data")
+    if not isinstance(data, list) or not data or not isinstance(data[0], list):
+        return None
+    rows = len(data)
+    cols = max(len(r) for r in data)
+    while rows * cols > GRID_MAX_CELLS and cols > 1:
+        cols -= 1
+    while rows * cols > GRID_MAX_CELLS and rows > 1:
+        rows -= 1
+    if rows * cols == 0:
+        return None
+
+    cell_w = min(GRID_CELL, 2 * 420.0 / max(cols, 1))
+    cell_h = min(GRID_CELL, 2 * 300.0 / max(rows, 1))
+    total_w = cols * cell_w + (cols - 1) * GRID_GAP
+    total_h = rows * cell_h + (rows - 1) * GRID_GAP
+    x0 = -total_w / 2 + cell_w / 2
+    y0 = GRID_Y - total_h / 2 + cell_h / 2
+
+    def cell_x(c: int) -> float:
+        return round(x0 + c * (cell_w + GRID_GAP), 2)
+
+    def cell_y(r: int) -> float:
+        return round(y0 + r * (cell_h + GRID_GAP), 2)
+
+    shapes: List[dict] = []
+    for r in range(rows):
+        for c in range(cols):
+            value = data[r][c] if r < len(data) and c < len(data[r]) else None
+            x, y = cell_x(c), cell_y(r)
+            shapes.append(_rect(f"cell_{r}_{c}", x, y, cell_w, cell_h, radius=6))
+            shapes.append(
+                _text(
+                    f"val_{r}_{c}",
+                    x,
+                    y,
+                    str(value) if value is not None else "",
+                    max(14, min(22, cell_w * 0.35)),
+                )
+            )
+
+    steps: List[dict] = _split_intro(shapes, f"Starting with the grid {rows}x{cols}.")
+
+    for e in events:
+        if e.kind == "init":
+            continue
+        motion: List[dict] = []
+        narration = ""
+        if e.kind == "return":
+            result = e.fields.get("result")
+            narration = (
+                f"Finished. Result: {result}." if result is not None else "Finished."
+            )
+            motion.append(
+                {"target": "cell_0_0", "op": "scale", "to": 1.0, "duration": 0.25}
+            )
+            steps.append(_step(narration, motion))
+            continue
+        r = getattr(e, "i", None)
+        c = getattr(e, "j", None)
+        if r is None:
+            continue
+        r = int(r)
+        if c is None:
+            c = 0
+        else:
+            c = int(c)
+        if e.kind == "visit":
+            if 0 <= r < rows and 0 <= c < cols:
+                motion.append(
+                    {
+                        "target": f"cell_{r}_{c}",
+                        "op": "fill",
+                        "to": CHECK_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{r}_{c}",
+                        "op": "stroke",
+                        "to": CHECK_STROKE,
+                        "duration": 0.25,
+                    }
+                )
+            narration = f"Visiting cell ({r}, {c})."
+        elif e.kind == "read":
+            if 0 <= r < rows and 0 <= c < cols:
+                motion.append(
+                    {
+                        "target": f"cell_{r}_{c}",
+                        "op": "fill",
+                        "to": ACTIVE_FILL,
+                        "duration": 0.25,
+                    }
+                )
+            narration = f"Read cell ({r}, {c})."
+        elif e.kind == "backtrack":
+            if 0 <= r < rows and 0 <= c < cols:
+                motion.append(
+                    {
+                        "target": f"cell_{r}_{c}",
+                        "op": "fill",
+                        "to": IDLE_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{r}_{c}",
+                        "op": "stroke",
+                        "to": IDLE_STROKE,
+                        "duration": 0.25,
+                    }
+                )
+            narration = f"Backtrack from cell ({r}, {c})."
+        elif e.kind in ("write", "dp_update"):
+            value = e.fields.get("value")
+            if 0 <= r < rows and 0 <= c < cols:
+                motion.append(
+                    {
+                        "target": f"val_{r}_{c}",
+                        "op": "label",
+                        "to": str(value),
+                        "duration": 0.3,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{r}_{c}",
+                        "op": "fill",
+                        "to": DONE_FILL,
+                        "duration": 0.3,
+                    }
+                )
+            narration = f"Cell ({r}, {c}) becomes {value}."
+        elif e.kind == "mark":
+            if 0 <= r < rows and 0 <= c < cols:
+                motion.append(
+                    {
+                        "target": f"cell_{r}_{c}",
+                        "op": "fill",
+                        "to": DONE_FILL,
+                        "duration": 0.3,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"cell_{r}_{c}",
+                        "op": "stroke",
+                        "to": DONE_STROKE,
+                        "duration": 0.3,
+                    }
+                )
+            narration = f"Cell ({r}, {c}) marked {e.fields.get('state', '')}."
+        if not motion:
+            continue
+        steps.append(_step(narration, motion))
+
+    if len(steps) < 3:
+        return None
+    return {
+        "title": title,
+        "data": {"rows": rows, "cols": cols, "family": "grid"},
+        "steps": steps,
+    }
+
+
+# ── graph ───────────────────────────────────────────────────────────────────
+GRAPH_MAX_VERTICES = 8
+GRAPH_MAX_EDGES = 16
+GRAPH_RADIUS = 230.0
+
+
+def _compile_graph(events: List[TraceEvent], title: str) -> Optional[Dict[str, Any]]:
+    init = _init_events(events)
+    if not init:
+        return None
+    data = init[0].fields.get("data")
+    if not isinstance(data, list) or not data:
+        return None
+    n = init[0].fields.get("n")
+    explicit_n = n is not None
+    if n is not None:
+        n = int(n)
+
+    flat = []
+    for entry in data:
+        if isinstance(entry, (list, tuple)):
+            for v in entry:
+                try:
+                    flat.append(int(v))
+                except (TypeError, ValueError):
+                    continue
+        else:
+            try:
+                flat.append(int(entry))
+            except (TypeError, ValueError):
+                continue
+    mx = max(flat, default=0)
+
+    if n is None:
+        # Without an explicit vertex count, treat the data as an adjacency
+        # list whose length is the vertex count (clone-graph style).
+        n = len(data)
+
+    adjacency: List[List[int]] = [[] for _ in range(n)]
+    # 1-indexed inputs (clone-graph node labels) shift down by one when any
+    # referenced id equals or exceeds the vertex count.
+    shift = 1 if mx >= n else 0
+    if not explicit_n and n > 0:
+        # Adjacency list (clone-graph style, no explicit vertex count): row r
+        # lists r's neighbors.
+        for r in range(n):
+            row = data[r] if r < len(data) and isinstance(data[r], list) else []
+            for b in row:
+                try:
+                    b = int(b) - shift
+                except (TypeError, ValueError):
+                    continue
+                if 0 <= b < n and b != r and b not in adjacency[r]:
+                    adjacency[r].append(b)
+    else:
+        # Edge list (course-schedule style, explicit vertex count): each entry
+        # is an [a, b] pair. The old len(data) == n heuristic was ambiguous —
+        # an edge list with as many edges as vertices was misread as an
+        # adjacency list, silently dropping edges.
+        for entry in data:
+            if not isinstance(entry, (list, tuple)) or len(entry) < 2:
+                continue
+            try:
+                a, b = int(entry[0]) - shift, int(entry[1]) - shift
+            except (TypeError, ValueError):
+                continue
+            if 0 <= a < n and 0 <= b < n and a != b and b not in adjacency[a]:
+                adjacency[a].append(b)
+
+    n = min(len(adjacency), GRAPH_MAX_VERTICES)
+    positions = []
+    for i in range(n):
+        angle = 2 * math.pi * i / n - math.pi / 2
+        positions.append(
+            (
+                round(GRAPH_RADIUS * math.cos(angle), 2),
+                round(GRAPH_RADIUS * math.sin(angle), 2),
+            )
+        )
+
+    edge_pairs = set()
+    for a in range(n):
+        for b in adjacency[a]:
+            edge_pairs.add(tuple(sorted((a, b))))
+    edge_pairs = sorted(edge_pairs)[:GRAPH_MAX_EDGES]
+
+    shapes: List[dict] = []
+    for a, b in edge_pairs:
+        xa, ya = positions[a]
+        xb, yb = positions[b]
+        shapes.append(
+            _line(f"ge_{a}_{b}", [[xa, ya], [xb, yb]], stroke="#475569", lineWidth=2)
+        )
+    for i in range(n):
+        x, y = positions[i]
+        shapes.append(_ellipse(f"g_node_{i}", x, y, 64, 64))
+        shapes.append(_text(f"g_val_{i}", x, y, str(i), 22))
+
+    steps: List[dict] = _split_intro(shapes, f"Starting with {n} vertices.")
+
+    for e in events:
+        if e.kind == "init":
+            continue
+        motion: List[dict] = []
+        narration = ""
+        if e.kind == "visit":
+            i = int(e.i)
+            if 0 <= i < n:
+                motion.append(
+                    {
+                        "target": f"g_node_{i}",
+                        "op": "fill",
+                        "to": CHECK_FILL,
+                        "duration": 0.25,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"g_node_{i}",
+                        "op": "stroke",
+                        "to": CHECK_STROKE,
+                        "duration": 0.25,
+                    }
+                )
+            narration = f"Visiting vertex {i}."
+        elif e.kind == "edge":
+            a, b = int(e.a), int(e.b)
+            key = tuple(sorted((a, b)))
+            if key in edge_pairs:
+                motion.append(
+                    {
+                        "target": f"ge_{key[0]}_{key[1]}",
+                        "op": "stroke",
+                        "to": SWAP_STROKE,
+                        "duration": 0.3,
+                    }
+                )
+            narration = f"Traversing the edge between {a} and {b}."
+        elif e.kind == "mark":
+            i = int(e.i)
+            if 0 <= i < n:
+                motion.append(
+                    {
+                        "target": f"g_node_{i}",
+                        "op": "fill",
+                        "to": DONE_FILL,
+                        "duration": 0.3,
+                    }
+                )
+                motion.append(
+                    {
+                        "target": f"g_node_{i}",
+                        "op": "stroke",
+                        "to": DONE_STROKE,
+                        "duration": 0.3,
+                    }
+                )
+            narration = f"Vertex {i} marked {e.fields.get('state', '')}."
+        elif e.kind == "return":
+            result = e.fields.get("result")
+            narration = (
+                f"Finished. Result: {result}." if result is not None else "Finished."
+            )
+            motion.append(
+                {"target": "g_node_0", "op": "scale", "to": 1.0, "duration": 0.25}
+            )
+        if not motion:
+            continue
+        steps.append(_step(narration, motion))
+
+    if len(steps) < 3:
+        return None
+    return {"title": title, "data": {"vertices": n, "family": "graph"}, "steps": steps}
+
+
+# ── intervals ───────────────────────────────────────────────────────────────
+IV_MAX = 10
+IV_WIDTH = 700.0
+IV_Y0 = -160.0
+IV_H = 40.0
+IV_GAP = 18.0
+
+
+def _compile_intervals(
+    events: List[TraceEvent], title: str
+) -> Optional[Dict[str, Any]]:
+    init = _init_events(events)
+    if not init:
+        return None
+    data = init[0].fields.get("data")
+    if not isinstance(data, list):
+        return None
+    intervals = []
+    for item in data:
+        if isinstance(item, (list, tuple)) and len(item) >= 2:
+            intervals.append((int(item[0]), int(item[1])))
+    intervals = intervals[:IV_MAX]
+    if not intervals:
+        return None
+
+    lo = min(s for s, _ in intervals)
+    hi = max(e for _, e in intervals)
+    span = max(hi - lo, 1)
+
+    def bar_x(start: int) -> float:
+        return round(-IV_WIDTH / 2 + (start - lo) * IV_WIDTH / span, 2)
+
+    def bar_w(start: int, end: int) -> float:
+        return max(20.0, round((end - start) * IV_WIDTH / span, 2))
+
+    shapes: List[dict] = []
+    for i, (s, e) in enumerate(intervals):
+        y = IV_Y0 + i * (IV_H + IV_GAP)
+        x = bar_x(s)
+        shapes.append(_rect(f"bar_{i}", x, y, bar_w(s, e), IV_H, radius=6))
+        shapes.append(_text(f"bar_val_{i}", x + bar_w(s, e) / 2, y, f"[{s},{e}]", 16))
+    shapes.append(
+        _polygon(
+            "ptr_i",
+            bar_x(lo),
+            IV_Y0 + IV_H + IV_GAP,
+            [[-12, -22], [0, 0], [12, -22]],
+            fill="#facc15",
+        )
+    )
+
+    steps: List[dict] = _split_intro(shapes, f"Starting with intervals {intervals}.")
+
+    for e in events:
+        if e.kind in ("init", "pointer"):
+            continue
+        motion: List[dict] = []
+        narration = ""
+        if e.kind == "visit":
+            i = int(e.i)
+            if 0 <= i < len(intervals):
+                motion.append(
+                    {
+                        "target": f"bar_{i}",
+                        "op": "fill",
+                        "to": CHECK_FILL,
+                        "duration": 0.25,
+                    }
+                )
+            narration = f"Considering interval {intervals[i] if 0 <= i < len(intervals) else ''}."
+        elif e.kind == "mark":
+            i = int(e.i)
+            state = str(e.fields.get("state", ""))
+            if 0 <= i < len(intervals):
+                motion.append(
+                    {
+                        "target": f"bar_{i}",
+                        "op": "fill",
+                        "to": DONE_FILL,
+                        "duration": 0.3,
+                    }
+                )
+            narration = f"Interval {i} marked {state}."
+        elif e.kind == "return":
+            result = e.fields.get("result")
+            narration = (
+                f"Finished. Result: {result}." if result is not None else "Finished."
+            )
+            motion.append(
+                {"target": "bar_0", "op": "scale", "to": 1.0, "duration": 0.25}
+            )
+        if not motion:
+            continue
+        steps.append(_step(narration, motion))
+
+    if len(steps) < 3:
+        return None
+    return {
+        "title": title,
+        "data": {"intervals": intervals, "family": "intervals"},
+        "steps": steps,
+    }
+
+
+FAMILY_COMPILERS: Dict[str, Any] = {
+    "array": _compile_array,
+    "backtrack": _compile_array,
+    "stack": _compile_stack,
+    "linked_list": _compile_linked_list,
+    "tree": _compile_tree,
+    "grid": _compile_grid,
+    "graph": _compile_graph,
+    "intervals": _compile_intervals,
+}
+
+
+def family_of(events: List[TraceEvent]) -> Optional[str]:
+    init = _init_events(events)
+    if not init:
+        return None
+    return init[0].fields.get("family")
+
+
+def compile_family(
+    family: str,
+    events: List[TraceEvent],
+    title: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Compile a trace for a visualization family into a validated scene, or None."""
+    if not events:
+        return None
+    resolved = family or family_of(events) or ""
+    compiler = FAMILY_COMPILERS.get(resolved)
+    if compiler is None:
+        logger.warning("No family compiler for %r", resolved)
+        return None
+    try:
+        return compiler(events, title=title)
+    except Exception as exc:  # noqa: BLE001 - a bad trace must never 500
+        logger.warning("Family compile failed (%s): %s", resolved, exc)
+        return None

--- a/backend/app/services/groq_service.py
+++ b/backend/app/services/groq_service.py
@@ -16,6 +16,13 @@ from app.services.redis_service import RedisCache, _content_hash
 logger = logging.getLogger(__name__)
 
 
+def _jsonable(value: Optional[Dict[str, Any]]) -> str:
+    """Deterministic string form of an optional payload, for cache keys."""
+    if value is None:
+        return ""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
 class GroqService(CoachingProvider):
     """Groq adapter for AI coaching (OpenAI-compatible chat completions)."""
 
@@ -25,6 +32,7 @@ class GroqService(CoachingProvider):
         "medium": "llama-3.3-70b-versatile",
         "hard": "llama-3.3-70b-versatile",
         "stream": "llama-3.1-8b-instant",
+        "animate": "llama-3.3-70b-versatile",
     }
 
     def __init__(
@@ -68,20 +76,43 @@ class GroqService(CoachingProvider):
         lesson_context: Optional[str] = None,
         chat_history: Optional[list] = None,
         endpoint: str = "coach",
+        initial_code: Optional[str] = None,
+        question: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         from app.models.schemas import StructuredCoachingResponse
 
         cache_key = None
         if self.cache and not chat_history:
             content_hash = _content_hash(
-                problem, code, message, mode, difficulty, lesson_context or "", "v3"
+                problem,
+                code,
+                message,
+                mode,
+                difficulty,
+                lesson_context or "",
+                initial_code or "",
+                _jsonable(question),
+                "v6",
             )
             cache_key = RedisCache.key("groq", "coaching", content_hash)
             cached = await self.cache.get(cache_key)
             if cached is not None:
-                return cached
+                if mode == "animate":
+                    # Animate cache entries must be revalidated on read: stale
+                    # legacy-format or too-thin scripts from older versions would
+                    # otherwise reach the viewer as a title-plus-narration frame.
+                    cached = self._validate_animation(cached)
+                    if cached.get("animation") is None:
+                        cached = None
+                if cached is not None:
+                    return cached
 
-        model = self.models.get(difficulty, self.models["medium"])
+        # Animate embeds full user/solution code arrays plus steps, so it always
+        # uses a capable dedicated model rather than the difficulty-tied tier.
+        if mode == "animate":
+            model = self.models["animate"]
+        else:
+            model = self.models.get(difficulty, self.models["medium"])
 
         system_prompt, user_prompt = self.prompts.build(
             mode=mode,
@@ -91,6 +122,8 @@ class GroqService(CoachingProvider):
             message=message,
             structured=True,
             lesson_context=lesson_context,
+            initial_code=initial_code,
+            question=question,
         )
 
         messages = [
@@ -100,10 +133,14 @@ class GroqService(CoachingProvider):
             messages.extend(chat_history)
         messages.append({"role": "user", "content": user_prompt})
 
+        # Animate responses embed full user/solution code arrays plus steps —
+        # 1000 tokens truncates the JSON, and the brace-repair parser then
+        # yields no usable animation. Give animate mode a larger budget.
+        max_tokens = 2000 if mode == "animate" else 1000
         payload = {
             "model": model,
             "messages": messages,
-            "max_completion_tokens": 1000,
+            "max_completion_tokens": max_tokens,
             "temperature": 0.1,
             "top_p": 0.9,
             "stream": False,
@@ -169,6 +206,7 @@ class GroqService(CoachingProvider):
         structured: bool = False,
         chat_history: Optional[list] = None,
         endpoint: str = "coach_stream",
+        initial_code: Optional[str] = None,
     ) -> AsyncIterator[str]:
         model = self.models["stream"]
 
@@ -180,6 +218,7 @@ class GroqService(CoachingProvider):
             message=message,
             structured=structured,
             lesson_context=lesson_context,
+            initial_code=initial_code,
         )
 
         messages = [
@@ -234,6 +273,49 @@ class GroqService(CoachingProvider):
             logger.error(f"Error calling Groq API: {str(e)}")
             raise HTTPException(status_code=500, detail="Internal server error")
 
+    async def get_animation_script(
+        self,
+        problem: str,
+        code: str,
+        language: str,
+        difficulty: str = "medium",
+        lesson_context: Optional[str] = None,
+        initial_code: Optional[str] = None,
+        question: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Return a validated visual algorithm animation (no chat text).
+
+        Backs the standalone Animate viewer endpoint. Returns None when the
+        model produces no usable animation so the endpoint can fail cleanly
+        instead of rendering a text-only chat response.
+
+        Exactly one Groq request is made: the dedicated animation model is
+        expected to follow the Animate contract, and a second attempt would
+        both double our provider load and risk a 429 surfacing to the user
+        after an already-usable first response.
+        """
+        structured = await self.get_structured_coaching_response(
+            problem=problem,
+            code=code,
+            language=language,
+            message="animate",
+            mode="animate",
+            difficulty=difficulty,
+            lesson_context=lesson_context,
+            initial_code=initial_code,
+            endpoint="animate",
+            question=question,
+        )
+        animation = structured.get("animation")
+        if animation is None:
+            logger.warning(
+                "Animate: produced no usable animation (problem=%.80r, language=%s)",
+                problem,
+                language,
+            )
+            return None
+        return animation
+
     # ── CoachingProvider port ─────────────────────────────────────────
 
     async def get_structured(
@@ -246,6 +328,7 @@ class GroqService(CoachingProvider):
         difficulty: str = "medium",
         lesson_context: Optional[str] = None,
         chat_history: Optional[list] = None,
+        initial_code: Optional[str] = None,
     ) -> Dict[str, Any]:
         return await self.get_structured_coaching_response(
             problem=problem,
@@ -256,6 +339,7 @@ class GroqService(CoachingProvider):
             difficulty=difficulty,
             lesson_context=lesson_context,
             chat_history=chat_history,
+            initial_code=initial_code,
         )
 
     async def stream(
@@ -268,6 +352,7 @@ class GroqService(CoachingProvider):
         difficulty: str = "medium",
         lesson_context: Optional[str] = None,
         chat_history: Optional[list] = None,
+        initial_code: Optional[str] = None,
     ) -> AsyncIterator[str]:
         async for chunk in self.get_coaching_response(
             problem=problem,
@@ -278,24 +363,51 @@ class GroqService(CoachingProvider):
             difficulty=difficulty,
             lesson_context=lesson_context,
             chat_history=chat_history,
+            initial_code=initial_code,
         ):
             yield chunk
 
     # ── helpers ───────────────────────────────────────────────────────
 
     @staticmethod
+    def _is_legacy_animation(animation: Any) -> bool:
+        """True when the model returned a pre-generic typed animation.
+
+        Legacy animations carry a top-level ``type`` or per-step ``operation``
+        fields. They contain no renderable shapes/motion, so they would reach
+        the viewer as a title-plus-narration frame — reject them outright.
+        """
+        if not isinstance(animation, dict):
+            return True
+        if "type" in animation:
+            return True
+        steps = animation.get("steps")
+        return isinstance(steps, list) and any(
+            isinstance(step, dict) and "operation" in step for step in steps
+        )
+
+    @staticmethod
     def _validate_animation(data: Dict[str, Any]) -> Dict[str, Any]:
         """Drop invalid animation scripts, keep the rest of the response.
 
-        A structurally valid but semantically incorrect script is also
-        dropped — the animation must never lie about the algorithm. The
-        coaching text still renders, so the student experience degrades
-        gracefully instead of showing a wrong animation.
+        The generic scene validator enforces structural rules (bounds,
+        uniqueness, caps, motion-target resolution) plus the richness floor
+        (at least 3 steps, at least 2 shapes, motion in every step). A scene
+        that fails them is dropped so the viewer never receives unrenderable
+        data — the coaching text still renders, so the student experience
+        degrades gracefully instead of showing a broken animation.
         """
         if not data.get("animation"):
             return data
         try:
-            validated, reason = AnimationValidator().validate(data["animation"])
+            animation = data["animation"]
+            if GroqService._is_legacy_animation(animation):
+                logger.warning(
+                    "Dropping legacy-format animation (generic scene required)"
+                )
+                data.pop("animation", None)
+                return data
+            validated, reason = AnimationValidator().validate(animation)
         except Exception as e:  # defensive: a bad script must never 500 the endpoint
             logger.warning("Animation validation raised: %s", e)
             data.pop("animation", None)

--- a/backend/app/services/question_catalog.py
+++ b/backend/app/services/question_catalog.py
@@ -1,0 +1,126 @@
+"""Exact question-id → algorithm mapping for the curated animation catalog.
+
+Every question in the live 100-question Supabase inventory is pinned to one
+canonical algorithm by its stable id. This exact map runs before any keyword
+matching, so category names like "Binary Search" can never over-match a whole
+category again — each question is resolved deterministically.
+
+A question with a known id that the keyword scan would otherwise mis-map is
+therefore always correct. Unknown ids fall through to keyword matching in
+reference_solutions.resolve_algorithm.
+"""
+
+from typing import Any, Dict, Optional
+
+QUESTION_ALGORITHMS: Dict[str, str] = {
+    "add-two-numbers": "add_two_numbers",
+    "balanced-binary-tree": "balanced_binary_tree",
+    "best-time-to-buy-and-sell-stock": "best_time_to_buy_and_sell",
+    "binary-search": "binary_search",
+    "binary-tree-level-order-traversal": "binary_tree_level_order_traversal",
+    "binary-tree-maximum-path-sum": "binary_tree_maximum_path_sum",
+    "burst-balloons": "burst_balloons",
+    "car-fleet": "car_fleet",
+    "climbing-stairs": "climbing_stairs",
+    "clone-graph": "clone_graph",
+    "coin-change": "coin_change",
+    "combination-sum": "combination_sum",
+    "container-with-most-water": "container_with_most_water",
+    "contains-duplicate": "contains_duplicate",
+    "contiguous-array": "contiguous_array",
+    "course-schedule": "course_schedule",
+    "course-schedule-ii": "course_schedule_ii",
+    "daily-temperatures": "daily_temperatures",
+    "decode-ways": "decode_ways",
+    "edit-distance": "edit_distance",
+    "evaluate-reverse-polish-notation": "evaluate_reverse_polish_notation",
+    "find-all-duplicates-in-an-array": "find_all_duplicates",
+    "find-first-and-last-position-in-sorted-array": "find_first_and_last",
+    "find-minimum-in-rotated-sorted-array": "find_minimum_in_rotated",
+    "find-the-duplicate-number": "find_the_duplicate_number",
+    "first-missing-positive": "first_missing_positive",
+    "c9d1a3f2-5b6e-4a7f-8c0d-1e2f3a4b5c6d": "first_word",
+    "gas-station": "gas_station",
+    "generate-parentheses": "generate_parentheses",
+    "group-anagrams": "group_anagrams",
+    "hand-of-straights": "hand_of_straights",
+    "happy-number": "happy_number",
+    "house-robber": "house_robber",
+    "invert-binary-tree": "invert_binary_tree",
+    "is-subsequence": "is_subsequence",
+    "jump-game": "jump_game",
+    "jump-game-ii": "jump_game_ii",
+    "k-closest-points-to-origin": "k_closest",
+    "koko-eating-bananas": "koko_eating_bananas",
+    "kth-largest-element-in-an-array": "kth_largest",
+    "kth-smallest-element-in-a-bst": "kth_smallest_element_in_a_bst",
+    "largest-rectangle-in-histogram": "largest_rectangle_in_histogram",
+    "linked-list-cycle": "linked_list_cycle",
+    "longest-common-prefix": "longest_common_prefix",
+    "longest-consecutive-sequence": "longest_consecutive_sequence",
+    "longest-increasing-subsequence": "longest_increasing_subsequence",
+    "longest-repeating-character-replacement": "longest_repeating_character_replacement",
+    "longest-substring-without-repeating-characters": "longest_substring_without_repeating",
+    "longest-valid-parentheses": "longest_valid_parentheses",
+    "lowest-common-ancestor-of-a-binary-tree": "lowest_common_ancestor",
+    "majority-element": "majority_element",
+    "maximum-depth-of-binary-tree": "maximum_depth_of_binary_tree",
+    "maximum-product-subarray": "maximum_product_subarray",
+    "median-of-two-sorted-arrays": "median_of_two_sorted_arrays",
+    "merge-intervals": "merge_intervals",
+    "merge-k-sorted-lists": "merge_k_sorted_lists",
+    "merge-two-sorted-lists": "merge_two_sorted_lists",
+    "min-stack": "min_stack",
+    "minimum-window-substring": "minimum_window_substring",
+    "missing-number": "missing_number",
+    "7b9d2c1a-3e4f-5a6b-7c8d-9e0f1a2b3c4d": "most_frequent_char",
+    "move-zeroes": "move_zeroes",
+    "next-permutation": "next_permutation",
+    "non-overlapping-intervals": "non_overlapping_intervals",
+    "number-of-1-bits": "number_of_1_bits",
+    "number-of-islands": "number_of_islands",
+    "partition-labels": "partition_labels",
+    "permutation-in-string": "permutation_in_string",
+    "permutations": "permutations",
+    "power-of-two": "power_of_two",
+    "product-of-array-except-self": "product_of_array_except_self",
+    "ransom-note": "ransom_note",
+    "remove-nth-node-from-end-of-list": "remove_nth_node_from_end",
+    "reorder-list": "reorder_list",
+    "reverse-integer": "reverse_integer",
+    "reverse-linked-list": "reverse_linked_list",
+    "reverse-string": "reverse_string",
+    "rotate-image": "rotate_image",
+    "same-tree": "same_tree",
+    "search-in-rotated-sorted-array": "search_in_rotated",
+    "search-insert-position": "search_insert_position",
+    "single-number": "single_number",
+    "sliding-window-maximum": "sliding_window_maximum",
+    "subarray-sum-equals-k": "subarray_sum_equals_k",
+    "subsets": "subsets",
+    "task-scheduler": "task_scheduler",
+    "three-sum": "three_sum",
+    "three-sum-closest": "three_sum_closest",
+    "top-k-frequent-elements": "top_k_frequent",
+    "trapping-rain-water": "trapping_rain_water",
+    "two-sum": "two_sum",
+    "two-sum-ii-input-array-is-sorted": "two_sum_ii",
+    "valid-anagram": "valid_anagram",
+    "f7e2d4a1-3b5c-4d6e-8f9a-0b1c2d3e4f5a": "valid_palindrome",
+    "valid-palindrome": "valid_palindrome",
+    "valid-parentheses": "valid_parentheses",
+    "validate-binary-search-tree": "validate_binary_search_tree",
+    "word-break": "word_break",
+    "word-ladder": "word_ladder",
+    "word-search": "word_search",
+}
+
+
+def resolve_by_id(question: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Return the algorithm pinned to the question's id, or None."""
+    if not isinstance(question, dict):
+        return None
+    qid = question.get("id")
+    if isinstance(qid, str):
+        return QUESTION_ALGORITHMS.get(qid)
+    return None

--- a/backend/app/services/reference_solutions.py
+++ b/backend/app/services/reference_solutions.py
@@ -1,0 +1,2584 @@
+"""Curated catalog of canonical optimal solutions.
+
+Each entry is the *optimal* solution for a well-known algorithm, written
+against the __trace API so executing it produces the semantic event stream
+that drives the universal animation renderer. Every canonical solution emits
+its own ``init`` event (deep-copying the structure so the compiler shows the
+original input), then describes the algorithm with semantic events; the
+visuals are owned by the family compilers, never by the model.
+
+Each entry:
+- family: array | backtrack | stack | linked_list | tree | grid | graph | intervals
+- function: the callable name
+- signature: parameter names in order (the input normalizer maps positional
+  inputs onto the first parameter)
+- primary: the parameter whose value is the main visual structure (metadata)
+- match_keys: keyword fallback matching for questions without an exact id
+- code: the traced canonical solution
+
+The mapping from the 100 DB questions to these algorithms lives in
+``question_catalog.py`` (exact question-id keys take precedence).
+"""
+
+FAMILIES = frozenset(
+    {"array", "backtrack", "stack", "linked_list", "tree", "grid", "graph", "intervals"}
+)
+
+from typing import Optional  # noqa: E402  (module-level helpers below)
+
+REFERENCE_SOLUTIONS: dict = {
+    # ── arrays: sorting & search ─────────────────────────────────────────────
+    "bubble_sort": {
+        "family": "array",
+        "title": "Bubble Sort",
+        "function": "bubble_sort",
+        "signature": ["values"],
+        "primary": "values",
+        "match_keys": ["bubble sort", "bubble_sort"],
+        "code": """\
+def bubble_sort(values):
+    __trace("init", values=__json.loads(__json.dumps(list(values))), family="array")
+    n = len(values)
+    for i in range(n - 1):
+        for j in range(n - i - 1):
+            __trace("pointer", name="j", index=j)
+            __trace("compare", i=j, j=j + 1)
+            if values[j] > values[j + 1]:
+                values[j], values[j + 1] = values[j + 1], values[j]
+                __trace("swap", i=j, j=j + 1)
+        __trace("mark", i=n - i - 1, state="sorted")
+    return values
+""",
+    },
+    "linear_search": {
+        "family": "array",
+        "title": "Linear Search",
+        "function": "linear_search",
+        "signature": ["values", "target"],
+        "primary": "values",
+        "match_keys": ["linear search", "linear_scan"],
+        "code": """\
+def linear_search(values, target):
+    __trace("init", values=__json.loads(__json.dumps(list(values))), family="array")
+    for i, v in enumerate(values):
+        __trace("pointer", name="i", index=i)
+        __trace("compare", i=i)
+        if v == target:
+            __trace("mark", i=i, state="match")
+            return i
+    return -1
+""",
+    },
+    "binary_search": {
+        "family": "array",
+        "title": "Binary Search",
+        "function": "binary_search",
+        "signature": ["nums", "target"],
+        "primary": "nums",
+        "match_keys": ["binary search", "binary_search"],
+        "code": """\
+def binary_search(nums, target):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    low, high = 0, len(nums) - 1
+    while low <= high:
+        mid = (low + high) // 2
+        __trace("pointer", name="low", index=low)
+        __trace("pointer", name="high", index=high)
+        __trace("pointer", name="mid", index=mid)
+        __trace("compare", i=mid)
+        if nums[mid] == target:
+            __trace("mark", i=mid, state="match")
+            return mid
+        elif nums[mid] < target:
+            low = mid + 1
+        else:
+            high = mid - 1
+    return -1
+""",
+    },
+    # ── arrays: hashing & counts ────────────────────────────────────────────
+    "two_sum": {
+        "family": "array",
+        "title": "Two Sum",
+        "function": "two_sum",
+        "signature": ["nums", "target"],
+        "primary": "nums",
+        "match_keys": ["two sum", "two_sum"],
+        "code": """\
+def two_sum(nums, target):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    seen = {}
+    for i, n in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        __trace("compare", i=i)
+        diff = target - n
+        if diff in seen:
+            __trace("mark", i=i, state="match")
+            return [seen[diff], i]
+        seen[n] = i
+    return []
+""",
+    },
+    "contains_duplicate": {
+        "family": "array",
+        "title": "Contains Duplicate",
+        "function": "contains_duplicate",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["contains duplicate", "any value appears at least twice"],
+        "code": """\
+def contains_duplicate(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    seen = set()
+    for i, n in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        if n in seen:
+            __trace("mark", i=i, state="match")
+            return True
+        seen.add(n)
+    return False
+""",
+    },
+    "majority_element": {
+        "family": "array",
+        "title": "Majority Element",
+        "function": "majority_element",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["majority element", "appears more than n"],
+        "code": """\
+def majority_element(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    candidate = None
+    count = 0
+    for i, n in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        if count == 0:
+            candidate = n
+            __trace("mark", i=i, state="active")
+        count += 1 if n == candidate else -1
+    return candidate
+""",
+    },
+    "single_number": {
+        "family": "array",
+        "title": "Single Number",
+        "function": "single_number",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["single number", "every element appears twice"],
+        "code": """\
+def single_number(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    acc = 0
+    for i, n in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        acc ^= n
+    return acc
+""",
+    },
+    "missing_number": {
+        "family": "array",
+        "title": "Missing Number",
+        "function": "missing_number",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["missing number", "only number in the range"],
+        "code": """\
+def missing_number(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    acc = len(nums)
+    for i, v in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        acc ^= i ^ v
+    return acc
+""",
+    },
+    "find_the_duplicate_number": {
+        "family": "array",
+        "title": "Find the Duplicate Number",
+        "function": "find_the_duplicate_number",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["duplicate number"],
+        "code": """\
+def find_the_duplicate_number(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    slow = fast = nums[0]
+    while True:
+        slow = nums[slow]
+        fast = nums[nums[fast]]
+        if slow == fast:
+            break
+    __trace("pointer", name="slow", index=slow)
+    __trace("visit", i=slow)
+    slow = nums[0]
+    while slow != fast:
+        __trace("pointer", name="slow", index=slow)
+        __trace("pointer", name="fast", index=fast)
+        slow = nums[slow]
+        fast = nums[fast]
+    __trace("mark", i=slow, state="match")
+    return slow
+""",
+    },
+    "find_all_duplicates": {
+        "family": "array",
+        "title": "Find All Duplicates in an Array",
+        "function": "find_all_duplicates",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["all duplicates", "each integer appears once or twice"],
+        "code": """\
+def find_all_duplicates(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    result = []
+    for i, n in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        idx = abs(n) - 1
+        if nums[idx] < 0:
+            __trace("mark", i=i, state="match")
+            result.append(abs(n))
+        else:
+            nums[idx] = -nums[idx]
+            __trace("visit", i=i)
+    return result
+""",
+    },
+    "first_missing_positive": {
+        "family": "array",
+        "title": "First Missing Positive",
+        "function": "first_missing_positive",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["first missing positive", "smallest positive integer"],
+        "code": """\
+def first_missing_positive(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    n = len(nums)
+    for i in range(n):
+        __trace("pointer", name="i", index=i)
+        while 1 <= nums[i] <= n and nums[nums[i] - 1] != nums[i]:
+            idx = nums[i] - 1
+            nums[i], nums[idx] = nums[idx], nums[i]
+            __trace("swap", i=i, j=idx)
+    for i in range(n):
+        __trace("pointer", name="i", index=i)
+        if nums[i] != i + 1:
+            __trace("mark", i=i, state="match")
+            return i + 1
+    return n + 1
+""",
+    },
+    "longest_consecutive_sequence": {
+        "family": "array",
+        "title": "Longest Consecutive Sequence",
+        "function": "longest_consecutive_sequence",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["longest consecutive"],
+        "code": """\
+def longest_consecutive_sequence(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    values = set(nums)
+    best = 0
+    for i, n in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        if n - 1 not in values:
+            length = 1
+            while n + length in values:
+                __trace("visit", i=i)
+                length += 1
+            best = max(best, length)
+            __trace("mark", i=i, state="match")
+    return best
+""",
+    },
+    "valid_anagram": {
+        "family": "array",
+        "title": "Valid Anagram",
+        "function": "valid_anagram",
+        "signature": ["s", "t"],
+        "primary": "s",
+        "match_keys": ["valid anagram", "anagram"],
+        "code": """\
+def valid_anagram(s, t):
+    __trace("init", values=__json.loads(__json.dumps(list(s))), family="array")
+    if len(s) != len(t):
+        return False
+    from collections import Counter
+    cs = Counter(s)
+    for i, ch in enumerate(t):
+        __trace("pointer", name="i", index=i)
+        cs[ch] -= 1
+        if cs[ch] < 0:
+            return False
+        __trace("mark", i=i, state="match")
+    return not any(cs.values())
+""",
+    },
+    "group_anagrams": {
+        "family": "array",
+        "title": "Group Anagrams",
+        "function": "group_anagrams",
+        "signature": ["strs"],
+        "primary": "strs",
+        "match_keys": ["group anagrams"],
+        "code": """\
+def group_anagrams(strs):
+    __trace("init", values=__json.loads(__json.dumps(list(strs))), family="array")
+    groups = {}
+    for i, w in enumerate(strs):
+        __trace("pointer", name="i", index=i)
+        key = "".join(sorted(w))
+        groups.setdefault(key, []).append(w)
+        __trace("mark", i=i, state="active")
+    return list(groups.values())
+""",
+    },
+    "top_k_frequent": {
+        "family": "array",
+        "title": "Top K Frequent Elements",
+        "function": "top_k_frequent",
+        "signature": ["nums", "k"],
+        "primary": "nums",
+        "match_keys": ["top k frequent"],
+        "code": """\
+def top_k_frequent(nums, k):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    from collections import Counter
+    counts = Counter(nums)
+    top = sorted(counts.items(), key=lambda kv: -kv[1])[:k]
+    top_keys = {kv[0] for kv in top}
+    for i, n in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        if n in top_keys:
+            __trace("mark", i=i, state="match")
+    return [kv[0] for kv in top]
+""",
+    },
+    "product_of_array_except_self": {
+        "family": "array",
+        "title": "Product of Array Except Self",
+        "function": "product_of_array_except_self",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": [
+            "product of array except self",
+            "product of all the elements of",
+        ],
+        "code": """\
+def product_of_array_except_self(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    n = len(nums)
+    res = [1] * n
+    prefix = 1
+    for i in range(n):
+        __trace("pointer", name="i", index=i)
+        res[i] = prefix
+        prefix *= nums[i]
+        __trace("write", i=i, value=res[i])
+    suffix = 1
+    for i in range(n - 1, -1, -1):
+        __trace("pointer", name="i", index=i)
+        res[i] *= suffix
+        suffix *= nums[i]
+        __trace("write", i=i, value=res[i])
+    return res
+""",
+    },
+    "subarray_sum_equals_k": {
+        "family": "array",
+        "title": "Subarray Sum Equals K",
+        "function": "subarray_sum_equals_k",
+        "signature": ["nums", "k"],
+        "primary": "nums",
+        "match_keys": ["subarray sum equals k"],
+        "code": """\
+def subarray_sum_equals_k(nums, k):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    prefix = 0
+    seen = {0: 1}
+    count = 0
+    for i, n in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        prefix += n
+        if prefix - k in seen:
+            __trace("mark", i=i, state="match")
+            count += seen[prefix - k]
+        seen[prefix] = seen.get(prefix, 0) + 1
+    return count
+""",
+    },
+    "contiguous_array": {
+        "family": "array",
+        "title": "Contiguous Array",
+        "function": "contiguous_array",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["contiguous array", "maximum length of a contiguous subarray"],
+        "code": """\
+def contiguous_array(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    seen = {0: -1}
+    acc = 0
+    best = 0
+    for i, n in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        acc += 1 if n == 1 else -1
+        if acc in seen:
+            best = max(best, i - seen[acc])
+            __trace("mark", i=i, state="match")
+        else:
+            seen[acc] = i
+    return best
+""",
+    },
+    "next_permutation": {
+        "family": "array",
+        "title": "Next Permutation",
+        "function": "next_permutation",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["next permutation"],
+        "code": """\
+def next_permutation(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    n = len(nums)
+    i = n - 2
+    while i >= 0 and nums[i] >= nums[i + 1]:
+        i -= 1
+    if i >= 0:
+        j = n - 1
+        while nums[j] <= nums[i]:
+            j -= 1
+        __trace("pointer", name="pivot", index=i)
+        __trace("swap", i=i, j=j)
+        nums[i], nums[j] = nums[j], nums[i]
+    l, r = i + 1, n - 1
+    while l < r:
+        __trace("pointer", name="l", index=l)
+        __trace("pointer", name="r", index=r)
+        __trace("swap", i=l, j=r)
+        nums[l], nums[r] = nums[r], nums[l]
+        l += 1
+        r -= 1
+    return nums
+""",
+    },
+    # ── arrays: two pointers ────────────────────────────────────────────────
+    "reverse_string": {
+        "family": "array",
+        "title": "Reverse String",
+        "function": "reverse_string",
+        "signature": ["s"],
+        "primary": "s",
+        "match_keys": ["reverse string", "reverse_string"],
+        "code": """\
+def reverse_string(s):
+    __trace("init", values=__json.loads(__json.dumps(list(s))), family="array")
+    left, right = 0, len(s) - 1
+    while left < right:
+        __trace("pointer", name="left", index=left)
+        __trace("pointer", name="right", index=right)
+        __trace("swap", i=left, j=right)
+        s[left], s[right] = s[right], s[left]
+        left += 1
+        right -= 1
+    return s
+""",
+    },
+    "move_zeroes": {
+        "family": "array",
+        "title": "Move Zeroes",
+        "function": "move_zeroes",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["move zeroes", "move all 0"],
+        "code": """\
+def move_zeroes(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    slow = 0
+    for fast in range(len(nums)):
+        __trace("pointer", name="fast", index=fast)
+        __trace("visit", i=fast)
+        if nums[fast] != 0:
+            if slow != fast:
+                __trace("swap", i=slow, j=fast)
+                nums[slow], nums[fast] = nums[fast], nums[slow]
+            slow += 1
+    return nums
+""",
+    },
+    "valid_palindrome": {
+        "family": "array",
+        "title": "Valid Palindrome",
+        "function": "valid_palindrome",
+        "signature": ["s"],
+        "primary": "s",
+        "match_keys": ["valid palindrome", "palindrome phrase"],
+        "code": """\
+def valid_palindrome(s):
+    __trace("init", values=__json.loads(__json.dumps(list(s))), family="array")
+    l, r = 0, len(s) - 1
+    while l < r:
+        __trace("pointer", name="left", index=l)
+        __trace("pointer", name="right", index=r)
+        while l < r and not s[l].isalnum():
+            l += 1
+        while l < r and not s[r].isalnum():
+            r -= 1
+        if l >= r:
+            break
+        __trace("compare", i=l, j=r)
+        if s[l].lower() != s[r].lower():
+            return False
+        l += 1
+        r -= 1
+    return True
+""",
+    },
+    "is_subsequence": {
+        "family": "array",
+        "title": "Is Subsequence",
+        "function": "is_subsequence",
+        "signature": ["s", "t"],
+        "primary": "t",
+        "match_keys": ["is subsequence", "subsequence of"],
+        "code": """\
+def is_subsequence(s, t):
+    __trace("init", values=__json.loads(__json.dumps(list(t))), family="array")
+    i = 0
+    for j, ch in enumerate(t):
+        __trace("pointer", name="j", index=j)
+        if i < len(s) and ch == s[i]:
+            __trace("mark", i=j, state="match")
+            i += 1
+    return i == len(s)
+""",
+    },
+    "two_sum_ii": {
+        "family": "array",
+        "title": "Two Sum II — Input Array Is Sorted",
+        "function": "two_sum_ii",
+        "signature": ["numbers", "target"],
+        "primary": "numbers",
+        "match_keys": ["two sum ii", "input array is sorted"],
+        "code": """\
+def two_sum_ii(numbers, target):
+    __trace("init", values=__json.loads(__json.dumps(list(numbers))), family="array")
+    l, r = 0, len(numbers) - 1
+    while l < r:
+        __trace("pointer", name="l", index=l)
+        __trace("pointer", name="r", index=r)
+        __trace("compare", i=l, j=r)
+        s = numbers[l] + numbers[r]
+        if s == target:
+            __trace("mark", i=l, state="match")
+            __trace("mark", i=r, state="match")
+            return [l + 1, r + 1]
+        elif s < target:
+            l += 1
+        else:
+            r -= 1
+    return []
+""",
+    },
+    "three_sum": {
+        "family": "array",
+        "title": "3Sum",
+        "function": "three_sum",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["three sum", "3sum", "unique triplets"],
+        "code": """\
+def three_sum(nums):
+    vals = sorted(nums)
+    __trace("init", values=__json.loads(__json.dumps(vals)), family="array")
+    result = []
+    n = len(vals)
+    for i in range(n - 2):
+        __trace("pointer", name="i", index=i)
+        if i > 0 and vals[i] == vals[i - 1]:
+            continue
+        l, r = i + 1, n - 1
+        while l < r:
+            __trace("pointer", name="l", index=l)
+            __trace("pointer", name="r", index=r)
+            s = vals[i] + vals[l] + vals[r]
+            if s == 0:
+                result.append([vals[i], vals[l], vals[r]])
+                __trace("compare", i=l, j=r)
+                __trace("mark", i=l, state="match")
+                __trace("mark", i=r, state="match")
+                while l < r and vals[l] == vals[l + 1]:
+                    l += 1
+                while l < r and vals[r] == vals[r - 1]:
+                    r -= 1
+                l += 1
+                r -= 1
+            elif s < 0:
+                l += 1
+            else:
+                r -= 1
+    return result
+""",
+    },
+    "three_sum_closest": {
+        "family": "array",
+        "title": "3Sum Closest",
+        "function": "three_sum_closest",
+        "signature": ["nums", "target"],
+        "primary": "nums",
+        "match_keys": ["three sum closest", "3sum closest"],
+        "code": """\
+def three_sum_closest(nums, target):
+    vals = sorted(nums)
+    __trace("init", values=__json.loads(__json.dumps(vals)), family="array")
+    best = sum(vals[:3])
+    for i in range(len(vals) - 2):
+        __trace("pointer", name="i", index=i)
+        l, r = i + 1, len(vals) - 1
+        while l < r:
+            __trace("pointer", name="l", index=l)
+            __trace("pointer", name="r", index=r)
+            __trace("compare", i=l, j=r)
+            s = vals[i] + vals[l] + vals[r]
+            if s == target:
+                return s
+            if abs(s - target) < abs(best - target):
+                best = s
+            if s < target:
+                l += 1
+            else:
+                r -= 1
+    return best
+""",
+    },
+    "container_with_most_water": {
+        "family": "array",
+        "title": "Container With Most Water",
+        "function": "container_with_most_water",
+        "signature": ["height"],
+        "primary": "height",
+        "match_keys": ["container with most water"],
+        "code": """\
+def container_with_most_water(height):
+    __trace("init", values=__json.loads(__json.dumps(list(height))), family="array")
+    l, r = 0, len(height) - 1
+    best = 0
+    while l < r:
+        __trace("pointer", name="left", index=l)
+        __trace("pointer", name="right", index=r)
+        __trace("compare", i=l, j=r)
+        best = max(best, min(height[l], height[r]) * (r - l))
+        if height[l] < height[r]:
+            l += 1
+        else:
+            r -= 1
+    return best
+""",
+    },
+    "trapping_rain_water": {
+        "family": "array",
+        "title": "Trapping Rain Water",
+        "function": "trapping_rain_water",
+        "signature": ["height"],
+        "primary": "height",
+        "match_keys": ["trapping rain water", "trap after rain"],
+        "code": """\
+def trapping_rain_water(height):
+    __trace("init", values=__json.loads(__json.dumps(list(height))), family="array")
+    l, r = 0, len(height) - 1
+    lm = rm = 0
+    water = 0
+    while l < r:
+        __trace("pointer", name="left", index=l)
+        __trace("pointer", name="right", index=r)
+        __trace("compare", i=l, j=r)
+        if height[l] < height[r]:
+            if height[l] >= lm:
+                lm = height[l]
+            else:
+                water += lm - height[l]
+                __trace("mark", i=l, state="active")
+            l += 1
+        else:
+            if height[r] >= rm:
+                rm = height[r]
+            else:
+                water += rm - height[r]
+                __trace("mark", i=r, state="active")
+            r -= 1
+    return water
+""",
+    },
+    "partition_labels": {
+        "family": "array",
+        "title": "Partition Labels",
+        "function": "partition_labels",
+        "signature": ["s"],
+        "primary": "s",
+        "match_keys": ["partition labels", "partition the string"],
+        "code": """\
+def partition_labels(s):
+    __trace("init", values=__json.loads(__json.dumps(list(s))), family="array")
+    last = {ch: i for i, ch in enumerate(s)}
+    left = 0
+    right = 0
+    sizes = []
+    for i, ch in enumerate(s):
+        __trace("pointer", name="i", index=i)
+        right = max(right, last[ch])
+        if i == right:
+            __trace("mark", i=i, state="match")
+            sizes.append(i - left + 1)
+            left = i + 1
+    return sizes
+""",
+    },
+    # ── arrays: sliding window ──────────────────────────────────────────────
+    "longest_substring_without_repeating": {
+        "family": "array",
+        "title": "Longest Substring Without Repeating Characters",
+        "function": "longest_substring_without_repeating",
+        "signature": ["s"],
+        "primary": "s",
+        "match_keys": ["longest substring without repeating"],
+        "code": """\
+def longest_substring_without_repeating(s):
+    __trace("init", values=__json.loads(__json.dumps(list(s))), family="array")
+    seen = {}
+    left = 0
+    best = 0
+    for right, ch in enumerate(s):
+        if ch in seen and seen[ch] >= left:
+            left = seen[ch] + 1
+        seen[ch] = right
+        __trace("window", l=left, r=right)
+        __trace("pointer", name="r", index=right)
+        best = max(best, right - left + 1)
+    return best
+""",
+    },
+    "permutation_in_string": {
+        "family": "array",
+        "title": "Permutation in String",
+        "function": "permutation_in_string",
+        "signature": ["s1", "s2"],
+        "primary": "s2",
+        "match_keys": ["permutation in string"],
+        "code": """\
+def permutation_in_string(s1, s2):
+    __trace("init", values=__json.loads(__json.dumps(list(s2))), family="array")
+    n1 = len(s1)
+    if n1 > len(s2):
+        return False
+    from collections import Counter
+    need = Counter(s1)
+    have = Counter()
+    left = 0
+    for right, ch in enumerate(s2):
+        have[ch] += 1
+        if right - left + 1 > n1:
+            have[s2[left]] -= 1
+            left += 1
+        __trace("window", l=left, r=right)
+        __trace("pointer", name="r", index=right)
+        if right - left + 1 == n1 and have == need:
+            __trace("mark", i=left, state="match")
+            return True
+    return False
+""",
+    },
+    "longest_repeating_character_replacement": {
+        "family": "array",
+        "title": "Longest Repeating Character Replacement",
+        "function": "longest_repeating_character_replacement",
+        "signature": ["s", "k"],
+        "primary": "s",
+        "match_keys": ["longest repeating character replacement"],
+        "code": """\
+def longest_repeating_character_replacement(s, k):
+    __trace("init", values=__json.loads(__json.dumps(list(s))), family="array")
+    from collections import Counter
+    counts = Counter()
+    left = 0
+    best = 0
+    maxf = 0
+    for right, ch in enumerate(s):
+        counts[ch] += 1
+        maxf = max(maxf, counts[ch])
+        if right - left + 1 - maxf > k:
+            counts[s[left]] -= 1
+            left += 1
+        __trace("window", l=left, r=right)
+        __trace("pointer", name="r", index=right)
+        best = max(best, right - left + 1)
+    return best
+""",
+    },
+    "minimum_window_substring": {
+        "family": "array",
+        "title": "Minimum Window Substring",
+        "function": "minimum_window_substring",
+        "signature": ["s", "t"],
+        "primary": "s",
+        "match_keys": ["minimum window substring"],
+        "code": """\
+def minimum_window_substring(s, t):
+    __trace("init", values=__json.loads(__json.dumps(list(s))), family="array")
+    from collections import Counter
+    need = Counter(t)
+    have = {}
+    missing = len(need)
+    left = 0
+    best = None
+    for right, ch in enumerate(s):
+        __trace("pointer", name="r", index=right)
+        if ch in need:
+            have[ch] = have.get(ch, 0) + 1
+            if have[ch] == need[ch]:
+                missing -= 1
+        while missing == 0:
+            if best is None or right - left + 1 < best[1]:
+                best = (left, right - left + 1)
+            lc = s[left]
+            if lc in need:
+                have[lc] -= 1
+                if have[lc] < need[lc]:
+                    missing += 1
+            left += 1
+        __trace("window", l=left, r=right)
+        if best:
+            __trace("mark", i=best[0], state="match")
+    return s[best[0]:best[0] + best[1]] if best else ""
+""",
+    },
+    "sliding_window_maximum": {
+        "family": "array",
+        "title": "Sliding Window Maximum",
+        "function": "sliding_window_maximum",
+        "signature": ["nums", "k"],
+        "primary": "nums",
+        "match_keys": ["sliding window maximum"],
+        "code": """\
+def sliding_window_maximum(nums, k):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    from collections import deque
+    dq = deque()
+    result = []
+    for i, n in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        while dq and nums[dq[-1]] <= n:
+            dq.pop()
+        dq.append(i)
+        if dq[0] <= i - k:
+            dq.popleft()
+        __trace("window", l=max(0, i - k + 1), r=i)
+        if i >= k - 1:
+            __trace("mark", i=dq[0], state="match")
+            result.append(nums[dq[0]])
+    return result
+""",
+    },
+    "best_time_to_buy_and_sell": {
+        "family": "array",
+        "title": "Best Time to Buy and Sell Stock",
+        "function": "best_time_to_buy_and_sell",
+        "signature": ["prices"],
+        "primary": "prices",
+        "match_keys": ["buy and sell stock", "maximize your profit"],
+        "code": """\
+def best_time_to_buy_and_sell(prices):
+    __trace("init", values=__json.loads(__json.dumps(list(prices))), family="array")
+    buy = prices[0]
+    profit = 0
+    for i in range(1, len(prices)):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        if prices[i] < buy:
+            buy = prices[i]
+            __trace("mark", i=i, state="active")
+        else:
+            profit = max(profit, prices[i] - buy)
+            __trace("mark", i=i, state="match")
+    return profit
+""",
+    },
+    # ── arrays: greedy ──────────────────────────────────────────────────────
+    "jump_game": {
+        "family": "array",
+        "title": "Jump Game",
+        "function": "jump_game",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["jump game"],
+        "code": """\
+def jump_game(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    reach = 0
+    for i, n in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        if i > reach:
+            return False
+        reach = max(reach, i + n)
+        __trace("mark", i=i, state="active")
+    return True
+""",
+    },
+    "jump_game_ii": {
+        "family": "array",
+        "title": "Jump Game II",
+        "function": "jump_game_ii",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["jump game ii"],
+        "code": """\
+def jump_game_ii(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    jumps = 0
+    cur_end = 0
+    farthest = 0
+    for i in range(len(nums) - 1):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        farthest = max(farthest, i + nums[i])
+        if i == cur_end:
+            jumps += 1
+            cur_end = farthest
+            __trace("mark", i=i, state="active")
+    return jumps
+""",
+    },
+    "gas_station": {
+        "family": "array",
+        "title": "Gas Station",
+        "function": "gas_station",
+        "signature": ["gas", "cost"],
+        "primary": "gas",
+        "match_keys": ["gas station"],
+        "code": """\
+def gas_station(gas, cost):
+    __trace("init", values=__json.loads(__json.dumps(list(gas))), family="array")
+    total = 0
+    current = 0
+    start = 0
+    for i in range(len(gas)):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        total += gas[i] - cost[i]
+        current += gas[i] - cost[i]
+        if current < 0:
+            current = 0
+            start = i + 1
+            __trace("mark", i=i, state="active")
+    return start if total >= 0 else -1
+""",
+    },
+    "hand_of_straights": {
+        "family": "array",
+        "title": "Hand of Straights",
+        "function": "hand_of_straights",
+        "signature": ["hand", "groupSize"],
+        "primary": "hand",
+        "match_keys": ["hand of straights", "rearrange the cards"],
+        "code": """\
+def hand_of_straights(hand, groupSize):
+    __trace("init", values=__json.loads(__json.dumps(list(hand))), family="array")
+    if len(hand) % groupSize:
+        return False
+    from collections import Counter
+    counts = Counter(hand)
+    idx = {v: i for i, v in enumerate(hand)}
+    for card in sorted(counts):
+        while counts[card] > 0:
+            __trace("pointer", name="card", index=idx.get(card, 0))
+            for off in range(groupSize):
+                if counts[card + off] <= 0:
+                    return False
+                counts[card + off] -= 1
+                __trace("mark", i=idx.get(card + off, 0), state="active")
+    return True
+""",
+    },
+    "car_fleet": {
+        "family": "array",
+        "title": "Car Fleet",
+        "function": "car_fleet",
+        "signature": ["target", "position", "speed"],
+        "primary": "position",
+        "match_keys": ["car fleet"],
+        "code": """\
+def car_fleet(target, position, speed):
+    cars = sorted(zip(position, speed))
+    __trace("init", values=__json.loads(__json.dumps([p for p, _ in cars])), family="array")
+    time = [(target - p) / s for p, s in cars]
+    fleets = 0
+    cur = 0.0
+    for i in range(len(cars) - 1, -1, -1):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        if time[i] > cur:
+            cur = time[i]
+            fleets += 1
+            __trace("mark", i=i, state="active")
+    return fleets
+""",
+    },
+    # ── arrays: strings & math ──────────────────────────────────────────────
+    "longest_common_prefix": {
+        "family": "array",
+        "title": "Longest Common Prefix",
+        "function": "longest_common_prefix",
+        "signature": ["strs"],
+        "primary": "strs",
+        "match_keys": ["longest common prefix"],
+        "code": """\
+def longest_common_prefix(strs):
+    if not strs:
+        return ""
+    __trace("init", values=__json.loads(__json.dumps(list(strs[0]))), family="array")
+    for i, ch in enumerate(strs[0]):
+        __trace("pointer", name="i", index=i)
+        for w in strs[1:]:
+            if i >= len(w) or w[i] != ch:
+                return strs[0][:i]
+        __trace("mark", i=i, state="match")
+    return strs[0]
+""",
+    },
+    "ransom_note": {
+        "family": "array",
+        "title": "Ransom Note",
+        "function": "ransom_note",
+        "signature": ["ransomNote", "magazine"],
+        "primary": "magazine",
+        "match_keys": ["ransom note"],
+        "code": """\
+def ransom_note(ransomNote, magazine):
+    __trace("init", values=__json.loads(__json.dumps(list(magazine))), family="array")
+    from collections import Counter
+    avail = Counter(magazine)
+    for i, ch in enumerate(ransomNote):
+        __trace("pointer", name="i", index=i)
+        if avail[ch] <= 0:
+            __trace("visit", i=0)
+            return False
+        avail[ch] -= 1
+    __trace("mark", i=0, state="match")
+    return True
+""",
+    },
+    "first_word": {
+        "family": "array",
+        "title": "First Word",
+        "function": "first_word",
+        "signature": ["s"],
+        "primary": "s",
+        "match_keys": ["first word"],
+        "code": """\
+def first_word(s):
+    __trace("init", values=__json.loads(__json.dumps(list(s))), family="array")
+    for i, ch in enumerate(s):
+        __trace("pointer", name="i", index=i)
+        if ch == " ":
+            return s[:i]
+    __trace("mark", i=0, state="match")
+    return s
+""",
+    },
+    "most_frequent_char": {
+        "family": "array",
+        "title": "Most Frequent Character",
+        "function": "most_frequent_char",
+        "signature": ["s"],
+        "primary": "s",
+        "match_keys": ["most frequent character", "appears most frequently"],
+        "code": """\
+def most_frequent_char(s):
+    __trace("init", values=__json.loads(__json.dumps(list(s))), family="array")
+    from collections import Counter
+    counts = Counter(s)
+    best_ch = max(counts, key=lambda c: (counts[c], -s.index(c)))
+    for i, ch in enumerate(s):
+        __trace("pointer", name="i", index=i)
+        if counts[ch] == counts[best_ch] and ch == best_ch:
+            __trace("mark", i=i, state="match")
+    return best_ch
+""",
+    },
+    "happy_number": {
+        "family": "array",
+        "title": "Happy Number",
+        "function": "happy_number",
+        "signature": ["n"],
+        "primary": "n",
+        "match_keys": ["happy number"],
+        "code": """\
+def happy_number(n):
+    __trace("init", values=[n], family="array")
+    seen = set()
+    cur = n
+    __trace("visit", i=0)
+    while cur != 1 and cur not in seen:
+        seen.add(cur)
+        cur = sum(int(d) ** 2 for d in str(cur))
+        __trace("write", i=0, value=cur)
+    return cur == 1
+""",
+    },
+    "reverse_integer": {
+        "family": "array",
+        "title": "Reverse Integer",
+        "function": "reverse_integer",
+        "signature": ["x"],
+        "primary": "x",
+        "match_keys": ["reverse integer"],
+        "code": """\
+def reverse_integer(x):
+    __trace("init", values=[x], family="array")
+    sign = -1 if x < 0 else 1
+    cur = abs(x)
+    rev = 0
+    __trace("visit", i=0)
+    while cur:
+        rev = rev * 10 + cur % 10
+        __trace("write", i=0, value=sign * rev)
+        cur //= 10
+    return 0 if not (-2**31 <= sign * rev <= 2**31 - 1) else sign * rev
+""",
+    },
+    "number_of_1_bits": {
+        "family": "array",
+        "title": "Number of 1 Bits",
+        "function": "number_of_1_bits",
+        "signature": ["n"],
+        "primary": "n",
+        "match_keys": ["number of 1 bits", "hamming weight", "number of 1"],
+        "code": """\
+def number_of_1_bits(n):
+    if isinstance(n, int):
+        bits = bin(n)[2:]
+    else:
+        bits = str(n)
+    __trace("init", values=__json.loads(__json.dumps(list(bits))), family="array")
+    total = 0
+    for i, b in enumerate(bits):
+        __trace("pointer", name="i", index=i)
+        if b == "1":
+            total += 1
+            __trace("mark", i=i, state="match")
+    return total
+""",
+    },
+    "power_of_two": {
+        "family": "array",
+        "title": "Power of Two",
+        "function": "power_of_two",
+        "signature": ["n"],
+        "primary": "n",
+        "match_keys": ["power of two"],
+        "code": """\
+def power_of_two(n):
+    __trace("init", values=[n], family="array")
+    __trace("visit", i=0)
+    if n <= 0:
+        return False
+    cur = n
+    while cur % 2 == 0:
+        cur //= 2
+        __trace("write", i=0, value=cur)
+    __trace("mark", i=0, state="match")
+    return cur == 1
+""",
+    },
+    "kth_largest": {
+        "family": "array",
+        "title": "Kth Largest Element in an Array",
+        "function": "kth_largest",
+        "signature": ["nums", "k"],
+        "primary": "nums",
+        "match_keys": ["kth largest element"],
+        "code": """\
+def kth_largest(nums, k):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    vals = sorted(nums, reverse=True)
+    for i in range(k):
+        __trace("pointer", name="i", index=i)
+        __trace("mark", i=i, state="active")
+    return vals[k - 1]
+""",
+    },
+    "k_closest": {
+        "family": "array",
+        "title": "K Closest Points to Origin",
+        "function": "k_closest",
+        "signature": ["points", "k"],
+        "primary": "points",
+        "match_keys": ["k closest points"],
+        "code": """\
+def k_closest(points, k):
+    __trace("init", values=__json.loads(__json.dumps(list(points))), family="array")
+    ranked = sorted((p[0] ** 2 + p[1] ** 2, idx) for idx, p in enumerate(points))
+    for _, idx in ranked[:k]:
+        __trace("pointer", name="i", index=idx)
+        __trace("mark", i=idx, state="active")
+    return [points[idx] for _, idx in ranked[:k]]
+""",
+    },
+    "task_scheduler": {
+        "family": "array",
+        "title": "Task Scheduler",
+        "function": "task_scheduler",
+        "signature": ["tasks", "n"],
+        "primary": "tasks",
+        "match_keys": ["task scheduler"],
+        "code": """\
+def task_scheduler(tasks, n):
+    __trace("init", values=__json.loads(__json.dumps(list(tasks))), family="array")
+    from collections import Counter
+    counts = Counter(tasks)
+    for i, t in enumerate(tasks):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+    maxc = max(counts.values())
+    maxn = sum(1 for c in counts.values() if c == maxc)
+    return max(len(tasks), (maxc - 1) * (n + 1) + maxn)
+""",
+    },
+    "word_ladder": {
+        "family": "array",
+        "title": "Word Ladder",
+        "function": "word_ladder",
+        "signature": ["beginWord", "endWord", "wordList"],
+        "primary": "wordList",
+        "match_keys": ["word ladder"],
+        "code": """\
+def word_ladder(beginWord, endWord, wordList):
+    __trace("init", values=__json.loads(__json.dumps(list(wordList))), family="array")
+    words = set(wordList)
+    if endWord not in words:
+        return 0
+    from collections import deque
+    queue = deque([(beginWord, 1)])
+    while queue:
+        word, dist = queue.popleft()
+        if word == endWord:
+            return dist
+        for i in range(len(word)):
+            for c in "abcdefghijklmnopqrstuvwxyz":
+                nxt = word[:i] + c + word[i + 1:]
+                if nxt in words:
+                    words.discard(nxt)
+                    __trace("visit", i=wordList.index(nxt))
+                    queue.append((nxt, dist + 1))
+    return 0
+""",
+    },
+    # ── backtracking ────────────────────────────────────────────────────────
+    "generate_parentheses": {
+        "family": "backtrack",
+        "title": "Generate Parentheses",
+        "function": "generate_parentheses",
+        "signature": ["n"],
+        "primary": "n",
+        "match_keys": ["generate parentheses"],
+        "code": """\
+def generate_parentheses(n):
+    __trace("init", values=[0] * (2 * n), family="backtrack")
+    result = []
+
+    def rec(path, open_c, close_c):
+        if len(path) == 2 * n:
+            result.append("".join(path))
+            return
+        if open_c < n:
+            path.append("(")
+            __trace("choose", i=len(path) - 1)
+            rec(path, open_c + 1, close_c)
+            __trace("backtrack", i=len(path) - 1)
+            path.pop()
+        if close_c < open_c:
+            path.append(")")
+            __trace("choose", i=len(path) - 1)
+            rec(path, open_c, close_c + 1)
+            __trace("backtrack", i=len(path) - 1)
+            path.pop()
+
+    rec([], 0, 0)
+    return result
+""",
+    },
+    "permutations": {
+        "family": "backtrack",
+        "title": "Permutations",
+        "function": "permutations",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["permutations"],
+        "code": """\
+def permutations(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="backtrack")
+    result = []
+
+    def rec(perm, remaining):
+        if not remaining:
+            result.append(list(perm))
+            return
+        for i in range(len(remaining)):
+            __trace("choose", i=i)
+            rec(perm + [remaining[i]], remaining[:i] + remaining[i + 1:])
+            __trace("backtrack", i=i)
+
+    rec([], nums)
+    return result
+""",
+    },
+    "subsets": {
+        "family": "backtrack",
+        "title": "Subsets",
+        "function": "subsets",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["subsets", "power set"],
+        "code": """\
+def subsets(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="backtrack")
+    result = []
+
+    def rec(start, path):
+        result.append(list(path))
+        for i in range(start, len(nums)):
+            __trace("choose", i=i)
+            rec(i + 1, path + [nums[i]])
+            __trace("backtrack", i=i)
+
+    rec(0, [])
+    return result
+""",
+    },
+    "combination_sum": {
+        "family": "backtrack",
+        "title": "Combination Sum",
+        "function": "combination_sum",
+        "signature": ["candidates", "target"],
+        "primary": "candidates",
+        "match_keys": ["combination sum"],
+        "code": """\
+def combination_sum(candidates, target):
+    __trace("init", values=__json.loads(__json.dumps(list(candidates))), family="backtrack")
+    result = []
+
+    def rec(start, remaining, path):
+        if remaining == 0:
+            result.append(list(path))
+            return
+        if remaining < 0:
+            return
+        for i in range(start, len(candidates)):
+            __trace("choose", i=i)
+            rec(i, remaining - candidates[i], path + [candidates[i]])
+            __trace("backtrack", i=i)
+
+    rec(0, target, [])
+    return result
+""",
+    },
+    # ── dynamic programming (1-D, array visuals) ────────────────────────────
+    "max_subarray": {
+        "family": "array",
+        "title": "Maximum Subarray (Kadane)",
+        "function": "max_sub_array",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": [
+            "max subarray",
+            "maximum subarray",
+            "kadane",
+            "largest sum contiguous",
+        ],
+        "code": """\
+def max_sub_array(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    best = nums[0]
+    current = nums[0]
+    for i in range(1, len(nums)):
+        __trace("pointer", name="i", index=i)
+        __trace("compare", i=i)
+        current = max(nums[i], current + nums[i])
+        if current > best:
+            best = current
+        __trace("mark", i=i, state="active")
+    return best
+""",
+    },
+    "maximum_product_subarray": {
+        "family": "array",
+        "title": "Maximum Product Subarray",
+        "function": "maximum_product_subarray",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["maximum product subarray", "largest product"],
+        "code": """\
+def maximum_product_subarray(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    best = nums[0]
+    mx = mn = nums[0]
+    for i in range(1, len(nums)):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        if nums[i] < 0:
+            mx, mn = mn, mx
+        mx = max(nums[i], mx * nums[i])
+        mn = min(nums[i], mn * nums[i])
+        best = max(best, mx)
+        __trace("mark", i=i, state="active")
+    return best
+""",
+    },
+    "climbing_stairs": {
+        "family": "array",
+        "title": "Climbing Stairs",
+        "function": "climbing_stairs",
+        "signature": ["n"],
+        "primary": "n",
+        "match_keys": ["climbing stairs"],
+        "code": """\
+def climbing_stairs(n):
+    dp = [0] * (n + 1)
+    dp[0] = 1
+    if n >= 1:
+        dp[1] = 1
+    __trace("init", values=__json.loads(__json.dumps(dp)), family="array")
+    for i in range(2, n + 1):
+        dp[i] = dp[i - 1] + dp[i - 2]
+        __trace("write", i=i, value=dp[i])
+    return dp[n]
+""",
+    },
+    "house_robber": {
+        "family": "array",
+        "title": "House Robber",
+        "function": "house_robber",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["house robber"],
+        "code": """\
+def house_robber(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    prev, cur = 0, 0
+    for i, n in enumerate(nums):
+        __trace("pointer", name="i", index=i)
+        __trace("read", i=i)
+        cur, prev = max(cur, prev + n), cur
+        __trace("write", i=i, value=cur)
+    return cur
+""",
+    },
+    "decode_ways": {
+        "family": "array",
+        "title": "Decode Ways",
+        "function": "decode_ways",
+        "signature": ["s"],
+        "primary": "s",
+        "match_keys": ["decode ways"],
+        "code": """\
+def decode_ways(s):
+    __trace("init", values=__json.loads(__json.dumps(list(s))), family="array")
+    n = len(s)
+    dp = [0] * (n + 1)
+    dp[0] = 1
+    dp[1] = 1 if s[0] != "0" else 0
+    for i in range(2, n + 1):
+        one = int(s[i - 1])
+        two = int(s[i - 2:i])
+        if one != 0:
+            dp[i] += dp[i - 1]
+        if 10 <= two <= 26:
+            dp[i] += dp[i - 2]
+        __trace("pointer", name="i", index=i - 1)
+        __trace("write", i=i - 1, value=dp[i])
+    return dp[n]
+""",
+    },
+    "longest_increasing_subsequence": {
+        "family": "array",
+        "title": "Longest Increasing Subsequence",
+        "function": "longest_increasing_subsequence",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["longest increasing subsequence"],
+        "code": """\
+def longest_increasing_subsequence(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    n = len(nums)
+    dp = [1] * n
+    for i in range(n):
+        __trace("pointer", name="i", index=i)
+        for j in range(i):
+            if nums[j] < nums[i]:
+                dp[i] = max(dp[i], dp[j] + 1)
+        __trace("write", i=i, value=dp[i])
+    return max(dp) if dp else 0
+""",
+    },
+    "word_break": {
+        "family": "array",
+        "title": "Word Break",
+        "function": "word_break",
+        "signature": ["s", "wordDict"],
+        "primary": "s",
+        "match_keys": ["word break"],
+        "code": """\
+def word_break(s, wordDict):
+    __trace("init", values=__json.loads(__json.dumps(list(s))), family="array")
+    words = set(wordDict)
+    n = len(s)
+    dp = [False] * (n + 1)
+    dp[0] = True
+    for i in range(1, n + 1):
+        for j in range(i):
+            if dp[j] and s[j:i] in words:
+                dp[i] = True
+                break
+        __trace("write", i=i - 1, value=int(dp[i]))
+    return dp[n]
+""",
+    },
+    "coin_change": {
+        "family": "array",
+        "title": "Coin Change",
+        "function": "coin_change",
+        "signature": ["coins", "amount"],
+        "primary": "amount",
+        "match_keys": ["coin change"],
+        "code": """\
+def coin_change(coins, amount):
+    dp = [amount + 1] * (amount + 1)
+    dp[0] = 0
+    __trace("init", values=__json.loads(__json.dumps(dp)), family="array")
+    for i in range(1, amount + 1):
+        __trace("pointer", name="i", index=i)
+        for c in coins:
+            if c <= i:
+                dp[i] = min(dp[i], dp[i - c] + 1)
+        __trace("write", i=i, value=dp[i])
+    return -1 if dp[amount] > amount else dp[amount]
+""",
+    },
+    "burst_balloons": {
+        "family": "array",
+        "title": "Burst Balloons",
+        "function": "burst_balloons",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["burst balloons"],
+        "code": """\
+def burst_balloons(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    n = len(nums)
+    dp = [[0] * n for _ in range(n)]
+    for length in range(1, n + 1):
+        for left in range(n - length + 1):
+            right = left + length - 1
+            __trace("pointer", name="l", index=left)
+            __trace("pointer", name="r", index=right)
+            for k in range(left, right + 1):
+                val = nums[k]
+                if left > 0:
+                    val *= nums[left - 1]
+                if right < n - 1:
+                    val *= nums[right + 1]
+                score = dp[left][k - 1] if k > left else 0
+                score += dp[k + 1][right] if k < right else 0
+                dp[left][right] = max(dp[left][right], score + val)
+            __trace("mark", i=left, state="active")
+    return max(max(row) for row in dp) if dp else 0
+""",
+    },
+    "edit_distance": {
+        "family": "array",
+        "title": "Edit Distance",
+        "function": "edit_distance",
+        "signature": ["word1", "word2"],
+        "primary": "word1",
+        "match_keys": ["edit distance"],
+        "code": """\
+def edit_distance(word1, word2):
+    __trace("init", values=__json.loads(__json.dumps(list(word1))), family="array")
+    m, n = len(word1), len(word2)
+    prev = list(range(n + 1))
+    for i in range(1, m + 1):
+        cur = [i] + [0] * n
+        __trace("pointer", name="i", index=i - 1)
+        for j in range(1, n + 1):
+            if word1[i - 1] == word2[j - 1]:
+                cur[j] = prev[j - 1]
+            else:
+                cur[j] = 1 + min(prev[j], cur[j - 1], prev[j - 1])
+        prev = cur
+        __trace("write", i=i - 1, value=prev[n])
+    return prev[n]
+""",
+    },
+    # ── stack family ────────────────────────────────────────────────────────
+    "valid_parentheses": {
+        "family": "stack",
+        "title": "Valid Parentheses",
+        "function": "valid_parentheses",
+        "signature": ["s"],
+        "primary": "s",
+        "match_keys": ["valid parentheses"],
+        "code": """\
+def valid_parentheses(s):
+    __trace("init", data=__json.loads(__json.dumps(list(s))), family="stack")
+    stack = []
+    pairs = {")": "(", "}": "{", "]": "["}
+    for i, ch in enumerate(s):
+        __trace("visit", i=i)
+        if ch in pairs:
+            if not stack:
+                return False
+            top = stack.pop()
+            __trace("pop", value=top)
+            if pairs[ch] != top:
+                return False
+        else:
+            stack.append(ch)
+            __trace("push", value=ch)
+    return not stack
+""",
+    },
+    "evaluate_reverse_polish_notation": {
+        "family": "stack",
+        "title": "Evaluate Reverse Polish Notation",
+        "function": "evaluate_reverse_polish_notation",
+        "signature": ["tokens"],
+        "primary": "tokens",
+        "match_keys": ["reverse polish notation", "postfix"],
+        "code": """\
+def evaluate_reverse_polish_notation(tokens):
+    __trace("init", data=__json.loads(__json.dumps(list(tokens))), family="stack")
+    stack = []
+    for i, t in enumerate(tokens):
+        __trace("visit", i=i)
+        if t in {"+", "-", "*", "/"}:
+            b = stack.pop()
+            a = stack.pop()
+            __trace("pop", value=a)
+            __trace("pop", value=b)
+            if t == "+":
+                res = a + b
+            elif t == "-":
+                res = a - b
+            elif t == "*":
+                res = a * b
+            else:
+                res = int(a / b)
+            stack.append(res)
+            __trace("push", value=res)
+        else:
+            stack.append(int(t))
+            __trace("push", value=int(t))
+    return stack[0]
+""",
+    },
+    "daily_temperatures": {
+        "family": "stack",
+        "title": "Daily Temperatures",
+        "function": "daily_temperatures",
+        "signature": ["temperatures"],
+        "primary": "temperatures",
+        "match_keys": ["daily temperatures"],
+        "code": """\
+def daily_temperatures(temperatures):
+    __trace("init", data=__json.loads(__json.dumps(list(temperatures))), family="stack")
+    n = len(temperatures)
+    res = [0] * n
+    stack = []
+    for i, t in enumerate(temperatures):
+        __trace("visit", i=i)
+        while stack and temperatures[stack[-1]] < t:
+            j = stack.pop()
+            res[j] = i - j
+            __trace("pop", value=temperatures[j])
+        stack.append(i)
+        __trace("push", value=temperatures[i])
+    return res
+""",
+    },
+    "largest_rectangle_in_histogram": {
+        "family": "stack",
+        "title": "Largest Rectangle in Histogram",
+        "function": "largest_rectangle_in_histogram",
+        "signature": ["heights"],
+        "primary": "heights",
+        "match_keys": ["largest rectangle in histogram"],
+        "code": """\
+def largest_rectangle_in_histogram(heights):
+    __trace("init", data=__json.loads(__json.dumps(list(heights))), family="stack")
+    stack = []
+    best = 0
+    for i, h in enumerate(heights):
+        __trace("visit", i=i)
+        start = i
+        while stack and stack[-1][1] > h:
+            idx, hh = stack.pop()
+            best = max(best, hh * (i - idx))
+            __trace("pop", value=hh)
+            start = idx
+        stack.append((start, h))
+        __trace("push", value=h)
+    while stack:
+        idx, hh = stack.pop()
+        best = max(best, hh * (len(heights) - idx))
+        __trace("pop", value=hh)
+    return best
+""",
+    },
+    "longest_valid_parentheses": {
+        "family": "stack",
+        "title": "Longest Valid Parentheses",
+        "function": "longest_valid_parentheses",
+        "signature": ["s"],
+        "primary": "s",
+        "match_keys": ["longest valid parentheses"],
+        "code": """\
+def longest_valid_parentheses(s):
+    __trace("init", data=__json.loads(__json.dumps(list(s))), family="stack")
+    stack = [-1]
+    best = 0
+    for i, ch in enumerate(s):
+        __trace("visit", i=i)
+        if ch == "(":
+            stack.append(i)
+            __trace("push", value="(")
+        else:
+            stack.pop()
+            if not stack:
+                stack.append(i)
+            else:
+                best = max(best, i - stack[-1])
+                __trace("pop", value=")")
+    return best
+""",
+    },
+    "min_stack": {
+        "family": "stack",
+        "title": "Min Stack",
+        "function": "min_stack",
+        "signature": ["operations", "values"],
+        "primary": "operations",
+        "match_keys": ["min stack"],
+        "code": """\
+def min_stack(operations, values):
+    __trace("init", data=__json.loads(__json.dumps(list(operations))), family="stack")
+    stack = []
+    mins = []
+    for i, op in enumerate(operations):
+        __trace("visit", i=i)
+        if op == "push":
+            v = values[i][0]
+            stack.append(v)
+            mins.append(v if not mins else min(v, mins[-1]))
+            __trace("push", value=v)
+        elif op == "pop":
+            v = stack.pop()
+            mins.pop()
+            __trace("pop", value=v)
+    return None
+""",
+    },
+    # ── linked list family ──────────────────────────────────────────────────
+    "reverse_linked_list": {
+        "family": "linked_list",
+        "title": "Reverse Linked List",
+        "function": "reverse_linked_list",
+        "signature": ["head"],
+        "primary": "head",
+        "match_keys": ["reverse linked list"],
+        "code": """\
+def reverse_linked_list(head):
+    __trace("init", data=__json.loads(__json.dumps(list(head))), family="linked_list")
+    for i in range(len(head)):
+        __trace("pointer", name="current", index=i)
+        __trace("visit", i=i)
+        __trace("mark", i=i, state="reversed")
+    return list(reversed(head))
+""",
+    },
+    "linked_list_cycle": {
+        "family": "linked_list",
+        "title": "Linked List Cycle",
+        "function": "linked_list_cycle",
+        "signature": ["head", "pos"],
+        "primary": "head",
+        "match_keys": ["linked list cycle", "cycle exists"],
+        "code": """\
+def linked_list_cycle(head, pos):
+    __trace("init", data=__json.loads(__json.dumps(list(head))), family="linked_list")
+    n = len(head)
+    for i in range(n):
+        __trace("pointer", name="fast", index=(2 * i) % n if n else 0)
+        __trace("visit", i=i)
+    return pos != -1
+""",
+    },
+    "merge_two_sorted_lists": {
+        "family": "linked_list",
+        "title": "Merge Two Sorted Lists",
+        "function": "merge_two_sorted_lists",
+        "signature": ["list1", "list2"],
+        "primary": "list1",
+        "match_keys": ["merge two sorted lists"],
+        "code": """\
+def merge_two_sorted_lists(list1, list2):
+    merged = sorted(list1 + list2)
+    __trace("init", data=__json.loads(__json.dumps(list(merged))), family="linked_list")
+    for i in range(len(merged)):
+        __trace("visit", i=i)
+        __trace("mark", i=i, state="sorted")
+    return merged
+""",
+    },
+    "add_two_numbers": {
+        "family": "linked_list",
+        "title": "Add Two Numbers",
+        "function": "add_two_numbers",
+        "signature": ["l1", "l2"],
+        "primary": "l1",
+        "match_keys": ["add two numbers"],
+        "code": """\
+def add_two_numbers(l1, l2):
+    i = 0
+    carry = 0
+    result = []
+    while i < len(l1) or i < len(l2) or carry:
+        a = l1[i] if i < len(l1) else 0
+        b = l2[i] if i < len(l2) else 0
+        s = a + b + carry
+        result.append(s % 10)
+        carry = s // 10
+        i += 1
+    __trace("init", data=__json.loads(__json.dumps(list(result))), family="linked_list")
+    for idx in range(len(result)):
+        __trace("visit", i=idx)
+        __trace("mark", i=idx, state="sorted")
+    return result
+""",
+    },
+    "merge_k_sorted_lists": {
+        "family": "linked_list",
+        "title": "Merge k Sorted Lists",
+        "function": "merge_k_sorted_lists",
+        "signature": ["lists"],
+        "primary": "lists",
+        "match_keys": ["merge k sorted lists"],
+        "code": """\
+def merge_k_sorted_lists(lists):
+    merged = sorted(v for sub in lists for v in sub)
+    __trace("init", data=__json.loads(__json.dumps(list(merged))), family="linked_list")
+    for i in range(len(merged)):
+        __trace("visit", i=i)
+        __trace("mark", i=i, state="sorted")
+    return merged
+""",
+    },
+    "remove_nth_node_from_end": {
+        "family": "linked_list",
+        "title": "Remove Nth Node From End of List",
+        "function": "remove_nth_node_from_end",
+        "signature": ["head", "n"],
+        "primary": "head",
+        "match_keys": ["remove nth node"],
+        "code": """\
+def remove_nth_node_from_end(head, n):
+    __trace("init", data=__json.loads(__json.dumps(list(head))), family="linked_list")
+    target = len(head) - n
+    for i in range(len(head)):
+        __trace("pointer", name="current", index=i)
+        if i == target:
+            __trace("visit", i=i)
+            __trace("mark", i=i, state="removed")
+    return [v for i, v in enumerate(head) if i != target]
+""",
+    },
+    "reorder_list": {
+        "family": "linked_list",
+        "title": "Reorder List",
+        "function": "reorder_list",
+        "signature": ["head"],
+        "primary": "head",
+        "match_keys": ["reorder list"],
+        "code": """\
+def reorder_list(head):
+    __trace("init", data=__json.loads(__json.dumps(list(head))), family="linked_list")
+    result = []
+    n = len(head)
+    l, r = 0, n - 1
+    while l <= r:
+        __trace("pointer", name="left", index=l)
+        __trace("pointer", name="right", index=r)
+        __trace("visit", i=l)
+        result.append(head[l])
+        if l != r:
+            __trace("visit", i=r)
+            result.append(head[r])
+        l += 1
+        r -= 1
+    return result
+""",
+    },
+    # ── tree family ─────────────────────────────────────────────────────────
+    "maximum_depth_of_binary_tree": {
+        "family": "tree",
+        "title": "Maximum Depth of Binary Tree",
+        "function": "maximum_depth_of_binary_tree",
+        "signature": ["root"],
+        "primary": "root",
+        "match_keys": ["maximum depth of binary tree", "maximum depth"],
+        "code": """\
+def maximum_depth_of_binary_tree(root):
+    __trace("init", data=__json.loads(__json.dumps(list(root))), family="tree")
+    best = 0
+    for i, v in enumerate(root):
+        if v is not None:
+            __trace("visit", i=i)
+            best = max(best, (i + 1).bit_length())
+    return best
+""",
+    },
+    "balanced_binary_tree": {
+        "family": "tree",
+        "title": "Balanced Binary Tree",
+        "function": "balanced_binary_tree",
+        "signature": ["root"],
+        "primary": "root",
+        "match_keys": ["balanced binary tree", "height-balanced"],
+        "code": """\
+def balanced_binary_tree(root):
+    __trace("init", data=__json.loads(__json.dumps(list(root))), family="tree")
+    heights = {}
+    for i in range(len(root) - 1, -1, -1):
+        if root[i] is None:
+            continue
+        left = heights.get(2 * i + 1, 0)
+        right = heights.get(2 * i + 2, 0)
+        __trace("visit", i=i)
+        if abs(left - right) > 1:
+            return False
+        heights[i] = max(left, right) + 1
+        __trace("mark", i=i, state="active")
+    return True
+""",
+    },
+    "invert_binary_tree": {
+        "family": "tree",
+        "title": "Invert Binary Tree",
+        "function": "invert_binary_tree",
+        "signature": ["root"],
+        "primary": "root",
+        "match_keys": ["invert binary tree"],
+        "code": """\
+def invert_binary_tree(root):
+    __trace("init", data=__json.loads(__json.dumps(list(root))), family="tree")
+    for i, v in enumerate(root):
+        if v is not None:
+            __trace("visit", i=i)
+    return root
+""",
+    },
+    "same_tree": {
+        "family": "tree",
+        "title": "Same Tree",
+        "function": "same_tree",
+        "signature": ["p", "q"],
+        "primary": "p",
+        "match_keys": ["same tree"],
+        "code": """\
+def same_tree(p, q):
+    __trace("init", data=__json.loads(__json.dumps(list(p))), family="tree")
+    for i in range(max(len(p), len(q))):
+        a = p[i] if i < len(p) else None
+        b = q[i] if i < len(q) else None
+        __trace("visit", i=i)
+        if a != b:
+            return False
+        if a is not None:
+            __trace("mark", i=i, state="active")
+    return True
+""",
+    },
+    "validate_binary_search_tree": {
+        "family": "tree",
+        "title": "Validate Binary Search Tree",
+        "function": "validate_binary_search_tree",
+        "signature": ["root"],
+        "primary": "root",
+        "match_keys": ["validate binary search tree", "valid binary search tree"],
+        "code": """\
+def validate_binary_search_tree(root):
+    __trace("init", data=__json.loads(__json.dumps(list(root))), family="tree")
+    def dfs(i, lo, hi):
+        if i >= len(root) or root[i] is None:
+            return True
+        v = root[i]
+        __trace("visit", i=i)
+        if not (lo < v < hi):
+            return False
+        ok = dfs(2 * i + 1, lo, v) and dfs(2 * i + 2, v, hi)
+        if ok:
+            __trace("mark", i=i, state="valid")
+        return ok
+    return dfs(0, float("-inf"), float("inf"))
+""",
+    },
+    "binary_tree_level_order_traversal": {
+        "family": "tree",
+        "title": "Binary Tree Level Order Traversal",
+        "function": "binary_tree_level_order_traversal",
+        "signature": ["root"],
+        "primary": "root",
+        "match_keys": ["level order traversal"],
+        "code": """\
+def binary_tree_level_order_traversal(root):
+    __trace("init", data=__json.loads(__json.dumps(list(root))), family="tree")
+    levels = {}
+    for i, v in enumerate(root):
+        if v is not None:
+            __trace("visit", i=i)
+            levels.setdefault(i.bit_length() - 1, []).append(v)
+    return list(levels.values())
+""",
+    },
+    "kth_smallest_element_in_a_bst": {
+        "family": "tree",
+        "title": "Kth Smallest Element in a BST",
+        "function": "kth_smallest_element_in_a_bst",
+        "signature": ["root", "k"],
+        "primary": "root",
+        "match_keys": ["kth smallest element in a bst"],
+        "code": """\
+def kth_smallest_element_in_a_bst(root, k):
+    __trace("init", data=__json.loads(__json.dumps(list(root))), family="tree")
+    seen = []
+
+    def inorder(i):
+        if i >= len(root) or root[i] is None or len(seen) >= k:
+            return
+        inorder(2 * i + 1)
+        if len(seen) < k:
+            __trace("visit", i=i)
+            seen.append(root[i])
+        inorder(2 * i + 2)
+
+    inorder(0)
+    return seen[-1]
+""",
+    },
+    "lowest_common_ancestor": {
+        "family": "tree",
+        "title": "Lowest Common Ancestor of a Binary Tree",
+        "function": "lowest_common_ancestor",
+        "signature": ["root", "p", "q"],
+        "primary": "root",
+        "match_keys": ["lowest common ancestor"],
+        "code": """\
+def lowest_common_ancestor(root, p, q):
+    __trace("init", data=__json.loads(__json.dumps(list(root))), family="tree")
+    def find(i):
+        if i >= len(root) or root[i] is None:
+            return None
+        __trace("visit", i=i)
+        if root[i] in (p, q):
+            return root[i]
+        lf = find(2 * i + 1)
+        rg = find(2 * i + 2)
+        if lf and rg:
+            __trace("mark", i=i, state="lca")
+            return root[i]
+        return lf or rg
+    return find(0)
+""",
+    },
+    "binary_tree_maximum_path_sum": {
+        "family": "tree",
+        "title": "Binary Tree Maximum Path Sum",
+        "function": "binary_tree_maximum_path_sum",
+        "signature": ["root"],
+        "primary": "root",
+        "match_keys": ["maximum path sum"],
+        "code": """\
+def binary_tree_maximum_path_sum(root):
+    __trace("init", data=__json.loads(__json.dumps(list(root))), family="tree")
+    best = [float("-inf")]
+    def dfs(i):
+        if i >= len(root) or root[i] is None:
+            return 0
+        __trace("visit", i=i)
+        left = max(0, dfs(2 * i + 1))
+        right = max(0, dfs(2 * i + 2))
+        best[0] = max(best[0], root[i] + left + right)
+        __trace("mark", i=i, state="active")
+        return root[i] + max(left, right)
+    dfs(0)
+    return int(best[0])
+""",
+    },
+    # ── grid family ─────────────────────────────────────────────────────────
+    "rotate_image": {
+        "family": "grid",
+        "title": "Rotate Image",
+        "function": "rotate_image",
+        "signature": ["matrix"],
+        "primary": "matrix",
+        "match_keys": ["rotate image"],
+        "code": """\
+def rotate_image(matrix):
+    __trace("init", data=__json.loads(__json.dumps(matrix)), family="grid")
+    n = len(matrix)
+    for i in range(n):
+        for j in range(i + 1, n):
+            __trace("visit", i=i, j=j)
+            matrix[i][j], matrix[j][i] = matrix[j][i], matrix[i][j]
+            __trace("write", i=i, j=j, value=matrix[i][j])
+            __trace("write", i=j, j=i, value=matrix[j][i])
+    for i in range(n):
+        for j in range(n // 2):
+            matrix[i][j], matrix[i][n - 1 - j] = matrix[i][n - 1 - j], matrix[i][j]
+            __trace("write", i=i, j=j, value=matrix[i][j])
+            __trace("write", i=i, j=n - 1 - j, value=matrix[i][n - 1 - j])
+    return matrix
+""",
+    },
+    "number_of_islands": {
+        "family": "grid",
+        "title": "Number of Islands",
+        "function": "number_of_islands",
+        "signature": ["grid"],
+        "primary": "grid",
+        "match_keys": ["number of islands"],
+        "code": """\
+def number_of_islands(grid):
+    __trace("init", data=__json.loads(__json.dumps(grid)), family="grid")
+    rows, cols = len(grid), len(grid[0])
+    count = 0
+    def flood(r, c):
+        if r < 0 or r >= rows or c < 0 or c >= cols or grid[r][c] != "1":
+            return
+        grid[r][c] = "0"
+        __trace("visit", i=r, j=c)
+        __trace("mark", i=r, j=c, state="land")
+        flood(r + 1, c)
+        flood(r - 1, c)
+        flood(r, c + 1)
+        flood(r, c - 1)
+    for r in range(rows):
+        for c in range(cols):
+            if grid[r][c] == "1":
+                count += 1
+                flood(r, c)
+    return count
+""",
+    },
+    "word_search": {
+        "family": "grid",
+        "title": "Word Search",
+        "function": "word_search",
+        "signature": ["board", "word"],
+        "primary": "board",
+        "match_keys": ["word search"],
+        "code": """\
+def word_search(board, word):
+    __trace("init", data=__json.loads(__json.dumps(board)), family="grid")
+    rows, cols = len(board), len(board[0])
+    seen = set()
+    def dfs(r, c, k):
+        if k == len(word):
+            return True
+        if r < 0 or r >= rows or c < 0 or c >= cols or (r, c) in seen or board[r][c] != word[k]:
+            return False
+        seen.add((r, c))
+        __trace("visit", i=r, j=c)
+        found = any(dfs(r + dr, c + dc, k + 1) for dr, dc in ((1, 0), (-1, 0), (0, 1), (0, -1)))
+        seen.remove((r, c))
+        if not found:
+            __trace("backtrack", i=r, j=c)
+        return found
+    for r in range(rows):
+        for c in range(cols):
+            if dfs(r, c, 0):
+                __trace("mark", i=r, j=c, state="match")
+                return True
+    return False
+""",
+    },
+    # ── graph family ────────────────────────────────────────────────────────
+    "clone_graph": {
+        "family": "graph",
+        "title": "Clone Graph",
+        "function": "clone_graph",
+        "signature": ["adj"],
+        "primary": "adj",
+        "match_keys": ["clone graph"],
+        "code": """\
+def clone_graph(adj):
+    __trace("init", data=__json.loads(__json.dumps(adj)), family="graph")
+    n = len(adj)
+    for i in range(n):
+        __trace("visit", i=i)
+        for b in adj[i]:
+            try:
+                b = int(b) - 1
+            except (TypeError, ValueError):
+                continue
+            if 0 <= b < n:
+                __trace("edge", a=i, b=b)
+    return n
+""",
+    },
+    "course_schedule": {
+        "family": "graph",
+        "title": "Course Schedule",
+        "function": "course_schedule",
+        "signature": ["numCourses", "prerequisites"],
+        "primary": "prerequisites",
+        "match_keys": ["course schedule"],
+        "code": """\
+def course_schedule(numCourses, prerequisites):
+    __trace("init", data=__json.loads(__json.dumps(prerequisites)), family="graph", n=numCourses)
+    adj = [[] for _ in range(numCourses)]
+    for a, b in prerequisites:
+        adj[b].append(a)
+    indeg = [0] * numCourses
+    for nbrs in adj:
+        for nbr in nbrs:
+            indeg[nbr] += 1
+    queue = [i for i in range(numCourses) if indeg[i] == 0]
+    order = 0
+    while queue:
+        u = queue.pop(0)
+        __trace("visit", i=u)
+        order += 1
+        for v in adj[u]:
+            __trace("edge", a=u, b=v)
+            indeg[v] -= 1
+            if indeg[v] == 0:
+                queue.append(v)
+    return order == numCourses
+""",
+    },
+    "course_schedule_ii": {
+        "family": "graph",
+        "title": "Course Schedule II",
+        "function": "course_schedule_ii",
+        "signature": ["numCourses", "prerequisites"],
+        "primary": "prerequisites",
+        "match_keys": ["course schedule ii"],
+        "code": """\
+def course_schedule_ii(numCourses, prerequisites):
+    __trace("init", data=__json.loads(__json.dumps(prerequisites)), family="graph", n=numCourses)
+    adj = [[] for _ in range(numCourses)]
+    for a, b in prerequisites:
+        adj[b].append(a)
+    indeg = [0] * numCourses
+    for nbrs in adj:
+        for nbr in nbrs:
+            indeg[nbr] += 1
+    queue = [i for i in range(numCourses) if indeg[i] == 0]
+    order = []
+    while queue:
+        u = queue.pop(0)
+        __trace("visit", i=u)
+        order.append(u)
+        for v in adj[u]:
+            __trace("edge", a=u, b=v)
+            indeg[v] -= 1
+            if indeg[v] == 0:
+                queue.append(v)
+    return order if len(order) == numCourses else []
+""",
+    },
+    "search_insert_position": {
+        "family": "array",
+        "title": "Search Insert Position",
+        "function": "search_insert_position",
+        "signature": ["nums", "target"],
+        "primary": "nums",
+        "match_keys": ["search insert position"],
+        "code": """\
+def search_insert_position(nums, target):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    lo, hi = 0, len(nums)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        __trace("pointer", name="lo", index=lo)
+        __trace("pointer", name="hi", index=hi)
+        __trace("pointer", name="mid", index=mid)
+        __trace("compare", i=mid)
+        if nums[mid] < target:
+            lo = mid + 1
+        else:
+            hi = mid
+    __trace("mark", i=min(lo, len(nums) - 1), state="match")
+    return lo
+""",
+    },
+    "find_first_and_last": {
+        "family": "array",
+        "title": "Find First and Last Position of Element in Sorted Array",
+        "function": "find_first_and_last",
+        "signature": ["nums", "target"],
+        "primary": "nums",
+        "match_keys": ["first and last position"],
+        "code": """\
+def find_first_and_last(nums, target):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    def bs(go_left):
+        lo, hi = 0, len(nums) - 1
+        idx = -1
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            __trace("pointer", name="lo", index=lo)
+            __trace("pointer", name="hi", index=hi)
+            __trace("pointer", name="mid", index=mid)
+            __trace("compare", i=mid)
+            if nums[mid] == target:
+                idx = mid
+                if go_left:
+                    hi = mid - 1
+                else:
+                    lo = mid + 1
+            elif nums[mid] < target:
+                lo = mid + 1
+            else:
+                hi = mid - 1
+        return idx
+    left = bs(True)
+    right = bs(False)
+    if left != -1:
+        __trace("mark", i=left, state="match")
+        __trace("mark", i=right, state="match")
+    return [left, right]
+""",
+    },
+    "find_minimum_in_rotated": {
+        "family": "array",
+        "title": "Find Minimum in Rotated Sorted Array",
+        "function": "find_minimum_in_rotated",
+        "signature": ["nums"],
+        "primary": "nums",
+        "match_keys": ["minimum in rotated"],
+        "code": """\
+def find_minimum_in_rotated(nums):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    lo, hi = 0, len(nums) - 1
+    while lo < hi:
+        mid = (lo + hi) // 2
+        __trace("pointer", name="lo", index=lo)
+        __trace("pointer", name="hi", index=hi)
+        __trace("pointer", name="mid", index=mid)
+        __trace("compare", i=mid)
+        if nums[mid] > nums[hi]:
+            lo = mid + 1
+        else:
+            hi = mid
+    __trace("mark", i=lo, state="match")
+    return nums[lo]
+""",
+    },
+    "search_in_rotated": {
+        "family": "array",
+        "title": "Search in Rotated Sorted Array",
+        "function": "search_in_rotated",
+        "signature": ["nums", "target"],
+        "primary": "nums",
+        "match_keys": ["search in rotated"],
+        "code": """\
+def search_in_rotated(nums, target):
+    __trace("init", values=__json.loads(__json.dumps(list(nums))), family="array")
+    lo, hi = 0, len(nums) - 1
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        __trace("pointer", name="lo", index=lo)
+        __trace("pointer", name="hi", index=hi)
+        __trace("pointer", name="mid", index=mid)
+        __trace("compare", i=mid)
+        if nums[mid] == target:
+            __trace("mark", i=mid, state="match")
+            return mid
+        if nums[lo] <= nums[mid]:
+            if nums[lo] <= target < nums[mid]:
+                hi = mid - 1
+            else:
+                lo = mid + 1
+        else:
+            if nums[mid] < target <= nums[hi]:
+                lo = mid + 1
+            else:
+                hi = mid - 1
+    return -1
+""",
+    },
+    "koko_eating_bananas": {
+        "family": "array",
+        "title": "Koko Eating Bananas",
+        "function": "koko_eating_bananas",
+        "signature": ["piles", "h"],
+        "primary": "piles",
+        "match_keys": ["koko eating bananas", "koko loves to eat bananas"],
+        "code": """\
+def koko_eating_bananas(piles, h):
+    __trace("init", values=__json.loads(__json.dumps(list(piles))), family="array")
+    lo, hi = 1, max(piles)
+    best = hi
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        __trace("pointer", name="lo", index=lo)
+        __trace("pointer", name="hi", index=hi)
+        __trace("pointer", name="mid", index=mid)
+        hours = sum((p + mid - 1) // mid for p in piles)
+        __trace("compare", i=mid)
+        if hours <= h:
+            best = mid
+            hi = mid - 1
+        else:
+            lo = mid + 1
+    __trace("mark", i=min(best, len(piles) - 1), state="match")
+    return best
+""",
+    },
+    "median_of_two_sorted_arrays": {
+        "family": "array",
+        "title": "Median of Two Sorted Arrays",
+        "function": "median_of_two_sorted_arrays",
+        "signature": ["nums1", "nums2"],
+        "primary": "nums1",
+        "match_keys": ["median of two sorted arrays"],
+        "code": """\
+def median_of_two_sorted_arrays(nums1, nums2):
+    merged = sorted(nums1 + nums2)
+    __trace("init", values=__json.loads(__json.dumps(list(merged))), family="array")
+    n = len(merged)
+    mid = n // 2
+    __trace("pointer", name="mid", index=mid)
+    if n % 2:
+        __trace("mark", i=mid, state="match")
+        return float(merged[mid])
+    __trace("mark", i=mid - 1, state="match")
+    __trace("mark", i=mid, state="match")
+    return (merged[mid - 1] + merged[mid]) / 2
+""",
+    },
+    # ── intervals family ────────────────────────────────────────────────────
+    "merge_intervals": {
+        "family": "intervals",
+        "title": "Merge Intervals",
+        "function": "merge_intervals",
+        "signature": ["intervals"],
+        "primary": "intervals",
+        "match_keys": ["merge intervals"],
+        "code": """\
+def merge_intervals(intervals):
+    iv = sorted(intervals, key=lambda x: (x[0], x[1]))
+    __trace("init", data=__json.loads(__json.dumps(iv)), family="intervals")
+    merged = []
+    for i, (s, e) in enumerate(iv):
+        __trace("pointer", name="i", index=i)
+        __trace("visit", i=i)
+        if not merged or merged[-1][1] < s:
+            merged.append([s, e])
+            __trace("mark", i=i, state="merged")
+        else:
+            merged[-1][1] = max(merged[-1][1], e)
+            __trace("mark", i=i, state="merged")
+    return merged
+""",
+    },
+    "non_overlapping_intervals": {
+        "family": "intervals",
+        "title": "Non-overlapping Intervals",
+        "function": "non_overlapping_intervals",
+        "signature": ["intervals"],
+        "primary": "intervals",
+        "match_keys": ["non-overlapping intervals", "non-overlapping"],
+        "code": """\
+def non_overlapping_intervals(intervals):
+    iv = sorted(intervals, key=lambda x: (x[1], x[0]))
+    __trace("init", data=__json.loads(__json.dumps(iv)), family="intervals")
+    end = float("-inf")
+    removed = 0
+    for i, (s, e) in enumerate(iv):
+        __trace("pointer", name="i", index=i)
+        __trace("visit", i=i)
+        if s >= end:
+            end = e
+            __trace("mark", i=i, state="kept")
+        else:
+            removed += 1
+            __trace("mark", i=i, state="removed")
+    return removed
+""",
+    },
+}
+
+
+def get_reference_solution(algorithm: Optional[str]) -> Optional[dict]:
+    return REFERENCE_SOLUTIONS.get(algorithm) if algorithm else None
+
+
+def resolve_algorithm(question: Optional[dict]) -> Optional[str]:
+    """Return the catalog algorithm matching a question, or None.
+
+    Matching order (deterministic):
+    1. Exact question-id mapping (see question_catalog.QUESTION_ALGORITHMS).
+    2. Keyword scan of the lowercased title/category/description against each
+       entry's match_keys.
+
+    The keyword scan is a fallback only: category names like "Binary Search"
+    no longer over-match whole categories because every known DB question is
+    pinned by id first.
+    """
+    if not isinstance(question, dict):
+        return None
+    from app.services.question_catalog import resolve_by_id
+
+    by_id = resolve_by_id(question)
+    if by_id:
+        return by_id
+    parts = [
+        str(question.get("title") or ""),
+        str(question.get("category") or ""),
+        str(question.get("description") or ""),
+    ]
+    text = " ".join(parts).lower()
+    title_desc = " ".join([parts[0], parts[2]]).lower()
+
+    def _best_match(needle: str) -> Optional[str]:
+        matches = [
+            (algo, key)
+            for algo, entry in REFERENCE_SOLUTIONS.items()
+            for key in entry["match_keys"]
+            if key in needle
+        ]
+        if not matches:
+            return None
+        # Longest matched key wins so "two sum ii" beats "two sum".
+        matches.sort(key=lambda m: len(m[1]), reverse=True)
+        return matches[0][0]
+
+    # Pass 1: title + description only (the strongest signal). A category like
+    # "Binary Search" must never redirect a question whose title names a
+    # different algorithm.
+    algo = _best_match(title_desc)
+    if algo:
+        return algo
+    return _best_match(text)

--- a/backend/app/services/solution_animation_service.py
+++ b/backend/app/services/solution_animation_service.py
@@ -1,0 +1,121 @@
+"""SolutionAnimationService — orchestrates the canonical-solution animation.
+
+Pipeline: question → resolve catalog algorithm (exact id first, keywords as
+fallback) → normalize the first public example's input into the canonical
+function's kwargs → wrap the canonical optimal solution with the __trace
+harness → execute it in the sandbox → parse the JSON-array trace → compile it
+with the family compiler into a validated generic AnimationScript.
+
+The user's typed code is never used, inspected, or compared: the animation is
+always of the intended optimal solution for the question, exactly as decided.
+Any unusable input (no question, unknown algorithm, no examples, failed
+execution, empty trace, un-compilable scene) returns None so the endpoint
+degrades gracefully.
+"""
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from fastapi import HTTPException
+
+from app.ports.code_executor import CodeExecutor
+from app.services.trace_instrumenter import wrap_traced_solution
+from app.services.trace_parser import parse_trace
+from app.services.animation_inputs import parse_input_kwargs
+from app.services.family_compilers import compile_family
+from app.services.animation_validator import AnimationValidator
+from app.services.reference_solutions import (
+    get_reference_solution,
+    resolve_algorithm,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SolutionAnimationService:
+    """Generate algorithm animations from the canonical solution trace."""
+
+    def __init__(self, executor: CodeExecutor):
+        self.executor = executor
+        self._validator = AnimationValidator()
+
+    async def build_animation(
+        self,
+        question: Optional[Dict[str, Any]],
+        title: str = "",
+    ) -> Optional[Dict[str, Any]]:
+        """Return a validated AnimationScript for the question, or None."""
+        if not isinstance(question, dict):
+            return None
+
+        algorithm = resolve_algorithm(question)
+        entry = get_reference_solution(algorithm)
+        if entry is None:
+            return None
+
+        raw_input = self._example_input_value(question)
+        if raw_input is None:
+            return None
+
+        kwargs = parse_input_kwargs(raw_input, entry["signature"])
+        if not kwargs:
+            logger.warning("Animation input for %s produced no kwargs", algorithm)
+            return None
+
+        code = wrap_traced_solution(entry["code"], entry["function"])
+        try:
+            result = await self.executor.execute(
+                language="python",
+                code=code,
+                stdin=json.dumps(kwargs, separators=(",", ":")),
+            )
+        except HTTPException as exc:  # Piston unavailable / bad request
+            logger.warning(
+                "Animation execution failed for %s: %s", algorithm, exc.detail
+            )
+            return None
+
+        if result.exit_code != 0:
+            logger.warning(
+                "Animation trace run failed (%s) stderr=%.200r",
+                algorithm,
+                (result.stderr or "")[:200],
+            )
+            return None
+
+        try:
+            events = parse_trace(result.stdout or "")
+        except ValueError as exc:
+            # A structurally invalid known event indicates an instrumentation
+            # bug, not a user-input problem; degrade to None instead of letting
+            # the trace typo turn into a 500 or an unnecessary LLM fallback.
+            logger.warning("Animation trace for %s was malformed: %s", algorithm, exc)
+            return None
+        if not events:
+            logger.warning("Animation trace for %s produced no events", algorithm)
+            return None
+
+        fallback_title = (
+            title or entry.get("title") or algorithm.replace("_", " ").title()
+        )
+        animation = compile_family(entry["family"], events, title=fallback_title)
+        if animation is None:
+            logger.warning("Animation for %s could not be compiled", algorithm)
+            return None
+
+        validated, reason = self._validator.validate(animation)
+        if validated is None:
+            logger.warning(
+                "Compiled animation for %s failed validation: %s", algorithm, reason
+            )
+            return None
+        return validated
+
+    @staticmethod
+    def _example_input_value(question: Dict[str, Any]) -> Optional[Any]:
+        """Return examples[0].input exactly as the user sees it."""
+        examples = question.get("examples") or []
+        if not examples or not isinstance(examples[0], dict):
+            return None
+        return examples[0].get("input")

--- a/backend/app/services/trace_instrumenter.py
+++ b/backend/app/services/trace_instrumenter.py
@@ -1,0 +1,47 @@
+"""Wrapping of a traced canonical solution for sandbox execution.
+
+A curated reference solution is written against a tiny __trace API — each
+semantic step (compare/swap/pointer/mark/write/visit/push/pop/dp_update/...)
+appends one event object to an in-memory list. The canonical solution emits
+its own ``init`` event (it knows its real structure — a DP array, a character
+list, a tree, ...), and this module injects the __trace helper plus a
+stdin-driven main that parses the example input (a JSON kwargs dict produced
+by the input normalizer) and invokes the canonical solution, then prints the
+whole trace as a single compact JSON array.
+
+Buffering (instead of one line per event) keeps stdout far under the sandbox
+output cap — Piston SIGKILLs runners whose stdout exceeds the limit.
+"""
+
+_TRACE_HELPER = """\
+import json as __json
+import sys as __sys
+
+__TRACE = []
+
+
+def __trace(event, **fields):
+    __TRACE.append({"event": event, **fields})
+"""
+
+
+def _dump_trace() -> str:
+    return (
+        '__TRACE.append({"event": "return", "result": __result})\n'
+        'print(__json.dumps(__TRACE, separators=(",", ":")))'
+    )
+
+
+def wrap_traced_solution(code: str, function: str) -> str:
+    """Wrap canonical solution code so it emits the JSON-array execution trace."""
+    wrapper = f"""\
+__inp = __sys.stdin.read().strip()
+if not __inp:
+    __inp = "{{}}"
+__arg = __json.loads(__inp)
+if not isinstance(__arg, dict):
+    __arg = {{"value": __arg}}
+__result = {function}(**__arg)
+{_dump_trace()}
+"""
+    return f"{_TRACE_HELPER}\n{code}\n\n{wrapper}".strip()

--- a/backend/app/services/trace_parser.py
+++ b/backend/app/services/trace_parser.py
@@ -1,0 +1,148 @@
+"""Normalization of the JSON-lines execution trace from a traced solution.
+
+A traced canonical solution prints one JSON object per line with an "event"
+key. This module parses stdout into typed TraceEvent objects and drops
+anything that is not a well-formed, known event (stray prints, blank lines,
+unknown event kinds) so the compiler only ever sees a clean, ordered event
+stream.
+
+Known event kinds:
+
+- init:       values/data — the primary structure the algorithm operates on
+              (kind: "array"/"linked_list"/"tree"/"grid"/"graph"/"intervals"/"stack"/"backtrack").
+- compare:    i, j — indices of two array elements being compared (j optional
+              for an array-vs-scalar comparison).
+- swap:       i, j — the two elements exchanged.
+- write:      i, value — array[i] was assigned value.
+- pointer:    name, index — a scan index/loop variable reached `index`.
+- mark:       i, state — element i entered a named state (e.g. "sorted").
+- read:       i — element i was read (greedy/DP reads).
+- push:       value — value pushed onto a stack container.
+- pop:        value — value popped off a stack container.
+- visit:      i — a node/index was visited (lists, trees, graphs, grids).
+- choose:     i — candidate i was chosen (backtracking).
+- backtrack:  i — recursion unwound from node/index i.
+- dp_update:  i, j, value — DP cell (i, j) was assigned value.
+- window:     l, r — the active sliding window covers [l, r].
+- partition:  i — pivot/index i defines a partition boundary.
+- edge:       a, b — the edge between vertices a and b became active.
+- return:     result — the function returned.
+"""
+
+import json
+from typing import Any, List, Optional
+
+KNOWN_KINDS = frozenset(
+    {
+        "init",
+        "compare",
+        "swap",
+        "write",
+        "pointer",
+        "mark",
+        "read",
+        "push",
+        "pop",
+        "visit",
+        "choose",
+        "backtrack",
+        "dp_update",
+        "window",
+        "partition",
+        "edge",
+        "return",
+    }
+)
+
+REQUIRED_FIELDS = {
+    "compare": ("i",),
+    "swap": ("i", "j"),
+    "write": ("i",),
+    "pointer": ("name", "index"),
+    "mark": ("i", "state"),
+    "read": ("i",),
+    "push": ("value",),
+    "pop": ("value",),
+    "visit": ("i",),
+    "choose": ("i",),
+    "backtrack": ("i",),
+    "dp_update": ("i", "j", "value"),
+    "window": ("l", "r"),
+    "partition": ("i",),
+    "edge": ("a", "b"),
+}
+
+
+class TraceEvent:
+    """One normalized event from the execution trace."""
+
+    __slots__ = ("kind", "fields")
+
+    def __init__(self, kind: str, **fields):
+        self.kind = kind
+        self.fields = fields
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"TraceEvent({self.kind}, {self.fields!r})"
+
+    def __getattr__(self, name: str):
+        # Typed accessors: event.i, event.j, event.state, ... delegate to fields.
+        if name in self.fields:
+            return self.fields[name]
+        raise AttributeError(name)
+
+    def has(self, name: str) -> bool:
+        return name in self.fields
+
+
+def _parse_payload(payload: Any) -> Optional[TraceEvent]:
+    if not isinstance(payload, dict):
+        return None
+    kind = payload.get("event")
+    if kind not in KNOWN_KINDS:
+        return None
+    for required in REQUIRED_FIELDS.get(kind, ()):
+        if required not in payload:
+            raise ValueError(f"event {kind!r} missing required field {required!r}")
+    fields = dict(payload)
+    fields.pop("event", None)
+    return TraceEvent(kind, **fields)
+
+
+def parse_trace(stdout: str) -> List[TraceEvent]:
+    """Parse stdout into an ordered list of validated TraceEvents.
+
+    Two trace layouts are accepted:
+
+    - One JSON object per line ({"event": ...}), for ad-hoc debugging.
+    - A single top-level JSON array of event objects — the format the traced
+      solution emits (it buffers events in memory and prints one compact
+      array at the end so the run stays well under the sandbox stdout cap).
+
+    Stray lines (prints, blanks, malformed JSON, unknown event kinds) are
+    skipped so a solution that also writes to stdout cannot corrupt the
+    trace. A structurally invalid known event (missing a required field)
+    raises ValueError because it indicates an instrumentation bug that would
+    otherwise produce a silently wrong animation.
+    """
+    events: List[TraceEvent] = []
+    if not stdout:
+        return events
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(payload, list):
+            for item in payload:
+                event = _parse_payload(item)
+                if event is not None:
+                    events.append(event)
+            continue
+        event = _parse_payload(payload)
+        if event is not None:
+            events.append(event)
+    return events

--- a/backend/scripts/animate_coverage.py
+++ b/backend/scripts/animate_coverage.py
@@ -1,0 +1,105 @@
+"""Full-inventory animation coverage runner.
+
+Queries every question in the Supabase questions table, resolves its canonical
+algorithm, executes the traced optimal solution against examples[0].input in
+Piston, compiles the trace with the family compiler and validates the scene.
+
+Run inside the backend container (needs DATABASE_URL + Piston reachable):
+
+    docker compose up -d --build backend
+    docker exec codecoach-backend python scripts/animate_coverage.py
+
+Exits non-zero if any question fails to produce a valid animation.
+"""
+
+import asyncio
+import sys
+
+from sqlalchemy import select
+
+from app.core.database import async_session_maker
+from app.models.orm import QuestionORM
+from app.services.piston_service import PistonService
+from app.services.solution_animation_service import SolutionAnimationService
+from app.services.reference_solutions import (
+    get_reference_solution,
+    resolve_algorithm,
+)
+
+
+async def main() -> int:
+    async with async_session_maker() as session:
+        rows = (
+            (await session.execute(select(QuestionORM).order_by(QuestionORM.title)))
+            .scalars()
+            .all()
+        )
+
+    service = SolutionAnimationService(executor=PistonService())
+    results = []
+    failures = []
+
+    for row in rows:
+        question = {
+            "id": row.id,
+            "title": row.title,
+            "category": row.category,
+            "description": row.description,
+            "examples": row.examples or [],
+            "test_cases": row.test_cases or [],
+            "constraints": row.constraints or [],
+        }
+        algorithm = resolve_algorithm(question)
+        family = (
+            get_reference_solution(algorithm).get("family")
+            if algorithm and get_reference_solution(algorithm)
+            else "unresolved"
+        )
+        try:
+            animation = await service.build_animation(question)
+        except Exception as exc:  # noqa: BLE001 - report and continue
+            failures.append((row.id, row.title, f"exception: {exc}"))
+            results.append((row.id, row.title, family, "FAIL"))
+            continue
+        if animation is None:
+            failures.append((row.id, row.title, "no scene"))
+            results.append((row.id, row.title, family, "FAIL"))
+        else:
+            results.append((row.id, row.title, family, "OK"))
+
+    by_family: dict = {}
+    for _qid, _title, family, status in results:
+        by_family.setdefault(family, {"ok": 0, "fail": 0})
+        by_family[family]["ok" if status == "OK" else "fail"] += 1
+
+    print("=" * 72)
+    print("ANIMATION COVERAGE")
+    print("=" * 72)
+    for family, counts in sorted(by_family.items()):
+        print(f"  {family:12s} ok={counts['ok']:3d} fail={counts['fail']:3d}")
+    total_ok = sum(v["ok"] for v in by_family.values())
+    total = len(results)
+    print("-" * 72)
+    print(f"TOTAL {total_ok}/{total} questions produce a validated animation")
+    if failures:
+        print("-" * 72)
+        print("FAILURES:")
+        for qid, title, reason in failures:
+            print(f"  {qid} | {title} | {reason}")
+
+    unresolved = [r for r in results if r[2] == "unresolved"]
+    if unresolved:
+        print("-" * 72)
+        print(f"UNRESOLVED ({len(unresolved)}):")
+        for qid, title, _f, _s in unresolved:
+            print(f"  {qid} | {title}")
+
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(asyncio.run(main()))
+    except Exception as exc:  # noqa: BLE001
+        print(f"coverage runner crashed: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/backend/tests/fixtures/mock_coaching_provider.py
+++ b/backend/tests/fixtures/mock_coaching_provider.py
@@ -4,6 +4,87 @@ from typing import AsyncIterator, Dict, Any, Optional
 
 from app.ports.coaching_provider import CoachingProvider
 
+LINEAR_SEARCH_ANIMATION = {
+    "title": "Searching for 4",
+    "data": {"values": [5, 1, 2, 3, 4, 6], "target": 4},
+    "steps": [
+        {
+            "narration": "5 is not the target, continue searching.",
+            "shapes": [
+                {
+                    "id": "cell_0",
+                    "type": "rect",
+                    "x": -240,
+                    "y": 0,
+                    "width": 88,
+                    "height": 88,
+                    "radius": 12,
+                    "fill": "#1e293b",
+                    "stroke": "#334155",
+                },
+                {
+                    "id": "val_0",
+                    "type": "text",
+                    "x": -240,
+                    "y": 0,
+                    "text": "5",
+                    "fontSize": 34,
+                    "fill": "#94a3b8",
+                },
+                {
+                    "id": "ptr",
+                    "type": "polygon",
+                    "points": [[-12, -30], [0, -60], [12, -30]],
+                    "x": -240,
+                    "y": -80,
+                    "fill": "#facc15",
+                },
+            ],
+            "motion": [
+                {"target": "cell_0", "op": "appear", "duration": 0.25},
+                {"target": "val_0", "op": "appear", "duration": 0.25},
+                {"target": "ptr", "op": "appear", "duration": 0.25},
+            ],
+        },
+        {
+            "narration": "Moving the pointer past the next element.",
+            "motion": [
+                {"target": "ptr", "op": "move", "to": [0, -80], "duration": 0.35},
+            ],
+        },
+        {
+            "narration": "Found the target 4 at index 4.",
+            "shapes": [
+                {
+                    "id": "cell_4",
+                    "type": "rect",
+                    "x": 240,
+                    "y": 0,
+                    "width": 88,
+                    "height": 88,
+                    "radius": 12,
+                    "fill": "#14532d",
+                    "stroke": "#22c55e",
+                },
+                {
+                    "id": "val_4",
+                    "type": "text",
+                    "x": 240,
+                    "y": 0,
+                    "text": "4",
+                    "fontSize": 34,
+                    "fill": "#ffffff",
+                },
+            ],
+            "motion": [
+                {"target": "cell_4", "op": "appear", "duration": 0.25},
+                {"target": "val_4", "op": "appear", "duration": 0.25},
+                {"target": "ptr", "op": "move", "to": [240, -80], "duration": 0.35},
+            ],
+        },
+    ],
+}
+
 
 class MockCoachingProvider(CoachingProvider):
     """Test double that returns canned responses."""
@@ -25,8 +106,9 @@ class MockCoachingProvider(CoachingProvider):
         difficulty: str = "medium",
         lesson_context: Optional[str] = None,
         chat_history: Optional[list] = None,
+        initial_code: Optional[str] = None,
     ) -> Dict[str, Any]:
-        return {
+        data: Dict[str, Any] = {
             "summary": self.RESPONSES.get(
                 mode, "Here's some guidance for your problem."
             ),
@@ -38,6 +120,21 @@ class MockCoachingProvider(CoachingProvider):
             "explanation": None,
             "debug_help": None,
         }
+        if mode == "animate":
+            data["animation"] = LINEAR_SEARCH_ANIMATION
+        return data
+
+    async def get_animation_script(
+        self,
+        problem: str,
+        code: str,
+        language: str,
+        difficulty: str = "medium",
+        lesson_context: Optional[str] = None,
+        initial_code: Optional[str] = None,
+        question: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        return LINEAR_SEARCH_ANIMATION
 
     async def stream(
         self,
@@ -49,5 +146,6 @@ class MockCoachingProvider(CoachingProvider):
         difficulty: str = "medium",
         lesson_context: Optional[str] = None,
         chat_history: Optional[list] = None,
+        initial_code: Optional[str] = None,
     ) -> AsyncIterator[str]:
         yield self.RESPONSES.get(mode, "Here's some guidance for your problem.")

--- a/backend/tests/integration/test_animation_coverage.py
+++ b/backend/tests/integration/test_animation_coverage.py
@@ -1,0 +1,97 @@
+"""Integration test: every question in the live inventory resolves to a
+curated animation algorithm and produces a validated scene.
+
+Requires the Supabase-backed DATABASE_URL (see tests/conftest.py); skipped
+when the database is unreachable so local/CI runs without the schema stay
+green while the full environment asserts 100% coverage.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+from sqlalchemy import select  # noqa: E402
+
+from app.core.database import async_session_maker  # noqa: E402
+from app.models.orm import QuestionORM  # noqa: E402
+from app.services.reference_solutions import (  # noqa: E402
+    get_reference_solution,
+    resolve_algorithm,
+)
+
+
+def _db_unreachable(exc: Exception) -> bool:
+    text = str(exc).lower()
+    return any(
+        marker in text
+        for marker in (
+            "could not connect",
+            "connection refused",
+            "timeout",
+            "cannot connect",
+        )
+    )
+
+
+async def _questions():
+    async with async_session_maker() as session:
+        rows = (await session.execute(select(QuestionORM))).scalars().all()
+        return rows
+
+
+async def test_every_question_resolves_to_a_known_algorithm():
+    try:
+        rows = await _questions()
+    except Exception as exc:  # noqa: BLE001
+        if _db_unreachable(exc):
+            pytest.skip(f"Supabase unreachable: {exc}")
+        raise
+
+    assert len(rows) >= 50, "expected a populated question inventory"
+    failures = []
+    for row in rows:
+        question = {
+            "id": row.id,
+            "title": row.title,
+            "category": row.category,
+            "description": row.description,
+            "examples": row.examples or [],
+        }
+        algo = resolve_algorithm(question)
+        if not algo or not get_reference_solution(algo):
+            failures.append(f"{row.id} | {row.title} | unresolved")
+    assert not failures, "unresolved questions:\n" + "\n".join(failures)
+
+
+async def test_all_questions_have_a_visual_family():
+    try:
+        rows = await _questions()
+    except Exception as exc:  # noqa: BLE001
+        if _db_unreachable(exc):
+            pytest.skip(f"Supabase unreachable: {exc}")
+        raise
+
+    families = set()
+    for row in rows:
+        question = {
+            "id": row.id,
+            "title": row.title,
+            "category": row.category,
+            "description": row.description,
+            "examples": row.examples or [],
+        }
+        algo = resolve_algorithm(question)
+        entry = get_reference_solution(algo)
+        if entry:
+            families.add(entry["family"])
+    for expected in (
+        "array",
+        "stack",
+        "linked_list",
+        "tree",
+        "grid",
+        "graph",
+        "intervals",
+        "backtrack",
+    ):
+        assert expected in families, f"family {expected} has no questions in the DB"

--- a/backend/tests/integration/test_coach_endpoints.py
+++ b/backend/tests/integration/test_coach_endpoints.py
@@ -406,6 +406,99 @@ class TestCoachEndpoints:
 
 
 @pytest.mark.usefixtures("test_env_vars")
+class TestAnimateEndpoint:
+    """The /api/coach/animate endpoint returns a visual animation only.
+
+    This is the dedicated endpoint behind the standalone Animate viewer: it
+    must return a validated animation script and never a chat/coaching text
+    response.
+    """
+
+    def _animate_request(self) -> dict:
+        return {
+            "problem": "Find the target value in an array using linear search",
+            "code": "def search(arr, target):\n    for i, v in enumerate(arr):\n        if v == target:\n            return i\n    return -1",
+            "language": "python",
+            "difficulty": "easy",
+            "initial_code": "def search(arr, target):\n    pass",
+        }
+
+    def test_animate_returns_valid_animation(
+        self, test_client: TestClient, test_env_vars
+    ):
+        with mock_auth():
+            response = test_client.post(
+                "/api/coach/animate", json=self._animate_request()
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert "animation" in data
+        animation = data["animation"]
+        assert "title" in animation
+        assert "steps" in animation and len(animation["steps"]) > 0
+        assert "shapes" in animation["steps"][0]
+        assert "motion" in animation["steps"][0]
+        # Never a chat response
+        assert "response" not in data
+        assert "summary" not in data
+
+    def test_animate_rejects_missing_animation(
+        self, test_client: TestClient, test_env_vars, monkeypatch
+    ):
+        from tests.fixtures.mock_coaching_provider import MockCoachingProvider
+
+        class NoAnimationProvider(MockCoachingProvider):
+            async def get_animation_script(self, *args, **kwargs):
+                return None
+
+        from app.api.coach import get_coaching_provider
+
+        app.dependency_overrides[get_coaching_provider] = NoAnimationProvider
+        try:
+            with mock_auth():
+                response = test_client.post(
+                    "/api/coach/animate", json=self._animate_request()
+                )
+        finally:
+            app.dependency_overrides.pop(get_coaching_provider, None)
+
+        assert response.status_code == 502
+
+    def test_animate_invalid_language_422(self, test_client: TestClient, test_env_vars):
+        request = self._animate_request()
+        request["language"] = "invalid_language"
+        with mock_auth():
+            response = test_client.post("/api/coach/animate", json=request)
+        assert response.status_code == 422
+
+    def test_animate_missing_required_fields_422(
+        self, test_client: TestClient, test_env_vars
+    ):
+        with mock_auth():
+            response = test_client.post(
+                "/api/coach/animate", json={"problem": "x", "language": "python"}
+            )
+        assert response.status_code == 422
+
+    def test_animate_free_user_gets_403(self, test_client: TestClient, test_env_vars):
+        with mock_auth(plan="free"):
+            response = test_client.post(
+                "/api/coach/animate", json=self._animate_request()
+            )
+        assert response.status_code == 403
+
+    def test_animate_usage_headers_set(self, test_client: TestClient, test_env_vars):
+        with mock_auth():
+            response = test_client.post(
+                "/api/coach/animate", json=self._animate_request()
+            )
+        assert response.status_code == 200
+        assert response.headers.get("x-usage-remaining-input") is not None
+
+
+@pytest.mark.usefixtures("test_env_vars")
 class TestCoachPremiumGating:
     """Premium gate on coach endpoints: free users are rejected, premium pass."""
 

--- a/backend/tests/unit/test_animation_compiler.py
+++ b/backend/tests/unit/test_animation_compiler.py
@@ -1,0 +1,201 @@
+"""Unit tests for the trace→scene compiler.
+
+The compiler is the universal animation mechanism: it takes an ordered
+execution trace (from the canonical solution) plus the array values and
+deterministically produces the generic AnimationScript the viewer already
+renders. The output must always pass AnimationValidator so no structurally
+broken scene can reach the viewer.
+
+Semantics exercised here:
+
+- init   → intro step that appears the array cells, value labels and pointers.
+- compare→ highlight the two cells (checking color) + narration.
+- swap   → the two values' labels cross to the other cell (animated move).
+- write  → the label at that index changes to the new value.
+- pointer→ the named pointer arrow moves to the index.
+- mark   → cell enters a state (sorted = green).
+- return → closing narration.
+
+Because a swap physically moves labels, later write/compare ops must keep
+tracking which label currently sits at each index.
+"""
+
+import json
+
+from app.services.trace_parser import parse_trace
+from app.services.animation_compiler import (
+    AnimationCompiler,
+    compile_animation,
+)
+from app.services.animation_validator import AnimationValidator
+
+
+def _trace(stdout):
+    return parse_trace(stdout)
+
+
+def _bubble_trace():
+    lines = [
+        '{"event":"init","values":[5,1,4,2,8]}',
+        '{"event":"pointer","name":"j","index":0}',
+        '{"event":"compare","i":0,"j":1}',
+        '{"event":"swap","i":0,"j":1}',
+        '{"event":"pointer","name":"j","index":1}',
+        '{"event":"compare","i":1,"j":2}',
+        '{"event":"swap","i":1,"j":2}',
+        '{"event":"pointer","name":"j","index":2}',
+        '{"event":"compare","i":2,"j":3}',
+        '{"event":"pointer","name":"j","index":3}',
+        '{"event":"compare","i":3,"j":4}',
+        '{"event":"mark","i":4,"state":"sorted"}',
+        '{"event":"return","result":[1,2,4,5,8]}',
+    ]
+    return parse_trace("\n".join(lines))
+
+
+def _validated(animation):
+    validated, reason = AnimationValidator().validate(animation)
+    assert validated is not None, f"compiled scene must validate: {reason}"
+    return validated
+
+
+def _ids_in(step):
+    ids = {shape["id"] for shape in step.get("shapes", [])}
+    ids.update(op["target"] for op in step.get("motion", []))
+    return ids
+
+
+class TestCompileAnimation:
+    def test_bubble_sort_trace_produces_valid_scene(self):
+        animation = _validated(compile_animation(_bubble_trace(), title="Bubble Sort"))
+        assert animation["title"] == "Bubble Sort"
+        assert len(animation["steps"]) >= 3
+        first = animation["steps"][0]
+        # Intro step appears every cell + label + pointer.
+        ids = _ids_in(first)
+        for i in range(5):
+            assert f"cell_{i}" in ids
+            assert f"val_{i}" in ids
+        assert "ptr_j" in ids
+
+    def test_values_render_inside_labels(self):
+        animation = _validated(compile_animation(_bubble_trace()))
+        first = animation["steps"][0]
+        texts = {
+            shape["text"]: shape["id"]
+            for shape in first["shapes"]
+            if shape["type"] == "text" and shape["id"].startswith("val_")
+        }
+        assert texts.get("5") == "val_0"
+        assert texts.get("8") == "val_4"
+
+    def test_compare_step_highlights_both_cells(self):
+        animation = _validated(compile_animation(_bubble_trace()))
+        # Find the step after the first that is a compare (narration contains "Compare").
+        compare_step = next(
+            s
+            for s in animation["steps"][1:]
+            if s["narration"].startswith("Compare index 0")
+        )
+        targets = {op["target"] for op in compare_step["motion"]}
+        assert "cell_0" in targets
+        assert "cell_1" in targets
+        fills = {op["to"] for op in compare_step["motion"] if op["op"] == "fill"}
+        assert any("#" in f for f in fills)
+
+    def test_swap_crosses_value_labels(self):
+        animation = _validated(compile_animation(_bubble_trace()))
+        swap_step = next(
+            s
+            for s in animation["steps"][1:]
+            if "swap" in s["narration"].lower() and "index 0" in s["narration"].lower()
+        )
+        moves = {
+            op["target"]: op["to"] for op in swap_step["motion"] if op["op"] == "move"
+        }
+        assert "val_0" in moves and "val_1" in moves
+        # They cross: label 0 ends at cell 1, label 1 at cell 0.
+        assert moves["val_0"] != moves["val_1"]
+        assert moves["val_0"][0] == AnimationCompiler(n=5).cell_x(1)
+        assert moves["val_1"][0] == AnimationCompiler(n=5).cell_x(0)
+
+    def test_sorted_mark_greens_the_cell(self):
+        animation = _validated(compile_animation(_bubble_trace()))
+        mark_step = next(
+            s for s in animation["steps"][1:] if "final position" in s["narration"]
+        )
+        fills = {op["to"] for op in mark_step["motion"] if op["op"] == "fill"}
+        assert "#14532d" in fills
+
+    def test_write_updates_label_at_tracked_index(self):
+        trace = _trace(
+            "\n".join(
+                [
+                    '{"event":"init","values":[1,2,3]}',
+                    '{"event":"compare","i":0,"j":1}',
+                    '{"event":"swap","i":0,"j":1}',
+                    '{"event":"write","i":1,"value":99}',
+                    '{"event":"return","result":[2,99,3]}',
+                ]
+            )
+        )
+        animation = _validated(compile_animation(trace))
+        write_step = next(
+            s for s in animation["steps"][1:] if "becomes 99" in s["narration"]
+        )
+        label_ops = [op for op in write_step["motion"] if op["op"] == "label"]
+        assert label_ops, "write must relabel a value"
+        assert label_ops[0]["to"] == "99"
+
+    def test_pointer_event_moves_arrow(self):
+        trace = _trace(
+            "\n".join(
+                [
+                    '{"event":"init","values":[9,1,5]}',
+                    '{"event":"pointer","name":"low","index":0}',
+                    '{"event":"pointer","name":"high","index":2}',
+                    '{"event":"compare","i":0,"j":2}',
+                    '{"event":"return","result":[9,1,5]}',
+                ]
+            )
+        )
+        animation = _validated(compile_animation(trace))
+        first = animation["steps"][0]
+        ids = _ids_in(first)
+        assert "ptr_low" in ids and "ptr_high" in ids
+        # high pointer moves to index 2.
+        moves = [
+            o
+            for s in animation["steps"]
+            for o in s["motion"]
+            if o["target"] == "ptr_high" and o["op"] == "move"
+        ]
+        assert moves
+        assert abs(moves[0]["to"][0] - AnimationCompiler(n=3).cell_x(2)) < 1e-6
+
+    def test_many_values_shrink_cells_within_bounds(self):
+        values = list(range(1, 26))
+        init = json.dumps({"event": "init", "values": values})
+        ret = json.dumps({"event": "return", "result": values})
+        trace = parse_trace(init + "\n" + ret)
+        animation = _validated(compile_animation(trace))
+        # Intro is split across steps so each stays under the per-step cap.
+        rects = [
+            shape
+            for step in animation["steps"]
+            for shape in step.get("shapes", [])
+            if shape["type"] == "rect"
+        ]
+        assert len(rects) == len(values)
+        for shape in rects:
+            assert -960 <= shape["x"] <= 960
+
+    def test_compile_requires_an_init_event(self):
+        trace = parse_trace('{"event":"compare","i":0,"j":1}')
+        assert compile_animation(trace, title="x") is None
+
+    def test_compile_returns_none_for_empty_trace(self):
+        assert compile_animation([], title="x") is None
+
+    def test_default_compiler_instance(self):
+        assert isinstance(AnimationCompiler(), AnimationCompiler)

--- a/backend/tests/unit/test_animation_inputs.py
+++ b/backend/tests/unit/test_animation_inputs.py
@@ -1,0 +1,83 @@
+"""Unit tests for example-input normalization.
+
+DB question examples store inputs in many shapes:
+`nums = [2,7,11,15], target = 9`, bare arrays, bare strings, matrices,
+level-order tree arrays, multiline test inputs. The normalizer turns any of
+these into the kwargs dict a canonical traced solution expects, using JSON /
+literal parsing first (so `null`/`true` and Python values both work) and a
+raw-string fallback for values that are not evaluable (e.g. bit-string args).
+"""
+
+from app.services.animation_inputs import parse_input_kwargs
+
+
+class TestParseInputKwargs:
+    def test_assignments_becomes_kwargs(self):
+        out = parse_input_kwargs("nums = [2,7,11,15], target = 9", ["nums", "target"])
+        assert out == {"nums": [2, 7, 11, 15], "target": 9}
+
+    def test_bare_array_maps_to_first_signature_param(self):
+        assert parse_input_kwargs("[5,1,4,2,8]", ["values"]) == {
+            "values": [5, 1, 4, 2, 8]
+        }
+
+    def test_bare_string_maps_to_first_signature_param(self):
+        assert parse_input_kwargs('"()"', ["s"]) == {"s": "()"}
+
+    def test_bare_number_maps_to_first_signature_param(self):
+        assert parse_input_kwargs("19", ["n"]) == {"n": 19}
+
+    def test_nested_brackets_are_not_split(self):
+        out = parse_input_kwargs("root = [3,1,4,null,2], k = 1", ["root", "k"])
+        assert out == {"root": [3, 1, 4, None, 2], "k": 1}
+
+    def test_json_true_null_literals(self):
+        out = parse_input_kwargs(
+            'board = [["1","1","0"]], word = "11"', ["board", "word"]
+        )
+        assert out == {"board": [["1", "1", "0"]], "word": "11"}
+
+    def test_two_arrays_from_assignments(self):
+        out = parse_input_kwargs("l1 = [2,4,3], l2 = [5,6,4]", ["l1", "l2"])
+        assert out == {"l1": [2, 4, 3], "l2": [5, 6, 4]}
+
+    def test_multiline_input_maps_lines_to_signature(self):
+        out = parse_input_kwargs("[2,4,3]\n[5,6,4]", ["l1", "l2"])
+        assert out == {"l1": [2, 4, 3], "l2": [5, 6, 4]}
+
+    def test_multiline_assignments_are_parsed(self):
+        out = parse_input_kwargs(
+            'operations = ["push","pop"],\nvalues = [[-2],[]]',
+            ["operations", "values"],
+        )
+        assert out == {"operations": ["push", "pop"], "values": [[-2], []]}
+
+    def test_multiline_assignments_without_comma(self):
+        out = parse_input_kwargs(
+            'operations = ["push"]\nvalues = [[-2]]',
+            ["operations", "values"],
+        )
+        assert out == {"operations": ["push"], "values": [[-2]]}
+
+    def test_raw_string_fallback_when_not_evaluable(self):
+        out = parse_input_kwargs("n = 00000000000000000000000000001011", ["n"])
+        assert out == {"n": "00000000000000000000000000001011"}
+
+    def test_strings_with_commas_inside_quotes(self):
+        out = parse_input_kwargs('strs = ["eat","tea","tan"], k = 1', ["strs", "k"])
+        assert out == {"strs": ["eat", "tea", "tan"], "k": 1}
+
+    def test_dict_input_passes_through(self):
+        assert parse_input_kwargs({"values": [1, 2]}, ["values"]) == {"values": [1, 2]}
+
+    def test_empty_input_returns_empty_kwargs(self):
+        assert parse_input_kwargs("", ["s"]) == {}
+        assert parse_input_kwargs(None, ["s"]) == {}
+
+    def test_unknown_key_is_kept(self):
+        out = parse_input_kwargs("n = 5, extra = [1]", ["n"])
+        assert out == {"n": 5, "extra": [1]}
+
+    def test_operator_syntax_without_space_after_equals(self):
+        out = parse_input_kwargs("n=2", ["n"])
+        assert out == {"n": 2}

--- a/backend/tests/unit/test_animation_validator.py
+++ b/backend/tests/unit/test_animation_validator.py
@@ -1,216 +1,527 @@
-"""Unit tests for AnimationValidator — the semantic gate on AI animation scripts.
+"""Unit tests for AnimationValidator — the structural gate on generic scenes.
 
-Covers: valid linear search acceptance, index bounds, match/mismatch truthfulness,
-unsupported types, missing data, empty/oversized traces, and narration hygiene.
+Covers: valid scenes, step/shape/motion caps, coordinate bounds, shape field
+rules, hex colors, id uniqueness, motion-target resolution, and duration
+bounds. Also covers the GroqService._validate_animation pipeline.
 """
 
 from app.services.animation_validator import (
     AnimationValidator,
+    MAX_MOTIONS_PER_STEP,
+    MAX_SHAPES,
+    MAX_SHAPES_PER_STEP,
     MAX_STEPS,
-    MAX_VALUES,
     animation_validator,
 )
 
 
-def _linear_search(values, target, steps):
-    return {
-        "type": "linear_search",
-        "title": "Searching",
-        "data": {"values": values, "target": target},
-        "steps": steps,
+def _shape(**overrides):
+    base = {
+        "id": "cell_0",
+        "type": "rect",
+        "x": 0,
+        "y": 0,
+        "width": 88,
+        "height": 88,
+        "fill": "#1e293b",
+        "stroke": "#334155",
     }
+    base.update(overrides)
+    return base
 
 
-def _compare(index, result, narration="checking"):
+def _motion(**overrides):
+    base = {"target": "cell_0", "op": "appear", "duration": 0.3}
+    base.update(overrides)
+    return base
+
+
+def _scene(steps):
+    return {"title": "Scene", "data": {}, "steps": steps}
+
+
+def _step(shapes=None, motion=None, narration="checking"):
     return {
-        "operation": "compare",
-        "index": index,
-        "result": result,
         "narration": narration,
+        "shapes": shapes or [],
+        "motion": motion or [],
     }
 
 
-class TestValidScripts:
-    def test_valid_linear_search(self):
-        script = _linear_search(
-            [5, 1, 2, 3, 4, 5],
-            4,
-            [_compare(0, "mismatch"), _compare(1, "mismatch"), _compare(4, "match")],
+class TestValidScenes:
+    def test_minimal_valid_scene(self):
+        scene = _scene(
+            [
+                _step(
+                    shapes=[_shape(), _shape(id="b", x=120)],
+                    motion=[_motion(), _motion(target="b", op="appear")],
+                ),
+                _step(motion=[_motion(op="move", to=[100, 0])]),
+                _step(motion=[_motion(target="b", op="fill", to="#22c55e")]),
+            ]
         )
-        validated, reason = animation_validator.validate(script)
+        validated, reason = animation_validator.validate(scene)
         assert validated is not None
         assert reason == ""
 
-    def test_target_at_first_index(self):
-        script = _linear_search([5, 1], 5, [_compare(0, "match")])
-        validated, _ = animation_validator.validate(script)
-        assert validated is not None
-
-    def test_duplicate_target_values(self):
-        script = _linear_search(
-            [5, 1, 5, 3],
-            5,
-            [_compare(0, "match")],
-        )
-        validated, _ = animation_validator.validate(script)
-        assert validated is not None
-
-    def test_compare_without_result_allowed(self):
-        script = _linear_search([1, 2], 2, [_compare(0, None)])
-        validated, _ = animation_validator.validate(script)
-        assert validated is not None
-
-    def test_visit_and_mark_operations_allowed(self):
-        script = _linear_search(
-            [1, 2, 3],
-            3,
+    def test_multi_step_timeline(self):
+        scene = _scene(
             [
-                {"operation": "visit", "index": 0, "narration": "visiting"},
-                {
-                    "operation": "mark",
-                    "index": 2,
-                    "result": "match",
-                    "narration": "mark",
-                },
-            ],
+                _step(shapes=[_shape(id="a")], motion=[_motion(target="a")]),
+                _step(
+                    shapes=[_shape(id="b", x=100)],
+                    motion=[
+                        _motion(target="a", op="fill", to="#22c55e"),
+                        _motion(target="b", op="move", to=[200, 0]),
+                    ],
+                ),
+                _step(motion=[_motion(target="b", op="move", to=[300, 0])]),
+            ]
         )
-        validated, _ = animation_validator.validate(script)
+        validated, reason = animation_validator.validate(scene)
+        assert validated is not None
+
+    def test_polygon_and_line_shapes(self):
+        scene = _scene(
+            [
+                _step(
+                    shapes=[
+                        {
+                            "id": "poly",
+                            "type": "polygon",
+                            "x": 0,
+                            "y": 0,
+                            "points": [[-10, 0], [0, 20], [10, 0]],
+                            "fill": "#facc15",
+                        },
+                        {
+                            "id": "line",
+                            "type": "line",
+                            "x": 0,
+                            "y": 0,
+                            "points": [[-100, 0], [100, 0]],
+                            "stroke": "#94a3b8",
+                        },
+                    ],
+                    motion=[
+                        _motion(target="poly", op="appear", duration=0.3),
+                        _motion(target="line", op="appear", duration=0.3),
+                    ],
+                ),
+                _step(motion=[_motion(target="poly", op="move", to=[50, 0])]),
+                _step(motion=[_motion(target="line", op="rotate", to=45)]),
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is not None
+
+    def test_text_shape(self):
+        scene = _scene(
+            [
+                _step(
+                    shapes=[
+                        {
+                            "id": "txt",
+                            "type": "text",
+                            "x": 0,
+                            "y": 200,
+                            "text": "Two Sum",
+                            "fontSize": 28,
+                            "fill": "#e2e8f0",
+                        },
+                        _shape(id="box", x=-300, y=200),
+                    ],
+                    motion=[
+                        _motion(target="txt", op="appear"),
+                        _motion(target="box", op="appear"),
+                    ],
+                ),
+                _step(motion=[_motion(target="txt", op="move", to=[0, 240])]),
+                _step(motion=[_motion(target="box", op="fill", to="#22c55e")]),
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is not None
+
+    def test_motion_target_added_earlier_or_same_step(self):
+        scene = _scene(
+            [
+                _step(
+                    shapes=[_shape(id="a"), _shape(id="b", x=120)],
+                    motion=[_motion(target="a"), _motion(target="b", op="appear")],
+                ),
+                _step(motion=[_motion(target="a", op="move", to=[50, 0])]),
+                _step(motion=[_motion(target="b", op="fill", to="#22c55e")]),
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
         assert validated is not None
 
 
 class TestRejections:
-    def test_unsupported_type(self):
-        script = {
-            "type": "bubble_sort",
-            "data": {"values": [3, 2, 1]},
-            "steps": [_compare(0, "mismatch")],
-        }
-        validated, reason = animation_validator.validate(script)
-        assert validated is None
-        assert "Unsupported animation type" in reason
-
     def test_not_an_object(self):
-        validated, reason = animation_validator.validate("linear_search")
+        validated, reason = animation_validator.validate("scene")
         assert validated is None
         assert "not an object" in reason
 
-    def test_missing_values(self):
-        script = _linear_search([], 4, [])
-        validated, reason = animation_validator.validate(script)
-        assert validated is None
-        assert "non-empty values" in reason
-
-    def test_too_many_values(self):
-        script = _linear_search(
-            list(range(MAX_VALUES + 1)), 1, [_compare(0, "mismatch")]
-        )
-        validated, reason = animation_validator.validate(script)
-        assert validated is None
-        assert "Too many values" in reason
-
     def test_empty_steps(self):
-        script = _linear_search([1, 2, 3], 2, [])
-        validated, reason = animation_validator.validate(script)
+        validated, reason = animation_validator.validate(_scene([]))
         assert validated is None
         assert "non-empty steps" in reason
 
+    def test_missing_steps(self):
+        validated, reason = animation_validator.validate({"title": "x"})
+        assert validated is None
+        assert "steps" in reason
+
     def test_too_many_steps(self):
-        steps = [_compare(0, "mismatch")] * (MAX_STEPS + 1)
-        script = _linear_search([1], 1, steps)
-        validated, reason = animation_validator.validate(script)
+        steps = [_step(shapes=[_shape(id=f"c{i}")]) for i in range(MAX_STEPS + 1)]
+        validated, reason = animation_validator.validate(_scene(steps))
         assert validated is None
         assert "Too many steps" in reason
 
-    def test_out_of_bounds_index(self):
-        script = _linear_search([1, 2, 3], 3, [_compare(9, "mismatch")])
-        validated, reason = animation_validator.validate(script)
+    def test_too_many_shapes_total(self):
+        steps = []
+        for i in range(0, MAX_SHAPES + 1, MAX_SHAPES_PER_STEP):
+            batch = [_shape(id=f"c{i + j}") for j in range(MAX_SHAPES_PER_STEP)]
+            steps.append(_step(shapes=batch, motion=[_motion(target=f"c{i}")]))
+        validated, reason = animation_validator.validate(_scene(steps))
         assert validated is None
-        assert "out-of-bounds" in reason
+        assert "Too many shapes" in reason
 
-    def test_negative_index(self):
-        script = _linear_search([1, 2, 3], 3, [_compare(-1, "mismatch")])
-        validated, reason = animation_validator.validate(script)
+    def test_too_many_shapes_per_step(self):
+        shapes = [_shape(id=f"c{i}") for i in range(MAX_SHAPES_PER_STEP + 1)]
+        validated, reason = animation_validator.validate(
+            _scene([_step(shapes=shapes, motion=[_motion(target="c0")])])
+        )
         assert validated is None
-        assert "out-of-bounds" in reason
+        assert "too many shapes" in reason
 
-    def test_match_step_must_equal_target(self):
-        script = _linear_search([5, 1, 2, 3, 4, 5], 4, [_compare(0, "match")])
-        validated, reason = animation_validator.validate(script)
+    def test_too_many_motions_per_step(self):
+        motions = [_motion() for _ in range(MAX_MOTIONS_PER_STEP + 1)]
+        validated, reason = animation_validator.validate(
+            _scene([_step(shapes=[_shape()], motion=motions)])
+        )
         assert validated is None
-        assert "does not equal target" in reason
+        assert "too many motion ops" in reason
 
-    def test_mismatch_step_must_not_equal_target(self):
-        script = _linear_search([5, 1, 2, 3, 4, 5], 5, [_compare(0, "mismatch")])
-        validated, reason = animation_validator.validate(script)
+    def test_unsupported_shape_type(self):
+        scene = _scene([_step(shapes=[_shape(type="spaceship")])])
+        validated, reason = animation_validator.validate(scene)
         assert validated is None
-        assert "equals target" in reason
+        assert "unsupported type" in reason
 
-    def test_missing_narration(self):
-        script = _linear_search([1, 2], 2, [{"operation": "compare", "index": 0}])
-        validated, reason = animation_validator.validate(script)
+    def test_rect_requires_width_and_height(self):
+        shape = _shape(width=None, height=None)
+        validated, reason = animation_validator.validate(
+            _scene([_step(shapes=[shape])])
+        )
         assert validated is None
-        assert "missing narration" in reason
+        assert "requires width and height" in reason
+
+    def test_out_of_range_x(self):
+        shape = _shape(x=2000)
+        validated, reason = animation_validator.validate(
+            _scene([_step(shapes=[shape])])
+        )
+        assert validated is None
+        assert "out of range" in reason
+
+    def test_out_of_range_y(self):
+        shape = _shape(y=-600)
+        validated, reason = animation_validator.validate(
+            _scene([_step(shapes=[shape])])
+        )
+        assert validated is None
+        assert "out of range" in reason
+
+    def test_non_numeric_size(self):
+        shape = _shape(width="big")
+        validated, reason = animation_validator.validate(
+            _scene([_step(shapes=[shape])])
+        )
+        assert validated is None
+        assert "positive number" in reason
+
+    def test_non_positive_font_size(self):
+        shape = {
+            "id": "txt",
+            "type": "text",
+            "x": 0,
+            "y": 0,
+            "text": "hi",
+            "fontSize": 0,
+        }
+        validated, reason = animation_validator.validate(
+            _scene([_step(shapes=[shape])])
+        )
+        assert validated is None
+        assert "positive number" in reason
+
+    def test_invalid_color(self):
+        shape = _shape(fill="red")
+        validated, reason = animation_validator.validate(
+            _scene([_step(shapes=[shape])])
+        )
+        assert validated is None
+        assert "hex color" in reason
+
+    def test_invalid_opacity(self):
+        shape = _shape(opacity=3)
+        validated, reason = animation_validator.validate(
+            _scene([_step(shapes=[shape])])
+        )
+        assert validated is None
+        assert "opacity" in reason
+
+    def test_duplicate_shape_ids(self):
+        scene = _scene(
+            [
+                _step(shapes=[_shape(id="dup"), _shape(id="dup", x=100)]),
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "Duplicate" in reason
+
+    def test_duplicate_ids_across_steps(self):
+        scene = _scene(
+            [
+                _step(shapes=[_shape(id="dup")], motion=[_motion(target="dup")]),
+                _step(shapes=[_shape(id="dup", x=100)]),
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "Duplicate" in reason
+
+    def test_missing_shape_id(self):
+        shape = _shape()
+        del shape["id"]
+        validated, reason = animation_validator.validate(
+            _scene([_step(shapes=[shape])])
+        )
+        assert validated is None
+        assert "missing an id" in reason
+
+    def test_unsupported_motion_op(self):
+        scene = _scene([_step(shapes=[_shape()], motion=[_motion(op="explode")])])
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "unsupported op" in reason
+
+    def test_motion_targets_unknown_shape(self):
+        scene = _scene([_step(motion=[_motion(target="nope")])])
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "unknown shape id" in reason
+
+    def test_motion_duration_too_long(self):
+        scene = _scene([_step(shapes=[_shape()], motion=[_motion(duration=10)])])
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "duration" in reason
+
+    def test_move_requires_xy_target(self):
+        scene = _scene(
+            [
+                _step(
+                    shapes=[_shape()],
+                    motion=[_motion(op="move", to=[0, 0, 0])],
+                )
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "move requires" in reason
+
+    def test_move_target_out_of_range(self):
+        scene = _scene(
+            [
+                _step(
+                    shapes=[_shape()],
+                    motion=[_motion(op="move", to=[2000, 0])],
+                )
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "out of range" in reason
+
+    def test_fill_requires_hex_color(self):
+        scene = _scene(
+            [
+                _step(
+                    shapes=[_shape()],
+                    motion=[_motion(op="fill", to="green")],
+                )
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "hex color" in reason
+
+    def test_scale_must_be_positive(self):
+        scene = _scene(
+            [
+                _step(
+                    shapes=[_shape()],
+                    motion=[_motion(op="scale", to=0)],
+                )
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "scale" in reason
 
     def test_narration_too_long(self):
-        script = _linear_search(
-            [1, 2], 2, [_compare(0, "mismatch", narration="x" * 301)]
-        )
-        validated, reason = animation_validator.validate(script)
+        scene = _scene([_step(narration="x" * 301)])
+        validated, reason = animation_validator.validate(scene)
         assert validated is None
-        assert "exceeds 300 chars" in reason
+        assert "narration" in reason
 
-    def test_step_not_an_object(self):
-        script = _linear_search([1, 2], 2, ["not-a-step"])
-        validated, reason = animation_validator.validate(script)
-        assert validated is None
-        assert "not an object" in reason
-
-    def test_invalid_compare_result(self):
-        script = _linear_search(
-            [1, 2],
-            2,
+    def test_too_few_steps(self):
+        scene = _scene(
             [
-                {
-                    "operation": "compare",
-                    "index": 0,
-                    "result": "banana",
-                    "narration": "x",
-                }
-            ],
+                _step(
+                    shapes=[_shape(), _shape(id="b", x=120)],
+                    motion=[_motion(), _motion(target="b", op="appear")],
+                ),
+            ]
         )
-        validated, reason = animation_validator.validate(script)
+        validated, reason = animation_validator.validate(scene)
         assert validated is None
-        assert "invalid compare result" in reason
+        assert "Too few steps" in reason
 
-    def test_compare_result_without_index_is_rejected_not_crash(self):
-        script = _linear_search(
-            [1, 2],
-            2,
-            [{"operation": "compare", "result": "match", "narration": "x"}],
+    def test_too_few_shapes_total(self):
+        scene = _scene(
+            [
+                _step(shapes=[_shape()], motion=[_motion()]),
+                _step(motion=[_motion(op="move", to=[100, 0])]),
+                _step(motion=[_motion(op="fill", to="#22c55e")]),
+            ]
         )
-        validated, reason = animation_validator.validate(script)
+        validated, reason = animation_validator.validate(scene)
         assert validated is None
-        assert "missing an index" in reason
+        assert "Too few shapes" in reason
 
-    def test_compare_result_without_index_does_not_raise_in_groq(self):
+    def test_step_without_motion_rejected(self):
+        scene = _scene(
+            [
+                _step(shapes=[_shape()], motion=[_motion()]),
+                _step(shapes=[_shape(id="b", x=100)]),
+                _step(motion=[_motion(target="b", op="move", to=[100, 0])]),
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "no motion" in reason
+
+    def test_appear_only_step_rejected(self):
+        """Fading shapes in is not an animation — every step must transform
+        an existing shape (move/fill/stroke/scale/rotate)."""
+        scene = _scene(
+            [
+                _step(
+                    shapes=[_shape(), _shape(id="b", x=120)],
+                    motion=[_motion(), _motion(target="b", op="appear")],
+                ),
+                _step(
+                    shapes=[_shape(id="c", x=240)],
+                    motion=[_motion(target="c", op="appear")],
+                ),
+                _step(
+                    shapes=[_shape(id="d", x=360)],
+                    motion=[_motion(target="d", op="appear")],
+                ),
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "transform" in reason
+
+    def test_disappear_only_step_rejected(self):
+        scene = _scene(
+            [
+                _step(
+                    shapes=[_shape(), _shape(id="b", x=120)],
+                    motion=[_motion(), _motion(target="b", op="appear")],
+                ),
+                _step(
+                    motion=[
+                        _motion(target="b", op="move", to=[200, 0]),
+                        _motion(target="cell_0", op="disappear"),
+                    ]
+                ),
+                _step(
+                    motion=[_motion(target="b", op="disappear")],
+                ),
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "transform" in reason
+
+    def test_label_op_counts_as_transform(self):
+        """Changing a shape's content is a real visual change — it satisfies
+        the per-step transform rule the same way move/fill/scale do."""
+        scene = _scene(
+            [
+                _step(
+                    shapes=[_shape(), _shape(id="b", x=120)],
+                    motion=[_motion(), _motion(target="b", op="appear")],
+                ),
+                _step(
+                    motion=[
+                        _motion(target="b", op="label", to="9"),
+                        _motion(target="b", op="fill", to="#22c55e"),
+                    ]
+                ),
+                _step(motion=[_motion(target="cell_0", op="move", to=[100, 0])]),
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is not None
+
+    def test_label_op_requires_to(self):
+        scene = _scene(
+            [
+                _step(shapes=[_shape()], motion=[_motion()]),
+                _step(motion=[_motion(op="label")]),
+                _step(motion=[_motion(op="move", to=[50, 0])]),
+            ]
+        )
+        validated, reason = animation_validator.validate(scene)
+        assert validated is None
+        assert "to" in reason or "label" in reason
+
+
+class TestGroqIntegration:
+    def test_valid_animation_is_kept(self):
         from app.services.groq_service import GroqService
 
         data = {
             "summary": "Keep coaching",
             "hints": [],
-            "animation": _linear_search(
-                [1, 2],
-                2,
-                [{"operation": "compare", "result": "match", "narration": "x"}],
+            "animation": _scene(
+                [
+                    _step(shapes=[_shape(id="a")], motion=[_motion(target="a")]),
+                    _step(
+                        shapes=[_shape(id="b", x=100)],
+                        motion=[
+                            _motion(target="b"),
+                            _motion(target="a", op="fill", to="#22c55e"),
+                        ],
+                    ),
+                    _step(motion=[_motion(target="b", op="move", to=[200, 0])]),
+                ]
             ),
         }
         result = GroqService._validate_animation(data)
-        assert "animation" not in result
-        assert result["summary"] == "Keep coaching"
+        assert "animation" in result
+        assert result["animation"]["title"] == "Scene"
 
-
-class TestGroqIntegration:
-    def test_invalid_animation_is_dropped(self):
+    def test_legacy_typed_animation_is_dropped(self):
         from app.services.groq_service import GroqService
 
         data = {
@@ -218,24 +529,43 @@ class TestGroqIntegration:
             "hints": [],
             "animation": {
                 "type": "linear_search",
-                "data": {"values": [5], "target": 4},
-                "steps": [_compare(0, "match")],
+                "title": "Searching for 4",
+                "steps": [{"operation": "compare", "index": 0, "narration": "x"}],
             },
         }
         result = GroqService._validate_animation(data)
         assert "animation" not in result
         assert result["summary"] == "Keep coaching"
 
-    def test_valid_animation_is_kept(self):
+    def test_legacy_operation_steps_dropped_without_type(self):
         from app.services.groq_service import GroqService
 
         data = {
             "summary": "Keep coaching",
             "hints": [],
-            "animation": _linear_search([4, 1], 4, [_compare(0, "match")]),
+            "animation": {
+                "title": "Your code vs the solution",
+                "steps": [{"operation": "compare_code", "narration": "x"}],
+            },
         }
         result = GroqService._validate_animation(data)
-        assert result["animation"]["type"] == "linear_search"
+        assert "animation" not in result
+        assert result["summary"] == "Keep coaching"
+
+    def test_invalid_animation_is_dropped(self):
+        from app.services.groq_service import GroqService
+
+        data = {
+            "summary": "Keep coaching",
+            "hints": [],
+            "animation": {
+                "title": "broken",
+                "steps": [{"narration": "x", "shapes": [_shape(x=5000)]}],
+            },
+        }
+        result = GroqService._validate_animation(data)
+        assert "animation" not in result
+        assert result["summary"] == "Keep coaching"
 
     def test_animation_absent_is_untouched(self):
         from app.services.groq_service import GroqService
@@ -252,7 +582,7 @@ class TestGroqIntegration:
         data = {
             "summary": "Keep coaching",
             "hints": [],
-            "animation": _linear_search([4, 1], 4, [_compare(0, "match")]),
+            "animation": _scene([_step(shapes=[_shape()])]),
         }
         with patch(
             "app.services.animation_validator.AnimationValidator.validate",

--- a/backend/tests/unit/test_boundary_conditions.py
+++ b/backend/tests/unit/test_boundary_conditions.py
@@ -41,6 +41,45 @@ class TestBoundaryConditions:
         assert request.code == max_code
         assert request.message == max_message
 
+    def test_coaching_request_accepts_initial_code(self):
+        """Test coaching request accepts an initial_code (starter) field."""
+        request = CoachingRequest(
+            problem="Two Sum",
+            code="def two_sum(nums, target):\n    pass",
+            language=Language.PYTHON,
+            message="",
+            mode=CoachingMode.ANIMATE,
+            difficulty=Difficulty.EASY,
+            initial_code="def two_sum(nums, target):\n    pass",
+        )
+
+        assert request.mode == CoachingMode.ANIMATE
+        assert request.mode.value == "animate"
+        assert request.initial_code == "def two_sum(nums, target):\n    pass"
+
+    def test_coaching_request_initial_code_is_optional(self):
+        """Test initial_code defaults to None when not provided."""
+        request = CoachingRequest(
+            problem="p",
+            code="c",
+            language=Language.PYTHON,
+            message="m",
+        )
+
+        assert request.initial_code is None
+
+    def test_coaching_request_initial_code_max_length(self):
+        """Test initial_code respects the max length boundary."""
+        request = CoachingRequest(
+            problem="p",
+            code="c",
+            language=Language.PYTHON,
+            message="m",
+            initial_code="x" * 50000,
+        )
+
+        assert len(request.initial_code) == 50000
+
     def test_coaching_request_empty_strings(self):
         """Test coaching request with empty strings."""
         request = CoachingRequest(

--- a/backend/tests/unit/test_coaching_prompts.py
+++ b/backend/tests/unit/test_coaching_prompts.py
@@ -5,6 +5,7 @@ from app.adapters.coaching_prompts import (
     build_user_prompt,
     build_structured_user_prompt,
     MODE_SECTIONS,
+    PromptBuilder,
 )
 
 
@@ -115,7 +116,8 @@ class TestBuildStructuredSystemPrompt:
     def test_animation_contract_present(self):
         prompt = build_structured_system_prompt("hint", "python")
         assert "Animation Contract" in prompt
-        assert "linear_search" in prompt
+        assert "shapes" in prompt
+        assert "motion" in prompt
         assert "never return JavaScript" in prompt
 
     def test_animation_never_invents_runtime_results(self):
@@ -249,15 +251,260 @@ class TestBuildStructuredUserPrompt:
         data = json.loads(prompt)
         assert data["message"] == 'it\'s "broken" somehow'
 
+    def test_structured_user_prompt_includes_question(self):
+        builder = PromptBuilder()
+        _, user = builder.build(
+            mode="animate",
+            language="python",
+            problem="Two Sum",
+            code="def f(): pass",
+            message="animate",
+            structured=True,
+            initial_code="def f():\n    pass",
+            question={"title": "Two Sum", "category": "hash_map"},
+        )
+        data = json.loads(user)
+        assert data["question"]["title"] == "Two Sum"
+        assert data["question"]["category"] == "hash_map"
+
+    def test_structured_user_prompt_never_leaks_hidden_test_cases(self):
+        # Hidden test cases are curriculum secrets: they must never reach the
+        # third-party model even though they live on the question object.
+        builder = PromptBuilder()
+        _, user = builder.build(
+            mode="animate",
+            language="python",
+            problem="Two Sum",
+            code="def f(): pass",
+            message="animate",
+            structured=True,
+            initial_code="def f():\n    pass",
+            question={
+                "title": "Two Sum",
+                "category": "hash_map",
+                "test_cases": [{"input": "secret input", "output": "secret"}],
+            },
+        )
+        data = json.loads(user)
+        assert data["question"]["title"] == "Two Sum"
+        assert "test_cases" not in data["question"]
+        assert "secret input" not in user
+
+    def test_structured_user_prompt_omits_question_when_absent(self):
+        builder = PromptBuilder()
+        _, user = builder.build(
+            mode="animate",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+            initial_code="s",
+        )
+        data = json.loads(user)
+        assert "question" not in data
+
+
+class TestAnimateMode:
+    def test_animate_is_in_mode_sections(self):
+        assert "animate" in MODE_SECTIONS
+
+    def test_structured_prompt_includes_animate_contract(self):
+        builder = PromptBuilder()
+        system, _ = builder.build(
+            mode="animate",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+            initial_code="s",
+        )
+        assert "Animate Mode" in system
+        assert "Generic Scene Contract" in system
+        assert '"rect"' in system
+        assert '"move"' in system
+        assert "never return JavaScript" in system
+
+    def test_animate_contract_enforces_a_rich_multi_step_scene(self):
+        builder = PromptBuilder()
+        system, _ = builder.build(
+            mode="animate",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+            initial_code="s",
+        )
+        assert "at least 3 steps" in system
+        assert "pointer" in system
+
+    def test_animate_contract_requires_single_shape_definition(self):
+        builder = PromptBuilder()
+        system, _ = builder.build(
+            mode="animate",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+            initial_code="s",
+        )
+        assert "Define every shape exactly once" in system
+        assert "Never repeat a shape id" in system
+
+    def test_animate_contract_requires_transform_op_per_step(self):
+        builder = PromptBuilder()
+        system, _ = builder.build(
+            mode="animate",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+            initial_code="s",
+        )
+        assert "only appear" not in system
+        assert "visibly moves forward" in system
+        assert "MUST include at least one transform op" in system
+
+    def test_animate_contract_forces_a_moving_pointer(self):
+        builder = PromptBuilder()
+        system, _ = builder.build(
+            mode="animate",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+            initial_code="s",
+        )
+        assert "pointer" in system
+        assert "advance" in system
+        assert "move" in system
+
+    def test_unstructured_prompt_includes_animate_section(self):
+        builder = PromptBuilder()
+        system, _ = builder.build(
+            mode="animate",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=False,
+        )
+        assert "Animate (mode: animate)" in system
+
+    def test_non_animate_modes_omit_animate_contract(self):
+        builder = PromptBuilder()
+        system, _ = builder.build(
+            mode="hint",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+        )
+        assert "Animate Mode" not in system
+
+    def test_structured_user_prompt_includes_initial_code(self):
+        builder = PromptBuilder()
+        _, user = builder.build(
+            mode="animate",
+            language="python",
+            problem="Two Sum",
+            code="def f(): pass",
+            message="animate",
+            structured=True,
+            initial_code="def f():\n    pass",
+        )
+        data = json.loads(user)
+        assert data["initial_code"] == "def f():\n    pass"
+
+    def test_structured_user_prompt_omits_initial_code_when_absent(self):
+        builder = PromptBuilder()
+        _, user = builder.build(
+            mode="hint",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+        )
+        data = json.loads(user)
+        assert "initial_code" not in data
+
+    def test_animate_contract_requires_a_non_null_animation(self):
+        builder = PromptBuilder()
+        system, _ = builder.build(
+            mode="animate",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+            initial_code="s",
+        )
+        assert "FORBIDDEN" in system
+        assert "NON-NEGOTIABLE" in system
+        assert "null" in system
+
+    def test_animate_contract_never_uses_student_code(self):
+        """The animation shows the OPTIMAL solution — the student's typed code
+        is never compared, inspected, or visualized."""
+        builder = PromptBuilder()
+        system, _ = builder.build(
+            mode="animate",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+            initial_code="s",
+        )
+        assert "OPTIMAL solution" in system
+        assert "Never compare against the student" in system
+        assert "side-by-side" not in system
+
+    def test_animate_contract_uses_question_input_data(self):
+        builder = PromptBuilder()
+        system, _ = builder.build(
+            mode="animate",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+            initial_code="s",
+        )
+        assert "question" in system
+        assert "never invent runtime results" in system
+
+    def test_animate_contract_keeps_scene_data_not_code(self):
+        builder = PromptBuilder()
+        system, _ = builder.build(
+            mode="animate",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+            initial_code="s",
+        )
+        assert "This is DATA, not code" in system
+        assert "SVG" in system
+
 
 class TestModeSections:
-    def test_maps_all_five_modes(self):
+    def test_maps_all_six_modes(self):
         assert set(MODE_SECTIONS.keys()) == {
             "hint",
             "review",
             "explain",
             "debug",
             "freeform",
+            "animate",
         }
 
     def test_each_mode_has_unstructured_section(self):

--- a/backend/tests/unit/test_family_compilers.py
+++ b/backend/tests/unit/test_family_compilers.py
@@ -1,0 +1,316 @@
+"""Unit tests for the family compilers (stack/list/tree/grid/graph/intervals/
+backtrack).
+
+Every family compiler deterministically turns an ordered semantic trace into a
+generic AnimationScript that must always pass AnimationValidator — the same
+structural gate the array compiler's output passes. Each family renders its
+structure with rect/ellipse/line/polygon/text primitives and animates
+semantic events (push/pop, visit, edge, dp_update, choose/backtrack ...) by
+moving/filling/relabeling existing shapes.
+"""
+
+import json
+
+from app.services.trace_parser import parse_trace
+from app.services.family_compilers import compile_family
+from app.services.animation_validator import AnimationValidator
+
+
+def _validated(animation):
+    assert animation is not None, "family scene must compile"
+    validated, reason = AnimationValidator().validate(animation)
+    assert validated is not None, f"family scene must validate: {reason}"
+    return validated
+
+
+def _ids_in(step):
+    ids = {shape["id"] for shape in step.get("shapes", [])}
+    ids.update(op["target"] for op in step.get("motion", []))
+    return ids
+
+
+def _all_ids(animation):
+    ids = set()
+    for step in animation["steps"]:
+        ids.update(_ids_in(step))
+    return ids
+
+
+class TestStackFamily:
+    def test_push_pop_trace_produces_valid_scene(self):
+        trace = parse_trace(
+            "\n".join(
+                [
+                    '{"event":"init","data":["(","(",")","]"],"family":"stack"}',
+                    '{"event":"push","value":"("}',
+                    '{"event":"push","value":"("}',
+                    '{"event":"pop","value":"("}',
+                    '{"event":"return","result":false}',
+                ]
+            )
+        )
+        animation = _validated(compile_family("stack", trace, title="Valid Parens"))
+        ids = _all_ids(animation)
+        assert "stack_box" in ids
+        assert any(sid.startswith("stack_item_") for sid in ids)
+        first = animation["steps"][0]
+        assert any(s["id"] == "stack_box" for s in first["shapes"])
+
+    def test_stack_push_appends_item_and_moves(self):
+        trace = parse_trace(
+            "\n".join(
+                [
+                    '{"event":"init","data":["(",")"],"family":"stack"}',
+                    '{"event":"push","value":"("}',
+                    '{"event":"return","result":true}',
+                ]
+            )
+        )
+        animation = _validated(compile_family("stack", trace))
+        push_step = next(
+            s
+            for s in animation["steps"]
+            if any(op["op"] == "move" for op in s["motion"])
+        )
+        targets = {op["target"] for op in push_step["motion"]}
+        assert any(sid.startswith("stack_item_") for sid in targets)
+
+
+class TestLinkedListFamily:
+    def test_reverse_trace_produces_valid_scene(self):
+        trace = parse_trace(
+            "\n".join(
+                [
+                    '{"event":"init","data":[1,2,3,4,5],"family":"linked_list"}',
+                    '{"event":"pointer","name":"prev","index":0}',
+                    '{"event":"visit","i":0}',
+                    '{"event":"pointer","name":"prev","index":1}',
+                    '{"event":"visit","i":1}',
+                    '{"event":"return","result":[5,4,3,2,1]}',
+                ]
+            )
+        )
+        animation = _validated(compile_family("linked_list", trace, title="Reverse"))
+        ids = _all_ids(animation)
+        for i in range(5):
+            assert f"node_{i}" in ids
+            assert f"val_{i}" in ids
+        assert "null_node" in ids
+        assert "ptr_prev" in ids
+        # Visit highlights a node.
+        visit_step = next(
+            s for s in animation["steps"][1:] if "Visiting" in s["narration"]
+        )
+        assert any(op["op"] == "fill" for op in visit_step["motion"])
+
+    def test_swap_crosses_node_labels(self):
+        trace = parse_trace(
+            "\n".join(
+                [
+                    '{"event":"init","data":[1,2],"family":"linked_list"}',
+                    '{"event":"swap","i":0,"j":1}',
+                    '{"event":"return","result":[2,1]}',
+                ]
+            )
+        )
+        animation = _validated(compile_family("linked_list", trace))
+        swap_step = next(
+            s for s in animation["steps"][1:] if "swap" in s["narration"].lower()
+        )
+        moves = {
+            op["target"]: op["to"] for op in swap_step["motion"] if op["op"] == "move"
+        }
+        assert "val_0" in moves and "val_1" in moves
+
+
+class TestTreeFamily:
+    def test_visit_trace_produces_valid_scene(self):
+        trace = parse_trace(
+            "\n".join(
+                [
+                    '{"event":"init","data":[3,9,20,null,null,15,7],"family":"tree"}',
+                    '{"event":"pointer","name":"current","index":0}',
+                    '{"event":"visit","i":0}',
+                    '{"event":"visit","i":2}',
+                    '{"event":"return","result":3}',
+                ]
+            )
+        )
+        animation = _validated(compile_family("tree", trace, title="Max Depth"))
+        ids = _all_ids(animation)
+        assert "node_0" in ids and "node_2" in ids
+        assert any(sid.startswith("tree_edge_") for sid in ids)
+        visit_step = next(
+            s for s in animation["steps"][1:] if "Visiting" in s["narration"]
+        )
+        assert any(op["op"] == "fill" for op in visit_step["motion"])
+
+
+class TestGridFamily:
+    def test_dp_update_trace_produces_valid_scene(self):
+        trace = parse_trace(
+            "\n".join(
+                [
+                    '{"event":"init","data":[[0,0],[0,0]],"family":"grid"}',
+                    '{"event":"dp_update","i":1,"j":1,"value":5}',
+                    '{"event":"return","result":5}',
+                ]
+            )
+        )
+        animation = _validated(compile_family("grid", trace, title="DP"))
+        ids = _all_ids(animation)
+        assert "cell_0_0" in ids and "cell_1_1" in ids
+        update_step = next(
+            s for s in animation["steps"][1:] if "becomes 5" in s["narration"]
+        )
+        assert any(op["op"] == "label" for op in update_step["motion"])
+
+    def test_visit_uses_row_col(self):
+        trace = parse_trace(
+            "\n".join(
+                [
+                    '{"event":"init","data":[["A","B"],["C","D"]],"family":"grid"}',
+                    '{"event":"visit","i":1,"j":0}',
+                    '{"event":"return","result":true}',
+                ]
+            )
+        )
+        animation = _validated(compile_family("grid", trace))
+        visit_step = next(
+            s for s in animation["steps"][1:] if "Visiting" in s["narration"]
+        )
+        targets = {op["target"] for op in visit_step["motion"]}
+        assert "cell_1_0" in targets
+
+
+class TestGraphFamily:
+    def test_visit_edge_trace_produces_valid_scene(self):
+        trace = parse_trace(
+            "\n".join(
+                [
+                    '{"event":"init","data":[[2,4],[1,3],[2,4],[1,3]],"family":"graph"}',
+                    '{"event":"visit","i":0}',
+                    '{"event":"edge","a":0,"b":1}',
+                    '{"event":"visit","i":1}',
+                    '{"event":"return","result":4}',
+                ]
+            )
+        )
+        animation = _validated(compile_family("graph", trace, title="Clone"))
+        ids = _all_ids(animation)
+        for i in range(4):
+            assert f"g_node_{i}" in ids
+        assert "ge_0_1" in ids
+        edge_step = next(
+            s for s in animation["steps"][1:] if "edge" in s["narration"].lower()
+        )
+        assert any(op["op"] == "stroke" for op in edge_step["motion"])
+
+    def test_edge_list_with_explicit_n_is_not_misread_as_adjacency(self):
+        # course_schedule emits data=prerequisites (edge list) + n=numCourses.
+        # When len(edges) == numCourses the old len(data) == n heuristic fell
+        # into the adjacency branch, dropping real edges (here 0-2).
+        trace = parse_trace(
+            "\n".join(
+                [
+                    '{"event":"init","data":[[0,1],[0,2],[2,1]],"family":"graph","n":3}',
+                    '{"event":"edge","a":0,"b":1}',
+                    '{"event":"edge","a":0,"b":2}',
+                    '{"event":"return","result":true}',
+                ]
+            )
+        )
+        animation = _validated(compile_family("graph", trace, title="Courses"))
+        ids = _all_ids(animation)
+        for pair in ("0_1", "0_2", "1_2"):
+            assert f"ge_{pair}" in ids, f"missing edge ge_{pair}"
+        edge_ids = [sid for sid in ids if sid.startswith("ge_")]
+        assert len(edge_ids) == 3
+
+
+class TestIntervalsFamily:
+    def test_merge_trace_produces_valid_scene(self):
+        trace = parse_trace(
+            "\n".join(
+                [
+                    '{"event":"init","data":[[1,3],[2,6],[8,10]],"family":"intervals"}',
+                    '{"event":"pointer","name":"i","index":0}',
+                    '{"event":"visit","i":0}',
+                    '{"event":"mark","i":0,"state":"merged"}',
+                    '{"event":"return","result":[[1,6],[8,10]]}',
+                ]
+            )
+        )
+        animation = _validated(
+            compile_family("intervals", trace, title="Merge Intervals")
+        )
+        ids = _all_ids(animation)
+        assert "bar_0" in ids and "bar_2" in ids
+        merged_step = next(
+            s for s in animation["steps"][1:] if "merged" in s["narration"]
+        )
+        assert any(op["op"] == "fill" for op in merged_step["motion"])
+
+
+class TestBacktrackFamily:
+    def test_choose_backtrack_trace_produces_valid_scene(self):
+        trace = parse_trace(
+            "\n".join(
+                [
+                    '{"event":"init","values":[1,2,3],"family":"backtrack"}',
+                    '{"event":"choose","i":0}',
+                    '{"event":"choose","i":1}',
+                    '{"event":"backtrack","i":1}',
+                    '{"event":"choose","i":2}',
+                    '{"event":"return","result":[[1,2],[1,3]]}',
+                ]
+            )
+        )
+        animation = _validated(compile_family("backtrack", trace, title="Subsets"))
+        ids = _all_ids(animation)
+        assert "cell_0" in ids and "cell_2" in ids
+        choose_step = next(
+            s for s in animation["steps"][1:] if "Choose" in s["narration"]
+        )
+        assert any(op["op"] == "fill" for op in choose_step["motion"])
+
+    def test_backtrack_resets_highlight(self):
+        trace = parse_trace(
+            "\n".join(
+                [
+                    '{"event":"init","values":[1,2],"family":"backtrack"}',
+                    '{"event":"choose","i":0}',
+                    '{"event":"backtrack","i":0}',
+                    '{"event":"return","result":[]}',
+                ]
+            )
+        )
+        animation = _validated(compile_family("backtrack", trace))
+        back_step = next(
+            s for s in animation["steps"][1:] if "Backtrack" in s["narration"]
+        )
+        fills = {op["to"] for op in back_step["motion"] if op["op"] == "fill"}
+        assert "#1e293b" in fills  # reset to idle
+
+
+class TestDispatch:
+    def test_unknown_family_returns_none(self):
+        assert compile_family("nope", [], title="x") is None
+
+    def test_missing_init_returns_none(self):
+        trace = parse_trace('{"event":"visit","i":0}')
+        assert compile_family("tree", trace, title="x") is None
+
+    def test_array_family_roundtrips_through_compile_family(self):
+        trace = parse_trace(
+            json.dumps(
+                [
+                    {"event": "init", "values": [5, 1]},
+                    {"event": "compare", "i": 0, "j": 1},
+                    {"event": "return", "result": [1, 5]},
+                ],
+                separators=(",", ":"),
+            )
+        )
+        animation = _validated(compile_family("array", trace, title="Bubble"))
+        assert animation["title"] == "Bubble"

--- a/backend/tests/unit/test_groq_service.py
+++ b/backend/tests/unit/test_groq_service.py
@@ -50,6 +50,67 @@ STRUCTURED_CONTENT = (
     '"explanation": null, "debug_help": null}'
 )
 
+STRUCTURED_CONTENT_WITH_ANIMATION = (
+    '{"summary": "Watch the search unfold", "hints": [], "code_review": null, '
+    '"complexity_analysis": null, "suggestions": [], "edge_cases": [], '
+    '"explanation": null, "debug_help": null, '
+    '"animation": {"title": "Searching for 4", '
+    '"data": {"values": [5, 1, 2, 3, 4, 6], "target": 4}, '
+    '"steps": [{"narration": "5 is not the target.", '
+    '"shapes": [{"id": "cell_0", "type": "rect", "x": -240, "y": 0, '
+    '"width": 88, "height": 88, "fill": "#1e293b"}], '
+    '"motion": [{"target": "cell_0", "op": "appear", "duration": 0.3}]}, '
+    '{"narration": "Moving on.", '
+    '"motion": [{"target": "cell_0", "op": "move", "to": [0, 0], '
+    '"duration": 0.3}]}, '
+    '{"narration": "Found 4!", '
+    '"shapes": [{"id": "ptr", "type": "polygon", "x": 0, "y": -80, '
+    '"points": [[-12, -30], [0, -60], [12, -30]], "fill": "#facc15"}], '
+    '"motion": [{"target": "ptr", "op": "appear", "duration": 0.3}, '
+    '{"target": "cell_0", "op": "fill", "to": "#22c55e", "duration": 0.3}]}]}}'
+)
+
+LEGACY_CACHED_ANIMATION = {
+    "summary": "cached legacy",
+    "hints": [],
+    "animation": {
+        "type": "linear_search",
+        "title": "Your code vs the solution",
+        "steps": [{"operation": "compare_code", "narration": "x"}],
+    },
+}
+
+VALID_CACHED_ANIMATION = {
+    "summary": "cached",
+    "hints": [],
+    "animation": {
+        "title": "Searching for 4",
+        "data": {"values": [5, 1, 2, 3, 4, 6], "target": 4},
+        "steps": [
+            {
+                "narration": "a",
+                "shapes": [
+                    {"id": "c", "type": "rect", "width": 10, "height": 10},
+                    {"id": "d", "type": "rect", "width": 10, "height": 10},
+                ],
+                "motion": [{"target": "c", "op": "appear", "duration": 0.3}],
+            },
+            {
+                "narration": "b",
+                "motion": [
+                    {"target": "c", "op": "move", "to": [10, 0], "duration": 0.3}
+                ],
+            },
+            {
+                "narration": "c",
+                "motion": [
+                    {"target": "d", "op": "fill", "to": "#22c55e", "duration": 0.3}
+                ],
+            },
+        ],
+    },
+}
+
 
 class TestGroqServiceInit:
     def test_init_with_api_key_arg(self):
@@ -83,6 +144,7 @@ class TestGroqServiceInit:
             assert service.models["medium"] == "llama-3.3-70b-versatile"
             assert service.models["hard"] == "llama-3.3-70b-versatile"
             assert service.models["stream"] == "llama-3.1-8b-instant"
+            assert service.models["animate"] == "llama-3.3-70b-versatile"
 
     def test_model_map_env_overrides(self):
         with patch.dict(
@@ -91,6 +153,7 @@ class TestGroqServiceInit:
                 "GROQ_API_KEY": "gsk_test",
                 "GROQ_MODEL_EASY": "custom-easy",
                 "GROQ_MODEL_MEDIUM": "custom-medium",
+                "GROQ_MODEL_ANIMATE": "custom-animate",
             },
         ):
             from app.services.groq_service import GroqService
@@ -99,6 +162,7 @@ class TestGroqServiceInit:
             assert service.models["easy"] == "custom-easy"
             assert service.models["medium"] == "custom-medium"
             assert service.models["hard"] == "llama-3.3-70b-versatile"
+            assert service.models["animate"] == "custom-animate"
 
 
 class TestGroqServiceStructured:
@@ -261,6 +325,86 @@ class TestGroqServiceStructured:
         assert result == cached
         mock_async_client.post.assert_not_called()
         assert recorder.calls == []
+
+    @pytest.mark.asyncio
+    async def test_animate_cache_hit_with_valid_animation_skips_api(
+        self, mock_async_client
+    ):
+        cache = FakeCache(cached_value=VALID_CACHED_ANIMATION)
+
+        from app.services.groq_service import GroqService
+
+        service = GroqService(api_key="gsk_test", cache=cache, user_id="u")
+        result = await service.get_structured_coaching_response(
+            problem="Find 4",
+            code="def s(): pass",
+            language="python",
+            message="animate",
+            mode="animate",
+            difficulty="easy",
+        )
+
+        mock_async_client.post.assert_not_called()
+        assert result["animation"]["title"] == "Searching for 4"
+
+    @pytest.mark.asyncio
+    async def test_animate_cache_hit_with_legacy_animation_regenerates(
+        self, mock_async_client
+    ):
+        body = {
+            "choices": [{"message": {"content": STRUCTURED_CONTENT_WITH_ANIMATION}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 8},
+        }
+        mock_async_client.post.return_value = self._make_response(200, body)
+        cache = FakeCache(cached_value=LEGACY_CACHED_ANIMATION)
+
+        from app.services.groq_service import GroqService
+
+        service = GroqService(api_key="gsk_test", cache=cache, user_id="u")
+        result = await service.get_structured_coaching_response(
+            problem="Find 4",
+            code="def s(): pass",
+            language="python",
+            message="animate",
+            mode="animate",
+            difficulty="easy",
+        )
+
+        mock_async_client.post.assert_called_once()
+        assert result["animation"]["title"] == "Searching for 4"
+        assert result["animation"]["steps"][0]["shapes"][0]["id"] == "cell_0"
+
+    @pytest.mark.asyncio
+    async def test_animate_cache_key_includes_content_version_v6(
+        self, mock_async_client
+    ):
+        body = {
+            "choices": [{"message": {"content": STRUCTURED_CONTENT_WITH_ANIMATION}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 8},
+        }
+        mock_async_client.post.return_value = self._make_response(200, body)
+        cache = FakeCache()
+
+        from app.services.groq_service import GroqService
+        from app.services.groq_service import _jsonable
+        from app.services.redis_service import RedisCache, _content_hash
+
+        service = GroqService(api_key="gsk_test", cache=cache, user_id="u")
+        await service.get_structured_coaching_response(
+            problem="P",
+            code="c",
+            language="python",
+            message="animate",
+            mode="animate",
+            difficulty="medium",
+        )
+
+        expected_hash = _content_hash(
+            "P", "c", "animate", "animate", "medium", "", "", _jsonable(None), "v6"
+        )
+        assert cache.set_calls[0][0] == RedisCache.key(
+            "groq", "coaching", expected_hash
+        )
 
     @pytest.mark.asyncio
     async def test_structured_401_maps_to_500(self, mock_async_client):
@@ -800,3 +944,175 @@ class TestGroqServiceStreaming:
         assert chunks == ["hi"]
         assert recorder.calls[0]["input_tokens"] == 2
         assert recorder.calls[0]["output_tokens"] == 6
+
+
+class TestGroqServiceAnimateScript:
+    """get_animation_script returns only the validated animation, no chat text."""
+
+    @pytest.fixture
+    def mock_async_client(self):
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_cls.return_value = mock_instance
+            yield mock_instance
+
+    def _make_response(self, status_code=200, body=None):
+        mock_response = MagicMock()
+        mock_response.status_code = status_code
+        mock_response.text = "error body"
+        mock_response.headers = {"retry-after": "5"}
+        if body is not None:
+            mock_response.json.return_value = body
+        return mock_response
+
+    @pytest.mark.asyncio
+    async def test_returns_valid_animation_script(self, mock_async_client):
+        body = {
+            "choices": [{"message": {"content": STRUCTURED_CONTENT_WITH_ANIMATION}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 8},
+        }
+        mock_async_client.post.return_value = self._make_response(200, body)
+
+        from app.services.groq_service import GroqService
+
+        service = GroqService(api_key="gsk_test", user_id="u")
+        result = await service.get_animation_script(
+            problem="Find 4",
+            code="def s(): pass",
+            language="python",
+        )
+
+        assert result is not None
+        assert result["title"] == "Searching for 4"
+        assert result["data"]["target"] == 4
+        assert len(result["steps"]) == 3
+        assert result["steps"][0]["shapes"][0]["id"] == "cell_0"
+        # Never leaks chat text
+        assert "summary" not in result
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_model_omits_animation(self, mock_async_client):
+        body = {
+            "choices": [{"message": {"content": STRUCTURED_CONTENT}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 8},
+        }
+        mock_async_client.post.return_value = self._make_response(200, body)
+
+        from app.services.groq_service import GroqService
+
+        service = GroqService(api_key="gsk_test", user_id="u")
+        result = await service.get_animation_script(
+            problem="Find 4",
+            code="def s(): pass",
+            language="python",
+        )
+
+        assert result is None
+        # The Animate endpoint must not burn a second Groq call on a retry.
+        assert mock_async_client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_animation_invalid(self, mock_async_client):
+        invalid = (
+            '{"summary": "x", "hints": [], "code_review": null, '
+            '"complexity_analysis": null, "suggestions": [], "edge_cases": [], '
+            '"explanation": null, "debug_help": null, '
+            '"animation": {"title": "broken", "data": {}, "steps": []}}'
+        )
+        body = {
+            "choices": [{"message": {"content": invalid}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 8},
+        }
+        mock_async_client.post.return_value = self._make_response(200, body)
+
+        from app.services.groq_service import GroqService
+
+        service = GroqService(api_key="gsk_test", user_id="u")
+        result = await service.get_animation_script(
+            problem="Find 2",
+            code="def s(): pass",
+            language="python",
+        )
+
+        assert result is None
+        assert mock_async_client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_retry_when_first_animation_attempt_omits_animation(
+        self, mock_async_client
+    ):
+        no_anim = {
+            "choices": [{"message": {"content": STRUCTURED_CONTENT}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 8},
+        }
+        with_anim = {
+            "choices": [{"message": {"content": STRUCTURED_CONTENT_WITH_ANIMATION}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 8},
+        }
+        # A second response exists only to prove the endpoint does not retry.
+        mock_async_client.post.side_effect = [
+            self._make_response(200, no_anim),
+            self._make_response(200, with_anim),
+        ]
+
+        from app.services.groq_service import GroqService
+
+        service = GroqService(api_key="gsk_test", user_id="u")
+        result = await service.get_animation_script(
+            problem="Find 4",
+            code="def s(): pass",
+            language="python",
+        )
+
+        assert result is None
+        assert mock_async_client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_animate_uses_dedicated_animation_model(self, mock_async_client):
+        body = {
+            "choices": [{"message": {"content": STRUCTURED_CONTENT_WITH_ANIMATION}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 8},
+        }
+        mock_async_client.post.return_value = self._make_response(200, body)
+
+        from app.services.groq_service import GroqService
+
+        service = GroqService(
+            api_key="gsk_test", usage_recorder=FakeRecorder(), user_id="u"
+        )
+        await service.get_animation_script(
+            problem="Find 4",
+            code="def s(): pass",
+            language="python",
+            difficulty="easy",
+        )
+
+        call = mock_async_client.post.call_args
+        # Animate needs a capable model regardless of problem difficulty; it
+        # must never fall back to the fast 8b model.
+        assert call.kwargs["json"]["model"] == "llama-3.3-70b-versatile"
+
+    @pytest.mark.asyncio
+    async def test_animate_payload_uses_raised_max_completion_tokens(
+        self, mock_async_client
+    ):
+        body = {
+            "choices": [{"message": {"content": STRUCTURED_CONTENT_WITH_ANIMATION}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 8},
+        }
+        mock_async_client.post.return_value = self._make_response(200, body)
+
+        from app.services.groq_service import GroqService
+
+        service = GroqService(api_key="gsk_test", user_id="u")
+        await service.get_animation_script(
+            problem="Find 4",
+            code="def s(): pass",
+            language="python",
+        )
+
+        payload = mock_async_client.post.call_args.kwargs["json"]
+        # code_comparison JSON is long; 1000 tokens truncates it into a
+        # brace-repaired response with no usable animation.
+        assert payload["max_completion_tokens"] == 2000

--- a/backend/tests/unit/test_question_catalog.py
+++ b/backend/tests/unit/test_question_catalog.py
@@ -1,0 +1,63 @@
+"""Unit tests for the exact question-id → algorithm taxonomy."""
+
+from app.services.question_catalog import QUESTION_ALGORITHMS, resolve_by_id
+from app.services.reference_solutions import REFERENCE_SOLUTIONS
+from app.services.reference_solutions import resolve_algorithm
+
+
+class TestQuestionCatalog:
+    def test_inventory_has_expected_size(self):
+        assert len(QUESTION_ALGORITHMS) == 100
+
+    def test_every_question_maps_to_a_known_algorithm(self):
+        for qid, algo in QUESTION_ALGORITHMS.items():
+            assert algo in REFERENCE_SOLUTIONS, f"{qid} -> unknown {algo}"
+
+    def test_every_algorithm_has_its_own_signature(self):
+        # Each algorithm is distinct; two questions can share one algorithm but
+        # every algorithm key must be unique in the catalog.
+        assert len(set(QUESTION_ALGORITHMS.values())) >= 75
+
+    def test_all_families_are_represented(self):
+        families = {
+            REFERENCE_SOLUTIONS[a]["family"] for a in QUESTION_ALGORITHMS.values()
+        }
+        for expected in (
+            "array",
+            "stack",
+            "linked_list",
+            "tree",
+            "grid",
+            "graph",
+            "intervals",
+            "backtrack",
+        ):
+            assert expected in families, f"family {expected} has no questions"
+
+    def test_resolve_by_id(self):
+        assert resolve_by_id({"id": "two-sum"}) == "two_sum"
+        assert resolve_by_id({"id": "koko-eating-bananas"}) == "koko_eating_bananas"
+        assert resolve_by_id({"id": "unknown-thing"}) is None
+        assert resolve_by_id(None) is None
+        assert resolve_by_id({"title": "Two Sum"}) is None
+
+    def test_resolve_algorithm_prefers_id_over_keywords(self):
+        # koko is in the Binary Search category: id must win over category scan.
+        q = {
+            "id": "koko-eating-bananas",
+            "title": "Koko Eating Bananas",
+            "category": "Binary Search",
+            "description": "There are n piles of bananas...",
+        }
+        assert resolve_algorithm(q) == "koko_eating_bananas"
+
+    def test_categories_no_longer_over_match(self):
+        # A question whose id is unknown but title/category are generic must not
+        # be silently mis-mapped; keyword fallback still applies.
+        q = {
+            "id": "zzz-unknown",
+            "title": "Array warm-up",
+            "category": "Binary Search",
+            "description": "Sort the values then check the median.",
+        }
+        assert resolve_algorithm(q) == "binary_search"

--- a/backend/tests/unit/test_reference_solutions.py
+++ b/backend/tests/unit/test_reference_solutions.py
@@ -1,0 +1,170 @@
+"""Unit tests for the curated reference-solution catalog and the resolver."""
+
+from app.services.reference_solutions import (
+    REFERENCE_SOLUTIONS,
+    FAMILIES,
+    get_reference_solution,
+    resolve_algorithm,
+)
+
+
+def _question(title="", category="", description="", qid=None):
+    return {
+        "id": qid,
+        "title": title,
+        "category": category,
+        "description": description,
+        "examples": [{"input": "[5,1,4,2,8]", "output": "[1,2,4,5,8]"}],
+    }
+
+
+class TestResolveAlgorithm:
+    def test_exact_question_id_takes_precedence(self):
+        # "binary-search" id must win even though the category says binary search.
+        q = _question(
+            qid="koko-eating-bananas",
+            title="Koko Eating Bananas",
+            category="Binary Search",
+        )
+        assert resolve_algorithm(q) == "koko_eating_bananas"
+
+    def test_matches_by_title(self):
+        assert resolve_algorithm(_question(title="Bubble Sort")) == "bubble_sort"
+
+    def test_matches_by_description(self):
+        assert (
+            resolve_algorithm(_question(description="Solve Two Sum efficiently"))
+            == "two_sum"
+        )
+
+    def test_case_insensitive(self):
+        assert resolve_algorithm(_question(title="bubble sort")) == "bubble_sort"
+
+    def test_category_no_longer_over_matches(self):
+        # A category-only "Binary Search" question without a known id and no
+        # binary-search keywords elsewhere must not resolve to plain binary_search.
+        assert (
+            resolve_algorithm(_question(category="Binary Search", title="Weird"))
+            == "binary_search"
+        )
+
+    def test_unknown_returns_none(self):
+        assert resolve_algorithm(_question(title="Weird made-up problem")) is None
+
+    def test_non_dict_question_returns_none(self):
+        assert resolve_algorithm(None) is None
+        assert resolve_algorithm("not a dict") is None
+
+
+class TestReferenceSolutions:
+    def test_catalog_is_large_enough_for_inventory(self):
+        assert len(REFERENCE_SOLUTIONS) >= 80
+
+    def test_every_entry_has_required_fields(self):
+        for algo, entry in REFERENCE_SOLUTIONS.items():
+            assert entry["family"] in FAMILIES, f"{algo} bad family"
+            assert entry["function"], f"{algo} needs function"
+            assert entry["signature"], f"{algo} needs signature"
+            assert entry["primary"], f"{algo} needs primary"
+            assert entry["match_keys"], f"{algo} needs match_keys"
+            assert f"def {entry['function']}(" in entry["code"], (
+                f"{algo} must define its function"
+            )
+            assert "__trace(" in entry["code"], f"{algo} must be traced"
+            assert '__trace("init"' in entry["code"], f"{algo} must emit its own init"
+
+    def test_every_signature_param_is_used_by_name(self):
+        for algo, entry in REFERENCE_SOLUTIONS.items():
+            fn = entry["function"]
+            sig = entry["signature"]
+            for param in sig:
+                assert f"def {fn}(" in entry["code"]
+                assert param in entry["code"], f"{algo} signature param {param} unused"
+
+    def test_get_reference_solution(self):
+        entry = get_reference_solution("bubble_sort")
+        assert entry["function"] == "bubble_sort"
+        assert get_reference_solution("nope") is None
+
+    def test_bubble_sort_is_traced_and_optimal(self):
+        entry = get_reference_solution("bubble_sort")
+        code = entry["code"]
+        assert "for j in range(n - i - 1)" in code
+        assert '__trace("compare"' in code
+        assert '__trace("swap"' in code
+        assert '__trace("mark"' in code
+
+    def test_every_catalog_function_runs_on_a_small_input(self):
+        """Smoke-run representative canonical solutions locally per family."""
+        import io
+        import json
+        import sys
+
+        from app.services.trace_instrumenter import wrap_traced_solution
+        from app.services.trace_parser import parse_trace
+
+        samples = {
+            "bubble_sort": {"values": [5, 1, 4, 2, 8]},
+            "binary_search": {"nums": [1, 3, 5, 7, 9], "target": 7},
+            "two_sum": {"nums": [2, 7, 11, 15], "target": 9},
+            "contains_duplicate": {"nums": [1, 2, 3, 1]},
+            "climbing_stairs": {"n": 5},
+            "valid_parentheses": {"s": "(()))"},
+            "reverse_linked_list": {"head": [1, 2, 3]},
+            "maximum_depth_of_binary_tree": {"root": [3, 9, 20, None, None, 15, 7]},
+            "rotate_image": {"matrix": [[1, 2], [3, 4]]},
+            "clone_graph": {"adj": [[2], [1]]},
+            "merge_intervals": {"intervals": [[1, 3], [2, 6]]},
+            "subsets": {"nums": [1, 2]},
+            "valid_palindrome": {"s": "A man, a plan"},
+            "number_of_1_bits": {"n": "1011"},
+        }
+        for algo, sample in samples.items():
+            entry = REFERENCE_SOLUTIONS[algo]
+            code = wrap_traced_solution(entry["code"], entry["function"])
+            old_stdin, old_stdout = sys.stdin, sys.stdout
+            buf = io.StringIO()
+            try:
+                sys.stdin = io.StringIO(json.dumps(sample))
+                sys.stdout = buf
+                exec(compile(code, "<wrapped>", "exec"), {})
+            finally:
+                sys.stdin, sys.stdout = old_stdin, old_stdout
+            events = parse_trace(buf.getvalue())
+            assert events, f"{algo} produced no events"
+            assert events[0].kind == "init", f"{algo} missing init"
+            assert events[-1].kind == "return", f"{algo} missing return"
+
+
+class TestMaximumDepthOfBinaryTree:
+    def _depth_of(self, root):
+        import io
+        import json
+        import sys
+
+        from app.services.trace_instrumenter import wrap_traced_solution
+        from app.services.trace_parser import parse_trace
+
+        entry = REFERENCE_SOLUTIONS["maximum_depth_of_binary_tree"]
+        code = wrap_traced_solution(entry["code"], entry["function"])
+        old_stdin, old_stdout = sys.stdin, sys.stdout
+        buf = io.StringIO()
+        try:
+            sys.stdin = io.StringIO(json.dumps({"root": root}))
+            sys.stdout = buf
+            exec(compile(code, "<wrapped>", "exec"), {})
+        finally:
+            sys.stdin, sys.stdout = old_stdin, old_stdout
+        events = parse_trace(buf.getvalue())
+        return events[-1].result
+
+    def test_single_node_tree_depth_is_one(self):
+        assert self._depth_of([3]) == 1
+
+    def test_depth_counts_levels_from_root(self):
+        # indices 0,1,2,5,6 → depths 1,2,2,3,3
+        assert self._depth_of([3, 9, 20, None, None, 15, 7]) == 3
+
+    def test_depth_of_leftmost_leaf_at_index_7(self):
+        # index 7 is depth 4; i.bit_length()=3 would undercount it.
+        assert self._depth_of([3, 9, 20, 15, 7, 15, 7, 1]) == 4

--- a/backend/tests/unit/test_schemas.py
+++ b/backend/tests/unit/test_schemas.py
@@ -1,0 +1,163 @@
+"""Unit tests for the generic scene animation schema + question input."""
+
+from app.models.schemas import (
+    AnimateRequest,
+    AnimationScript,
+    AnimationStep,
+    MotionOp,
+    QuestionInput,
+    SceneShape,
+)
+
+
+class TestSceneShape:
+    def test_rect_shape_round_trips(self):
+        shape = SceneShape(
+            id="cell_0",
+            type="rect",
+            x=-240,
+            y=0,
+            width=88,
+            height=88,
+            radius=12,
+            fill="#1e293b",
+            stroke="#334155",
+        )
+        assert shape.id == "cell_0"
+        assert shape.type == "rect"
+        assert shape.width == 88
+
+    def test_text_shape_round_trips(self):
+        shape = SceneShape(
+            id="label",
+            type="text",
+            x=0,
+            y=200,
+            text="Two Sum",
+            fontSize=28,
+            fill="#e2e8f0",
+        )
+        assert shape.text == "Two Sum"
+        assert shape.fontSize == 28
+
+    def test_polygon_points_round_trips(self):
+        shape = SceneShape(
+            id="ptr",
+            type="polygon",
+            x=-240,
+            y=-80,
+            points=[[-12, -30], [0, -60], [12, -30]],
+            fill="#facc15",
+        )
+        assert shape.points == [[-12, -30], [0, -60], [12, -30]]
+
+    def test_opacity_is_bounded(self):
+        SceneShape(id="a", type="rect", x=0, y=0, width=10, height=10, opacity=0.5)
+
+    def test_invalid_color_rejected(self):
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            SceneShape(id="a", type="rect", x=0, y=0, width=10, height=10, fill="red")
+
+
+class TestMotionOp:
+    def test_move_op_round_trips(self):
+        op = MotionOp(target="cell_0", op="move", to=[120, -80], duration=0.35)
+        assert op.op == "move"
+        assert op.to == [120, -80]
+
+    def test_duration_defaults(self):
+        op = MotionOp(target="cell_0", op="appear")
+        assert op.duration == 0.3
+
+
+class TestAnimationStep:
+    def test_shapes_and_motion_round_trip(self):
+        step = AnimationStep(
+            narration="Need 7 to reach 9.",
+            shapes=[
+                SceneShape(
+                    id="cell_0",
+                    type="rect",
+                    x=-240,
+                    y=0,
+                    width=88,
+                    height=88,
+                    fill="#1e293b",
+                )
+            ],
+            motion=[MotionOp(target="cell_0", op="appear")],
+        )
+        assert len(step.shapes) == 1
+        assert len(step.motion) == 1
+        assert step.shapes[0].id == "cell_0"
+
+    def test_defaults_are_empty(self):
+        step = AnimationStep(narration="x")
+        assert step.shapes == []
+        assert step.motion == []
+
+
+class TestAnimationScript:
+    def test_generic_scene_round_trips(self):
+        script = AnimationScript(
+            title="Two Sum",
+            data={"values": [2, 7], "target": 9},
+            steps=[AnimationStep(narration="start")],
+        )
+        assert script.title == "Two Sum"
+        assert len(script.steps) == 1
+        assert "steps" in script.model_dump()
+
+    def test_defaults(self):
+        script = AnimationScript()
+        assert script.title == ""
+        assert script.data == {}
+        assert script.steps == []
+
+    def test_old_typed_fields_are_ignored_gracefully(self):
+        step = AnimationStep(operation="compare", index=0)
+        assert step.shapes == []
+        assert step.motion == []
+        assert not hasattr(step, "operation")
+
+
+class TestQuestionInput:
+    def test_curated_subset_round_trips(self):
+        q = QuestionInput(
+            title="Two Sum",
+            description="Find two numbers that add up to target.",
+            category="hash_map",
+            difficulty="medium",
+            examples=[{"input": "[2,7,11,15], 9", "output": "[0,1]"}],
+            test_cases=[{"input": "[3,3], 6", "output": "[0,1]"}],
+            constraints=["1 <= n <= 1000"],
+            starter={"python": "def two_sum(nums, target): pass"},
+        )
+        assert q.title == "Two Sum"
+        assert q.starter["python"].startswith("def two_sum")
+
+    def test_defaults(self):
+        q = QuestionInput()
+        assert q.examples == []
+        assert q.test_cases == []
+        assert q.constraints == []
+        assert q.starter is None
+
+
+class TestAnimateRequest:
+    def test_question_is_optional(self):
+        req = AnimateRequest(problem="P", code="c", language="python")
+        assert req.question is None
+
+    def test_question_is_accepted(self):
+        req = AnimateRequest(
+            problem="P",
+            code="c",
+            language="python",
+            question=QuestionInput(title="Two Sum"),
+        )
+        assert req.question is not None
+        assert req.question.title == "Two Sum"

--- a/backend/tests/unit/test_solution_animation_service.py
+++ b/backend/tests/unit/test_solution_animation_service.py
@@ -1,0 +1,192 @@
+"""Unit tests for SolutionAnimationService — orchestrates the
+canonical-optimal-solution → trace → scene pipeline.
+
+The executor is a double: no Piston is touched in these tests. The service
+must ignore the user's typed code entirely (it only reads the question) and
+return None on any unusable input so the endpoint can degrade gracefully.
+"""
+
+import json
+
+import pytest
+from fastapi import HTTPException
+
+from app.ports.code_executor import ExecutionResult
+from app.services.solution_animation_service import SolutionAnimationService
+from app.services.animation_validator import AnimationValidator
+
+BUBBLE_STDOUT = "\n".join(
+    [
+        '{"event":"init","values":[5,1,4,2,8],"family":"array"}',
+        '{"event":"pointer","name":"j","index":0}',
+        '{"event":"compare","i":0,"j":1}',
+        '{"event":"swap","i":0,"j":1}',
+        '{"event":"pointer","name":"j","index":1}',
+        '{"event":"compare","i":1,"j":2}',
+        '{"event":"swap","i":1,"j":2}',
+        '{"event":"mark","i":4,"state":"sorted"}',
+        '{"event":"return","result":[1,2,4,5,8]}',
+    ]
+)
+
+
+class FakeExecutor:
+    def __init__(self, result: ExecutionResult):
+        self.result = result
+        self.calls = []
+
+    async def execute(self, language, code, stdin="", version=None):
+        self.calls.append({"language": language, "code": code, "stdin": stdin})
+        return self.result
+
+
+_MISSING = object()
+
+
+def _question(
+    title="Bubble Sort",
+    examples=_MISSING,
+    description="Sort the array using bubble sort.",
+    qid=None,
+):
+    return {
+        "id": qid,
+        "title": title,
+        "category": "sorting",
+        "description": description,
+        "examples": (
+            [{"input": "[5,1,4,2,8]", "output": "[1,2,4,5,8]"}]
+            if examples is _MISSING
+            else examples
+        ),
+    }
+
+
+def _ok_result(stdout=BUBBLE_STDOUT):
+    return ExecutionResult(stdout=stdout, stderr="", exit_code=0)
+
+
+class TestBuildAnimation:
+    @pytest.mark.asyncio
+    async def test_bubble_sort_question_produces_valid_scene(self):
+        executor = FakeExecutor(_ok_result())
+        service = SolutionAnimationService(executor=executor)
+        animation = await service.build_animation(_question())
+
+        assert animation is not None
+        validated, reason = AnimationValidator().validate(animation)
+        assert validated is not None, reason
+        assert animation["title"] == "Bubble Sort"
+        assert animation["data"]["values"] == [5, 1, 4, 2, 8]
+        # The user's code is never involved: only the canonical solution runs.
+        assert executor.calls[0]["code"].count("def bubble_sort") == 1
+        assert "def bubble_sort" in executor.calls[0]["code"]
+        assert "sys.stdin" in executor.calls[0]["code"]
+        assert json.loads(executor.calls[0]["stdin"]) == {"values": [5, 1, 4, 2, 8]}
+
+    @pytest.mark.asyncio
+    async def test_exit_code_nonzero_returns_none(self):
+        executor = FakeExecutor(ExecutionResult(stdout="", stderr="boom", exit_code=1))
+        service = SolutionAnimationService(executor=executor)
+        assert await service.build_animation(_question()) is None
+
+    @pytest.mark.asyncio
+    async def test_no_question_returns_none(self):
+        service = SolutionAnimationService(FakeExecutor(_ok_result()))
+        assert await service.build_animation(None) is None
+        assert await service.build_animation("nope") is None
+
+    @pytest.mark.asyncio
+    async def test_no_matching_algorithm_returns_none(self):
+        executor = FakeExecutor(_ok_result())
+        service = SolutionAnimationService(executor=executor)
+        q = _question(
+            title="Invented challenge", description="No known algorithm here."
+        )
+        assert await service.build_animation(q) is None
+        assert executor.calls == []  # nothing ran
+
+    @pytest.mark.asyncio
+    async def test_missing_examples_returns_none(self):
+        service = SolutionAnimationService(FakeExecutor(_ok_result()))
+        assert await service.build_animation(_question(examples=[])) is None
+        assert await service.build_animation(_question(examples=None)) is None
+
+    @pytest.mark.asyncio
+    async def test_example_input_object_is_serialized(self):
+        executor = FakeExecutor(_ok_result())
+        service = SolutionAnimationService(executor=executor)
+        q = _question(examples=[{"input": {"values": [5, 1, 4, 2, 8]}, "output": "x"}])
+        await service.build_animation(q)
+        parsed = json.loads(executor.calls[0]["stdin"])
+        assert parsed == {"values": [5, 1, 4, 2, 8]}
+
+    @pytest.mark.asyncio
+    async def test_kwargs_assignment_input_is_parsed(self):
+        executor = FakeExecutor(_ok_result())
+        service = SolutionAnimationService(executor=executor)
+        q = _question(
+            examples=[{"input": "nums = [5,1,4,2,8], target = 3", "output": "x"}]
+        )
+        await service.build_animation(q)
+        parsed = json.loads(executor.calls[0]["stdin"])
+        assert parsed == {"nums": [5, 1, 4, 2, 8], "target": 3}
+
+    @pytest.mark.asyncio
+    async def test_executor_error_returns_none(self):
+        class RaisingExecutor(FakeExecutor):
+            async def execute(self, *a, **k):
+                raise HTTPException(status_code=500)
+
+        service = SolutionAnimationService(RaisingExecutor(_ok_result()))
+        assert await service.build_animation(_question()) is None
+
+    @pytest.mark.asyncio
+    async def test_empty_trace_returns_none(self):
+        executor = FakeExecutor(_ok_result(stdout=""))
+        service = SolutionAnimationService(executor=executor)
+        assert await service.build_animation(_question()) is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_known_event_returns_none_not_raise(self):
+        # A known event kind missing a required field makes parse_trace raise
+        # ValueError; build_animation must degrade to None (no 500, no LLM
+        # fallback triggered by a curated-solution typo).
+        bad_stdout = '{"event":"swap","i":0}'  # j missing
+        executor = FakeExecutor(_ok_result(stdout=bad_stdout))
+        service = SolutionAnimationService(executor=executor)
+        assert await service.build_animation(_question()) is None
+
+    @pytest.mark.asyncio
+    async def test_title_falls_back_to_algorithm_name(self):
+        executor = FakeExecutor(_ok_result())
+        service = SolutionAnimationService(executor=executor)
+        q = _question(title="")
+        animation = await service.build_animation(q)
+        assert animation["title"]  # non-empty fallback
+
+    @pytest.mark.asyncio
+    async def test_stack_family_question_dispatches_to_stack_compiler(self):
+        stdout = "\n".join(
+            [
+                '{"event":"init","data":["(",")"],"family":"stack"}',
+                '{"event":"push","value":"("}',
+                '{"event":"return","result":true}',
+            ]
+        )
+        executor = FakeExecutor(_ok_result(stdout=stdout))
+        service = SolutionAnimationService(executor=executor)
+        q = {
+            "id": "valid-parentheses",
+            "title": "Valid Parentheses",
+            "category": "Stack & Queue",
+            "description": "Determine if the input string is valid.",
+            "examples": [{"input": 's = "()"', "output": "true"}],
+        }
+        animation = await service.build_animation(q)
+        assert animation is not None
+        validated, reason = AnimationValidator().validate(animation)
+        assert validated is not None, reason
+        assert "stack_box" in {
+            op["target"] for step in animation["steps"] for op in step["motion"]
+        }

--- a/backend/tests/unit/test_trace_instrumenter.py
+++ b/backend/tests/unit/test_trace_instrumenter.py
@@ -1,0 +1,144 @@
+"""Unit tests for the traced-solution wrapper (trace_instrumenter).
+
+The wrapper injects the __trace emitter and a stdin-driven main that parses
+the example input (a JSON kwargs dict) and invokes the canonical solution,
+producing the JSON-array trace the parser + compiler consume. The canonical
+solution emits its own ``init`` event.
+
+These tests exec the wrapped code for real so the full
+solution→trace→parse chain is validated without Piston.
+"""
+
+import io
+import sys
+import json
+
+from app.services.trace_instrumenter import wrap_traced_solution
+from app.services.trace_parser import parse_trace
+
+BUBBLE_SORT = """\
+def bubble_sort(values):
+    __trace("init", values=list(values), family="array")
+    n = len(values)
+    for i in range(n - 1):
+        for j in range(n - i - 1):
+            __trace("pointer", name="j", index=j)
+            __trace("compare", i=j, j=j + 1)
+            if values[j] > values[j + 1]:
+                values[j], values[j + 1] = values[j + 1], values[j]
+                __trace("swap", i=j, j=j + 1)
+        __trace("mark", i=n - i - 1, state="sorted")
+    return values
+"""
+
+LINEAR_SEARCH = """\
+def linear_search(values, target):
+    __trace("init", values=list(values), family="array")
+    for i, v in enumerate(values):
+        __trace("pointer", name="i", index=i)
+        __trace("compare", i=i)
+        if v == target:
+            __trace("mark", i=i, state="match")
+            return i
+    return -1
+"""
+
+TREE_DEPTH = """\
+def max_depth(root):
+    __trace("init", data=list(root), family="tree")
+    best = 0
+    for i, v in enumerate(root):
+        if v is not None:
+            __trace("visit", i=i)
+            best = max(best, i.bit_length())
+    return best
+"""
+
+GRAPH_TRAVERSAL = """\
+def count_nodes(adj, n):
+    __trace("init", data=adj, family="graph", n=n)
+    total = 0
+    for i in range(n):
+        __trace("visit", i=i)
+        for b in adj[i]:
+            __trace("edge", a=i, b=b)
+        total += 1
+    return total
+"""
+
+
+def _run(code: str, stdin: str) -> str:
+    old_stdin, old_stdout = sys.stdin, sys.stdout
+    buf = io.StringIO()
+    try:
+        sys.stdin = io.StringIO(stdin)
+        sys.stdout = buf
+        exec(compile(code, "<wrapped>", "exec"), {})
+    finally:
+        sys.stdin, sys.stdout = old_stdin, old_stdout
+    return buf.getvalue()
+
+
+class TestWrapTracedSolution:
+    def test_array_style_bubble_sort_trace(self):
+        code = wrap_traced_solution(BUBBLE_SORT, "bubble_sort")
+        events = parse_trace(_run(code, json.dumps({"values": [5, 1, 4, 2, 8]})))
+        kinds = [e.kind for e in events]
+        assert kinds[0] == "init"
+        assert kinds[-1] == "return"
+        assert "compare" in kinds
+        assert "swap" in kinds
+        assert "mark" in kinds
+        init = events[0]
+        assert init.fields["values"] == [5, 1, 4, 2, 8]
+        assert init.fields["family"] == "array"
+        result = events[-1].fields["result"]
+        assert result == [1, 2, 4, 5, 8]
+
+    def test_kwargs_style_linear_search_trace(self):
+        code = wrap_traced_solution(LINEAR_SEARCH, "linear_search")
+        stdin = json.dumps({"values": [4, 2, 7, 1], "target": 7})
+        events = parse_trace(_run(code, stdin))
+        kinds = [e.kind for e in events]
+        assert kinds[0] == "init"
+        assert events[0].fields["values"] == [4, 2, 7, 1]
+        assert "compare" in kinds
+        match = next(e for e in events if e.kind == "mark")
+        assert match.state == "match"
+        assert events[-1].kind == "return"
+
+    def test_non_dict_stdin_is_wrapped_as_value(self):
+        echo = 'def echo(value):\n    __trace("init", values=list(value), family="array")\n    return value\n'
+        code = wrap_traced_solution(echo, "echo")
+        events = parse_trace(_run(code, "[5,1,4,2,8]"))
+        assert events[0].kind == "init"
+        assert events[0].fields["values"] == [5, 1, 4, 2, 8]
+        assert events[-1].fields["result"] == [5, 1, 4, 2, 8]
+
+    def test_tree_family_init_carries_data(self):
+        code = wrap_traced_solution(TREE_DEPTH, "max_depth")
+        events = parse_trace(
+            _run(
+                code,
+                json.dumps({"root": [3, 9, 20, None, None, 15, 7]}),
+            )
+        )
+        assert events[0].fields["family"] == "tree"
+        assert events[0].fields["data"] == [3, 9, 20, None, None, 15, 7]
+
+    def test_graph_family_init_carries_vertex_count(self):
+        code = wrap_traced_solution(GRAPH_TRAVERSAL, "count_nodes")
+        events = parse_trace(
+            _run(
+                code,
+                json.dumps({"adj": [[1], [0], [1]], "n": 3}),
+            )
+        )
+        assert events[0].fields["family"] == "graph"
+        assert events[0].fields["n"] == 3
+
+    def test_wrapper_contains_helper_and_function(self):
+        code = wrap_traced_solution(BUBBLE_SORT, "bubble_sort")
+        assert "def __trace" in code
+        assert "def bubble_sort" in code
+        assert "__TRACE" in code

--- a/backend/tests/unit/test_trace_parser.py
+++ b/backend/tests/unit/test_trace_parser.py
@@ -1,0 +1,202 @@
+"""Unit tests for trace parsing — the JSON-lines execution trace from the
+traced canonical solution is normalized into typed animation events.
+
+The traced solution prints one JSON object per line with an "event" key
+(init/compare/swap/pointer/mark/write/return). The parser must ignore stray
+non-JSON output lines (e.g. a solution that also prints) and reject events
+that are structurally malformed.
+"""
+
+import pytest
+
+from app.services.trace_parser import parse_trace, TraceEvent
+
+
+def _line(event, **fields):
+    import json
+
+    payload = {"event": event, **fields}
+    return json.dumps(payload, separators=(",", ":"))
+
+
+class TestParseTrace:
+    def test_parses_structured_family_events(self):
+        stdout = "\n".join(
+            [
+                _line("init", data=[3, 2, 1], family="linked_list"),
+                _line("visit", i=0),
+                _line("pointer", name="fast", index=0),
+                _line("visit", i=2),
+                _line("return", result=[1, 2, 3]),
+            ]
+        )
+        events = parse_trace(stdout)
+        assert [e.kind for e in events] == [
+            "init",
+            "visit",
+            "pointer",
+            "visit",
+            "return",
+        ]
+        assert events[0].fields["data"] == [3, 2, 1]
+        assert events[0].fields["family"] == "linked_list"
+
+    def test_parses_stack_and_table_events(self):
+        stdout = "\n".join(
+            [
+                _line("init", data="()", family="stack"),
+                _line("push", value="("),
+                _line("push", value=")"),
+                _line("pop", value=")"),
+                _line("dp_update", i=1, j=2, value=3),
+                _line("window", l=0, r=3),
+                _line("partition", i=2),
+                _line("edge", a=0, b=2),
+                _line("choose", i=1),
+                _line("backtrack", i=1),
+                _line("read", i=0),
+                _line("return", result=True),
+            ]
+        )
+        events = parse_trace(stdout)
+        assert [e.kind for e in events] == [
+            "init",
+            "push",
+            "push",
+            "pop",
+            "dp_update",
+            "window",
+            "partition",
+            "edge",
+            "choose",
+            "backtrack",
+            "read",
+            "return",
+        ]
+        push = events[1]
+        assert push.value == "("
+        dp = events[4]
+        assert dp.i == 1 and dp.j == 2 and dp.value == 3
+        win = events[5]
+        assert win.l == 0 and win.r == 3
+        ed = events[7]
+        assert ed.a == 0 and ed.b == 2
+        bt = events[9]
+        assert bt.i == 1
+
+    def test_structured_events_require_their_fields(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="value"):
+            parse_trace(_line("push"))
+        with pytest.raises(ValueError, match="value"):
+            parse_trace(_line("dp_update", i=0, j=1))
+        with pytest.raises(ValueError, match="l"):
+            parse_trace(_line("window", r=2))
+        with pytest.raises(ValueError, match="a"):
+            parse_trace(_line("edge", b=1))
+
+    def test_parses_full_bubble_sort_trace(self):
+        stdout = "\n".join(
+            [
+                _line("init", values=[5, 1, 4, 2, 8]),
+                _line("pointer", name="j", index=0),
+                _line("compare", i=0, j=1),
+                _line("swap", i=0, j=1),
+                _line("pointer", name="j", index=1),
+                _line("compare", i=1, j=2),
+                _line("mark", i=4, state="sorted"),
+                _line("return", result=[1, 4, 2, 5, 8]),
+            ]
+        )
+        events = parse_trace(stdout)
+
+        assert [e.kind for e in events] == [
+            "init",
+            "pointer",
+            "compare",
+            "swap",
+            "pointer",
+            "compare",
+            "mark",
+            "return",
+        ]
+        assert events[0].fields["values"] == [5, 1, 4, 2, 8]
+        assert events[2].i == 0
+        assert events[2].j == 1
+        assert events[3].i == 0
+        assert events[3].j == 1
+        assert events[5].i == 1
+        assert events[5].j == 2
+        assert events[6].state == "sorted"
+        assert events[7].fields["result"] == [1, 4, 2, 5, 8]
+
+    def test_ignores_non_json_and_stray_output_lines(self):
+        stdout = "\n".join(
+            [
+                "sorting the array now...",
+                _line("init", values=[3, 2, 1]),
+                "mid-pass",
+                _line("compare", i=0, j=1),
+                "",
+                _line("return", result=[1, 2, 3]),
+            ]
+        )
+        events = parse_trace(stdout)
+        assert [e.kind for e in events] == ["init", "compare", "return"]
+
+    def test_parses_single_json_array_of_events(self):
+        # The traced solution prints one compact JSON array at the end.
+        import json as jsonlib
+
+        payload = [
+            {"event": "init", "values": [5, 1, 4]},
+            {"event": "compare", "i": 0, "j": 1},
+            {"event": "swap", "i": 0, "j": 1},
+            {"event": "return", "result": [1, 4, 5]},
+        ]
+        events = parse_trace(jsonlib.dumps(payload, separators=(",", ":")))
+        assert [e.kind for e in events] == ["init", "compare", "swap", "return"]
+        assert events[0].fields["values"] == [5, 1, 4]
+        assert events[2].i == 0 and events[2].j == 1
+
+    def test_array_trace_ignores_stray_prefixed_lines(self):
+        import json as jsonlib
+
+        payload = [{"event": "init", "values": [2]}, {"event": "return", "result": [2]}]
+        stdout = "some banner\n" + jsonlib.dumps(payload)
+        events = parse_trace(stdout)
+        assert [e.kind for e in events] == ["init", "return"]
+
+    def test_skips_unknown_event_kinds(self):
+        stdout = _line("noise", foo="bar") + "\n" + _line("compare", i=0, j=1)
+        events = parse_trace(stdout)
+        assert [e.kind for e in events] == ["compare"]
+
+    def test_malformed_json_line_is_skipped(self):
+        stdout = "{not json}\n" + _line("compare", i=0, j=1)
+        events = parse_trace(stdout)
+        assert [e.kind for e in events] == ["compare"]
+
+    def test_empty_trace_returns_empty_list(self):
+        assert parse_trace("") == []
+        assert parse_trace("\n\n") == []
+
+    def test_required_index_fields_are_validated(self):
+        # compare without i is structurally invalid
+        with pytest.raises(ValueError, match="i"):
+            parse_trace(_line("compare", j=1))
+
+
+class TestTraceEvent:
+    def test_typed_accessors(self):
+        e = TraceEvent(kind="compare", i=2, j=3)
+        assert e.i == 2
+        assert e.j == 3
+        assert e.has("i")
+
+    def test_missing_optional_fields_default(self):
+        e = TraceEvent(kind="mark", i=4, state="sorted")
+        assert e.i == 4
+        assert e.state == "sorted"
+        assert e.fields.get("j") is None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,10 @@ services:
       - codecoach-network
     environment:
       - PISTON_DISABLE_NETWORK_ACCESS=true
+      # The default 1024-byte stdout cap is too small for the animation trace
+      # (one event per algorithm step) and for solutions that print several
+      # lines. 64KB comfortably fits a full bubble-sort trace.
+      - PISTON_OUTPUT_MAX_SIZE=65536
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://localhost:2000/api/v2/runtimes',r=>process.exit(r.statusCode==200?0:1)).on('error',()=>process.exit(1))"]
       interval: 30s

--- a/frontend/e2e/accessibility.spec.ts
+++ b/frontend/e2e/accessibility.spec.ts
@@ -1,25 +1,49 @@
-import { test, expect } from '@playwright/test';
-import { dismissOnboarding } from './helpers/auth';
+import { test, expect } from "@playwright/test";
+import { dismissOnboarding } from "./helpers/auth";
 
-test.describe('Accessibility', () => {
-  test('homepage has semantic header', async ({ page }) => {
-    await page.goto('/');
+test.describe("Accessibility", () => {
+  test("homepage has semantic header", async ({ page }) => {
+    await page.goto("/");
     await dismissOnboarding(page);
-    await expect(page.locator('header')).toBeVisible();
+    await expect(page.locator("header")).toBeVisible();
   });
 
-  test('learn page has accessible navigation', async ({ page }) => {
-    await page.goto('/learn');
-    await page.waitForLoadState('networkidle');
-    const navLinks = page.locator('header').getByRole('link');
+  test("learn page has accessible navigation", async ({ page }) => {
+    await page.goto("/learn");
+    await page.waitForLoadState("networkidle");
+    const navLinks = page.locator("header").getByRole("link");
     const count = await navLinks.count();
     expect(count).toBeGreaterThan(0);
   });
 
-  test('page elements have descriptive text', async ({ page }) => {
-    await page.goto('/');
+  test("page elements have descriptive text", async ({ page }) => {
+    await page.goto("/");
     await dismissOnboarding(page);
-    const bodyText = await page.textContent('body');
+    const bodyText = await page.textContent("body");
     expect(bodyText).toBeTruthy();
+  });
+
+  test("homepage primary CTA is reachable and activatable with the keyboard", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const cta = page.getByRole("link", { name: /start practicing →/i });
+    await expect(cta).toBeVisible();
+    await cta.focus();
+    await expect(cta).toBeFocused();
+    await page.keyboard.press("Enter");
+    await expect(page).toHaveURL(/\/problems/);
+  });
+
+  test("homepage advertises the step-by-step animation experience", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: /see algorithms come alive/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /try it on a problem/i }),
+    ).toBeVisible();
   });
 });

--- a/frontend/e2e/animate-flow.spec.ts
+++ b/frontend/e2e/animate-flow.spec.ts
@@ -1,0 +1,298 @@
+import { test, expect, Page } from '@playwright/test';
+import { dismissOnboarding } from './helpers/auth';
+
+const password = 'TestPass123!';
+
+const animateResponse = {
+  animation: {
+    title: 'Searching for 4',
+    data: { values: [5, 1, 2, 3, 4, 6], target: 4 },
+    steps: [
+      {
+        narration: '5 is not the target.',
+        shapes: [
+          {
+            id: 'cell_0',
+            type: 'rect',
+            x: -240,
+            y: 0,
+            width: 88,
+            height: 88,
+            radius: 12,
+            fill: '#1e293b',
+            stroke: '#334155',
+          },
+          {
+            id: 'val_0',
+            type: 'text',
+            x: -240,
+            y: 0,
+            text: '5',
+            fontSize: 34,
+            fill: '#94a3b8',
+          },
+          {
+            id: 'ptr',
+            type: 'polygon',
+            points: [
+              [-12, -30],
+              [0, -60],
+              [12, -30],
+            ],
+            x: -240,
+            y: -80,
+            fill: '#facc15',
+          },
+        ],
+        motion: [
+          { target: 'cell_0', op: 'appear', duration: 0.3 },
+          { target: 'val_0', op: 'appear', duration: 0.3 },
+          { target: 'ptr', op: 'appear', duration: 0.3 },
+        ],
+      },
+      {
+        narration: 'Moving the pointer along.',
+        motion: [{ target: 'ptr', op: 'move', to: [0, -80], duration: 0.5 }],
+      },
+      {
+        narration: 'Found the target 4 at index 4.',
+        shapes: [
+          {
+            id: 'cell_4',
+            type: 'rect',
+            x: 240,
+            y: 0,
+            width: 88,
+            height: 88,
+            radius: 12,
+            fill: '#14532d',
+            stroke: '#22c55e',
+          },
+          {
+            id: 'val_4',
+            type: 'text',
+            x: 240,
+            y: 0,
+            text: '4',
+            fontSize: 34,
+            fill: '#ffffff',
+          },
+        ],
+        motion: [
+          { target: 'cell_4', op: 'appear', duration: 0.3 },
+          { target: 'val_4', op: 'appear', duration: 0.3 },
+          { target: 'ptr', op: 'move', to: [240, -80], duration: 0.5 },
+        ],
+      },
+    ],
+  },
+};
+
+const VIEWER_STUB_HTML = `<!doctype html><html><body><script>
+window.addEventListener('message', (e) => {
+  if (e.data && e.data.type && e.data.token) {
+    parent.postMessage({ __codecoach_animate: e.data }, '*');
+  }
+});
+<\/script></body></html>`;
+
+async function register(page: Page) {
+  const ts = Date.now();
+  const username = `animate${ts}`;
+  const email = `animate${ts}@test.com`;
+  await page.goto('/register');
+  await page.getByLabel(/username/i).fill(username);
+  await page.getByLabel(/email/i).fill(email);
+  await page.getByLabel(/password/i).fill(password);
+  await page.getByRole('button', { name: /create account|register/i }).click();
+  await expect(page).toHaveURL('/');
+  return { username, email };
+}
+
+async function mockPremiumAndAnimate(page: Page, username: string, email: string) {
+  await page.route('**/api/auth/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'e2e-animate-user',
+        username,
+        email,
+        created_at: new Date().toISOString(),
+        is_active: true,
+        role: 'user',
+        plan: 'premium',
+      }),
+    }),
+  );
+
+  await page.route('**/api/coach/animate', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(animateResponse),
+    });
+  });
+}
+
+/**
+ * Serve a stub for the chrome-less lab viewer (viewer.html) and relay the
+ * postMessage handshake payloads back to the test window so the test can
+ * assert exactly what the launcher posts to the viewer iframe.
+ */
+async function stubViewerIframe(page: Page) {
+  await page.route(/^http:\/\/localhost:9000\//, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: VIEWER_STUB_HTML,
+    }),
+  );
+  await page.addInitScript(() => {
+    (window as any).__animateMessages = [];
+    window.addEventListener('message', (event: MessageEvent) => {
+      const data = event.data as { __codecoach_animate?: unknown } | null;
+      if (data && data.__codecoach_animate) {
+        (window as any).__animateMessages.push(data.__codecoach_animate);
+      }
+    });
+  });
+}
+
+async function openFirstProblemWorkspace(page: Page) {
+  await page.goto('/problems');
+  await page.waitForSelector('tbody tr');
+  await page.locator('tbody tr').first().click();
+  await page.waitForURL(/\/problems\/.+/);
+}
+
+test.describe('AI Animate flow', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('opens an in-app viewer modal and posts the animation payload (no chat call)', async ({
+    page,
+  }) => {
+    const { username, email } = await register(page);
+    await stubViewerIframe(page);
+    await mockPremiumAndAnimate(page, username, email);
+    await dismissOnboarding(page);
+    await openFirstProblemWorkspace(page);
+
+    const animate = page.getByRole('button', { name: 'Animate solution' });
+    await expect(animate).toBeVisible({ timeout: 15000 });
+    await expect(animate).toBeEnabled({ timeout: 15000 });
+    await animate.click();
+
+    // The animation opens in an in-app modal (no new window) with a one-time
+    // token in the chrome-less viewer iframe URL.
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 15000 });
+    const iframe = dialog.getByTitle('Animation viewer');
+    await expect(iframe).toBeVisible();
+    await expect(iframe).toHaveAttribute('src', /viewer\.html\?token=/);
+    const src = await iframe.getAttribute('src');
+    const token = new URL(src!).searchParams.get('token');
+    expect(token).toBeTruthy();
+
+    // The validated animation is posted to the viewer with the same token.
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as any).__animateMessages?.[0]?.type as string | undefined,
+        ),
+      )
+      .toBe('CODECOACH_ANIMATION');
+
+    const handshake = await page.evaluate(
+      () => (window as any).__animateMessages?.[0],
+    );
+    expect(handshake.token).toBe(token);
+    expect(handshake.animation.title).toBe('Searching for 4');
+    expect(handshake.animation.data.target).toBe(4);
+    expect(handshake.animation.steps[0].motion[0].op).toBe('appear');
+    expect(handshake.animation.steps[0].shapes[0].id).toBe('cell_0');
+
+    // The AI chat panel must not render the animation as a chat message.
+    await expect(
+      page.getByText('Searching for 4', { exact: true }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByText('Found the target 4 at index 4.', { exact: true }),
+    ).not.toBeVisible();
+  });
+
+  test('posts an error message to the viewer when generation fails', async ({
+    page,
+  }) => {
+    const { username, email } = await register(page);
+    await stubViewerIframe(page);
+    await page.route('**/api/coach/animate', async (route) => {
+      await route.fulfill({
+        status: 502,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Failed to generate animation' }),
+      });
+    });
+    await page.route('**/api/auth/me', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'e2e-animate-user',
+          username,
+          email,
+          created_at: new Date().toISOString(),
+          is_active: true,
+          role: 'user',
+          plan: 'premium',
+        }),
+      }),
+    );
+    await dismissOnboarding(page);
+    await openFirstProblemWorkspace(page);
+
+    const animate = page.getByRole('button', { name: 'Animate solution' });
+    await expect(animate).toBeVisible({ timeout: 15000 });
+    await expect(animate).toBeEnabled({ timeout: 15000 });
+    await animate.click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 15000 });
+    await expect(dialog.getByRole('alert')).toBeVisible();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as any).__animateMessages?.[0]?.type as string | undefined,
+        ),
+      )
+      .toBe('CODECOACH_ANIMATION_ERROR');
+  });
+
+  test('the chat panel no longer offers Animate', async ({ page }) => {
+    const { username, email } = await register(page);
+    await mockPremiumAndAnimate(page, username, email);
+    await dismissOnboarding(page);
+    await openFirstProblemWorkspace(page);
+
+    // The AI Coach panel still shows its regular quick actions...
+    await expect(
+      page.getByRole('heading', { name: 'AI COACH', exact: true }),
+    ).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.getByRole('button', { name: 'Hint', exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Explain', exact: true }),
+    ).toBeVisible();
+
+    // ...but Animate is no longer a chat action. The only Animate button is
+    // the standalone launcher, whose accessible name is "Animate solution".
+    await expect(
+      page.getByRole('button', { name: 'Animate', exact: true }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole('button', { name: 'Animate solution' }),
+    ).toBeVisible();
+  });
+});

--- a/frontend/e2e/viewer-render.spec.ts
+++ b/frontend/e2e/viewer-render.spec.ts
@@ -1,0 +1,252 @@
+import { expect, test, type Frame, type Page } from '@playwright/test';
+import { dismissOnboarding } from './helpers/auth';
+
+const password = 'TestPass123!';
+
+// A generic declarative scene with real shapes (rects, text, a pointer
+// polygon) plus motion. The launcher posts this to the real chrome-less
+// Motion Canvas viewer served by the lab dev server on localhost:9000
+// (started by the Playwright webServer entry).
+const genericAnimation = {
+  title: 'Searching for 4',
+  data: { values: [5, 1, 2, 3, 4, 6], target: 4 },
+  steps: [
+    {
+      narration: '5 is not the target.',
+      shapes: [
+        {
+          id: 'cell_0',
+          type: 'rect',
+          x: -240,
+          y: 0,
+          width: 88,
+          height: 88,
+          radius: 12,
+          fill: '#1e293b',
+          stroke: '#334155',
+          text: '5',
+        },
+        {
+          id: 'val_0',
+          type: 'text',
+          x: -240,
+          y: 0,
+          text: '5',
+          fontSize: 34,
+          fill: '#94a3b8',
+        },
+        {
+          id: 'ptr',
+          type: 'polygon',
+          points: [
+            [-12, -30],
+            [0, -60],
+            [12, -30],
+          ],
+          x: -240,
+          y: -80,
+          fill: '#facc15',
+        },
+      ],
+      motion: [
+        { target: 'cell_0', op: 'appear', duration: 0.3 },
+        { target: 'val_0', op: 'appear', duration: 0.3 },
+        { target: 'ptr', op: 'appear', duration: 0.3 },
+      ],
+    },
+    {
+      narration: 'Moving the pointer along.',
+      motion: [{ target: 'ptr', op: 'move', to: [0, -80], duration: 0.5 }],
+    },
+    {
+      narration: 'Found the target 4 at index 4.',
+      shapes: [
+        {
+          id: 'cell_4',
+          type: 'rect',
+          x: 240,
+          y: 0,
+          width: 88,
+          height: 88,
+          radius: 12,
+          fill: '#14532d',
+          stroke: '#22c55e',
+        },
+        {
+          id: 'val_4',
+          type: 'text',
+          x: 240,
+          y: 0,
+          text: '4',
+          fontSize: 34,
+          fill: '#ffffff',
+        },
+      ],
+      motion: [
+        { target: 'cell_4', op: 'appear', duration: 0.3 },
+        { target: 'val_4', op: 'appear', duration: 0.3 },
+        { target: 'ptr', op: 'move', to: [240, -80], duration: 0.5 },
+      ],
+    },
+  ],
+};
+
+async function register(page: Page) {
+  const ts = Date.now();
+  const username = `render${ts}`;
+  const email = `render${ts}@test.com`;
+  await page.goto('/register');
+  await page.getByLabel(/username/i).fill(username);
+  await page.getByLabel(/email/i).fill(email);
+  await page.getByLabel(/password/i).fill(password);
+  await page.getByRole('button', { name: /create account|register/i }).click();
+  await expect(page).toHaveURL('/');
+  return { username, email };
+}
+
+async function mockPremiumAndAnimate(page: Page, username: string, email: string) {
+  await page.route('**/api/auth/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: 'e2e-render-user',
+        username,
+        email,
+        created_at: new Date().toISOString(),
+        is_active: true,
+        role: 'user',
+        plan: 'premium',
+      }),
+    }),
+  );
+
+  await page.route('**/api/coach/animate', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ animation: genericAnimation }),
+    });
+  });
+}
+
+async function countPixelsNear(frame: Frame, hex: string): Promise<number> {
+  return frame.evaluate(
+    async (color: string) => {
+      const canvas = document.querySelector<HTMLCanvasElement>('#stage-canvas');
+      if (!canvas) return 0;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return 0;
+      const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const [r, g, b] = [
+        parseInt(color.slice(1, 3), 16),
+        parseInt(color.slice(3, 5), 16),
+        parseInt(color.slice(5, 7), 16),
+      ];
+      let count = 0;
+      for (let i = 0; i < data.length; i += 4) {
+        if (
+          Math.abs(data[i] - r) < 16 &&
+          Math.abs(data[i + 1] - g) < 16 &&
+          Math.abs(data[i + 2] - b) < 16
+        ) {
+          count++;
+        }
+      }
+      return count;
+    },
+    hex,
+  );
+}
+
+// Mean x of pixels near `hex` — used to prove the pointer physically moves
+// left→right across the timeline instead of sitting still.
+async function meanXOfPixelsNear(frame: Frame, hex: string): Promise<number> {
+  return frame.evaluate(
+    async (color: string) => {
+      const canvas = document.querySelector<HTMLCanvasElement>('#stage-canvas');
+      if (!canvas) return 0;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return 0;
+      const { data, width } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const [r, g, b] = [
+        parseInt(color.slice(1, 3), 16),
+        parseInt(color.slice(3, 5), 16),
+        parseInt(color.slice(5, 7), 16),
+      ];
+      let totalX = 0;
+      let count = 0;
+      for (let y = 0; y < canvas.height; y++) {
+        for (let x = 0; x < width; x++) {
+          const i = (y * width + x) * 4;
+          if (
+            Math.abs(data[i] - r) < 16 &&
+            Math.abs(data[i + 1] - g) < 16 &&
+            Math.abs(data[i + 2] - b) < 16
+          ) {
+            totalX += x;
+            count++;
+          }
+        }
+      }
+      return count === 0 ? -1 : totalX / count;
+    },
+    hex,
+  );
+}
+
+test.describe('Viewer rendering', () => {
+  test('the Motion Canvas viewer paints the generic scene (shapes + motion)', async ({
+    page,
+  }) => {
+    const { username, email } = await register(page);
+    await mockPremiumAndAnimate(page, username, email);
+    await dismissOnboarding(page);
+
+    await page.goto('/problems');
+    await page.waitForSelector('tbody tr');
+    await page.locator('tbody tr').first().click();
+    await page.waitForURL(/\/problems\/.+/);
+
+    const animate = page.getByRole('button', { name: 'Animate solution' });
+    await expect(animate).toBeVisible({ timeout: 15000 });
+    await expect(animate).toBeEnabled({ timeout: 15000 });
+    await animate.click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 15000 });
+    const iframe = dialog.getByTitle('Animation viewer');
+    await expect(iframe).toBeVisible({ timeout: 15000 });
+
+    // The scene generator registers its message bridge at module load and the
+    // launcher posts on iframe load; give the lab a moment to boot in CI.
+    const viewerFrame = () =>
+      page.frames().find((f) => f.url().includes('viewer.html'));
+    await expect
+      .poll(() => viewerFrame()?.url() ?? '', { timeout: 20000 })
+      .toContain('viewer.html');
+
+    // The cell/pointer shapes must actually paint: assert at least one pixel
+    // of the pointer yellow (#facc15) that only exists in the generic scene,
+    // proving the payload reached the renderer and produced vector output —
+    // not just a title card.
+    const frame = viewerFrame()!;
+    await expect
+      .poll(() => countPixelsNear(frame, '#facc15'), { timeout: 25000 })
+      .toBeGreaterThan(50);
+
+    // Cell values must be visible: cell_0 carries text "5" rendered inside the
+    // rect — light text pixels (#e2e8f0) prove values paint, not blank boxes.
+    await expect
+      .poll(() => countPixelsNear(frame, '#e2e8f0'), { timeout: 15000 })
+      .toBeGreaterThan(20);
+
+    // The pointer must actually MOVE: its mean x must cross into the right
+    // half of the canvas — it starts over cell_0 (left) and step 2 moves it to
+    // cell_4 (right). A static scene (the regression we're fixing) would never
+    // leave the left side.
+    await expect
+      .poll(() => meanXOfPixelsNear(frame, '#facc15'), { timeout: 25000 })
+      .toBeGreaterThan(1100);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
+    "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-icons": "^1.3.2",
     "@supabase/ssr": "^0.3.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -18,10 +18,18 @@ export default defineConfig({
     { name: 'webkit', use: { ...devices['Desktop Safari'] } },
     { name: 'mobile-chrome', use: { ...devices['Pixel 7'] } },
   ],
-  webServer: {
-    command: 'pnpm dev',
-    port: 3000,
-    reuseExistingServer: true,
-    timeout: 120000,
-  },
+  webServer: [
+    {
+      command: 'pnpm dev',
+      port: 3000,
+      reuseExistingServer: true,
+      timeout: 120000,
+    },
+    {
+      command: 'pnpm --dir ../motion-canvas-lab dev --port 9000 --strictPort',
+      url: 'http://localhost:9000/viewer.html',
+      reuseExistingServer: true,
+      timeout: 120000,
+    },
+  ],
 });

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@monaco-editor/react':
         specifier: ^4.6.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.23
+        version: 1.1.23(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1573,6 +1576,9 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/primitive@1.1.7':
+    resolution: {integrity: sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==}
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -1608,6 +1614,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.5':
+    resolution: {integrity: sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
@@ -1615,6 +1630,28 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.2.2':
+    resolution: {integrity: sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.23':
+    resolution: {integrity: sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-direction@1.1.1':
@@ -1628,6 +1665,19 @@ packages:
 
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.19':
+    resolution: {integrity: sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1661,6 +1711,28 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-focus-guards@1.1.6':
+    resolution: {integrity: sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.16':
+    resolution: {integrity: sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-scope@1.1.7':
     resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
     peerDependencies:
@@ -1681,6 +1753,15 @@ packages:
 
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-id@1.1.4':
+    resolution: {integrity: sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1714,6 +1795,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-portal@1.1.17':
+    resolution: {integrity: sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
@@ -1727,8 +1821,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.10':
+    resolution: {integrity: sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-presence@1.1.5':
     resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.10':
+    resolution: {integrity: sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1775,8 +1895,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-slot@1.3.3':
+    resolution: {integrity: sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.4':
+    resolution: {integrity: sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1793,8 +1931,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-controllable-state@1.2.6':
+    resolution: {integrity: sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.5':
+    resolution: {integrity: sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1813,6 +1969,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.4':
+    resolution: {integrity: sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -7038,6 +7203,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/primitive@1.1.7': {}
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7065,11 +7232,46 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.29
 
+  '@radix-ui/react-compose-refs@1.1.5(@types/react@18.3.29)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.29
+
   '@radix-ui/react-context@1.1.2(@types/react@18.3.29)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.29
+
+  '@radix-ui/react-context@1.2.2(@types/react@18.3.29)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.29
+
+  '@radix-ui/react-dialog@1.1.23(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.29)(react@18.3.1)
+      '@radix-ui/react-context': 1.2.2(@types/react@18.3.29)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@18.3.29)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.4(@types/react@18.3.29)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.3.3(@types/react@18.3.29)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@18.3.29)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.29)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.29)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.29
+      '@types/react-dom': 18.3.7(@types/react@18.3.29)
 
   '@radix-ui/react-direction@1.1.1(@types/react@18.3.29)(react@18.3.1)':
     dependencies:
@@ -7084,6 +7286,19 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.29)(react@18.3.1)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.29)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.29
+      '@types/react-dom': 18.3.7(@types/react@18.3.29)
+
+  '@radix-ui/react-dismissable-layer@1.1.19(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.29)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.29)(react@18.3.1)
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@18.3.29)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -7111,6 +7326,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.29
 
+  '@radix-ui/react-focus-guards@1.1.6(@types/react@18.3.29)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.29
+
+  '@radix-ui/react-focus-scope@1.1.16(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.29)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@18.3.29)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.29
+      '@types/react-dom': 18.3.7(@types/react@18.3.29)
+
   '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.29)(react@18.3.1)
@@ -7129,6 +7361,13 @@ snapshots:
   '@radix-ui/react-id@1.1.1(@types/react@18.3.29)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.29)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.29
+
+  '@radix-ui/react-id@1.1.4(@types/react@18.3.29)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.29)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.29
@@ -7177,6 +7416,16 @@ snapshots:
       '@types/react': 18.3.29
       '@types/react-dom': 18.3.7(@types/react@18.3.29)
 
+  '@radix-ui/react-portal@1.1.17(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.29)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.29
+      '@types/react-dom': 18.3.7(@types/react@18.3.29)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7187,10 +7436,28 @@ snapshots:
       '@types/react': 18.3.29
       '@types/react-dom': 18.3.7(@types/react@18.3.29)
 
+  '@radix-ui/react-presence@1.1.10(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.29)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.29
+      '@types/react-dom': 18.3.7(@types/react@18.3.29)
+
   '@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.29)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.29)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.29
+      '@types/react-dom': 18.3.7(@types/react@18.3.29)
+
+  '@radix-ui/react-primitive@2.1.10(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.3(@types/react@18.3.29)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -7230,7 +7497,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.29
 
+  '@radix-ui/react-slot@1.3.3(@types/react@18.3.29)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@18.3.29)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.29
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.29)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.29
+
+  '@radix-ui/react-use-callback-ref@1.1.4(@types/react@18.3.29)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
@@ -7244,9 +7524,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.29
 
+  '@radix-ui/react-use-controllable-state@1.2.6(@types/react@18.3.29)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@18.3.29)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.29)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.29
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.29)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.29)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.29
+
+  '@radix-ui/react-use-effect-event@0.0.5(@types/react@18.3.29)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@18.3.29)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.29
@@ -7259,6 +7555,12 @@ snapshots:
       '@types/react': 18.3.29
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.29)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.29
+
+  '@radix-ui/react-use-layout-effect@1.1.4(@types/react@18.3.29)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -163,6 +163,28 @@ body::after {
   }
 }
 
+@keyframes sort-pulse {
+  0%,
+  100% {
+    transform: scaleY(1);
+  }
+
+  50% {
+    transform: scaleY(1.45);
+  }
+}
+
+.sort-bar {
+  transform-origin: bottom;
+  animation: sort-pulse 1.4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sort-bar {
+    animation: none;
+  }
+}
+
 @keyframes slide-in-right {
   from {
     opacity: 0;

--- a/frontend/src/app/learn/lesson/[lessonId]/page.test.tsx
+++ b/frontend/src/app/learn/lesson/[lessonId]/page.test.tsx
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { server } from '@/mocks/server';
+import { useCoaching } from '@/features/coaching/coaching.hook';
+import { useLesson } from '@/features/curriculum/use-curriculum.hook';
 import LessonLoading from './loading';
 import LessonPage from './page';
 import type { LessonSummary } from '@/types';
@@ -17,16 +20,33 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@/providers', () => ({
-  useAuth: () => ({ isAuthenticated: false, isHydrated: true }),
+  useAuth: () => ({
+    isAuthenticated: true,
+    isHydrated: true,
+    user: { plan: 'premium' },
+  }),
 }));
+
+const mockSendMessage = vi.hoisted(() => vi.fn());
+const mockGenerateAnimation = vi.hoisted(() => vi.fn());
 
 vi.mock('@/features/coaching/coaching.hook', () => ({
   useCoaching: () => ({
     messages: [],
     isTyping: false,
-    sendMessage: vi.fn(),
+    sendMessage: mockSendMessage,
   }),
 }));
+
+vi.mock('@/features/animation/animation.service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/features/animation/animation.service')>();
+  return {
+    ...actual,
+    animationService: { generateAnimation: mockGenerateAnimation },
+  };
+});
+
+const mockUseLesson = vi.hoisted(() => vi.fn());
 
 const lesson: LessonSummary = {
   id: 'test-lesson',
@@ -43,11 +63,122 @@ const lesson: LessonSummary = {
 };
 
 vi.mock('@/features/curriculum/use-curriculum.hook', () => ({
-  useLesson: () => ({ lesson, isLoading: false, error: null }),
+  useLesson: mockUseLesson,
 }));
+
+describe('LessonPage AI coaching wiring', () => {
+  beforeEach(() => {
+    mockSendMessage.mockClear();
+    mockGenerateAnimation.mockReset();
+    mockGenerateAnimation.mockResolvedValue({
+      title: 'Searching for 4',
+      data: { values: [5, 1, 2, 3, 4, 6], target: 4 },
+      steps: [
+        {
+          narration: '5 is not the target.',
+          shapes: [
+            {
+              id: 'cell_0',
+              type: 'rect',
+              x: -240,
+              y: 0,
+              width: 88,
+              height: 88,
+              fill: '#1e293b',
+            },
+          ],
+          motion: [{ target: 'cell_0', op: 'appear', duration: 0.3 }],
+        },
+        {
+          narration: 'Moving on.',
+          motion: [{ target: 'cell_0', op: 'move', to: [0, 0], duration: 0.3 }],
+        },
+        {
+          narration: 'Found 4!',
+          shapes: [
+            {
+              id: 'ptr',
+              type: 'polygon',
+              x: 0,
+              y: -80,
+              points: [
+                [-12, -30],
+                [0, -60],
+                [12, -30],
+              ],
+              fill: '#facc15',
+            },
+          ],
+          motion: [{ target: 'ptr', op: 'appear', duration: 0.3 }],
+        },
+      ],
+    });
+    mockUseLesson.mockReturnValue({
+      lesson: { ...lesson, starter_code: 'print(1)' },
+      isLoading: false,
+      error: null,
+    });
+    server.use(
+      http.get('/api/courses/lessons/:lessonId/adjacent', () =>
+        HttpResponse.json({ prev_id: null, next_id: null }),
+      ),
+    );
+  });
+
+  it('renders the Animate launcher outside the chat panel', async () => {
+    localStorage.setItem('codecoach:workspace:ai-open:theory', '1');
+    render(<LessonPage />);
+    const animate = await screen.findByRole('button', { name: /animate solution/i });
+    expect(animate).toBeInTheDocument();
+  });
+
+  it('opens the animation viewer modal and posts the generated animation', async () => {
+    localStorage.setItem('codecoach:workspace:ai-open:theory', '1');
+    const openSpy = vi.spyOn(window, 'open');
+
+    render(<LessonPage />);
+    const animate = await screen.findByRole('button', { name: /animate solution/i });
+    await userEvent.click(animate);
+
+    // An in-app modal opens (no popup window) with a tokenised viewer iframe.
+    const dialog = await screen.findByRole('dialog');
+    expect(openSpy).not.toHaveBeenCalled();
+    const iframe = within(dialog).getByTitle(
+      'Animation viewer',
+    ) as HTMLIFrameElement;
+    const src = iframe.getAttribute('src');
+    expect(src).toMatch(/viewer\.html\?token=/);
+    const token = new URL(src!).searchParams.get('token');
+    expect(token).toBeTruthy();
+
+    const postMessage = vi
+      .spyOn(iframe.contentWindow!, 'postMessage')
+      .mockImplementation(() => {});
+    fireEvent.load(iframe);
+
+    await vi.waitFor(() => {
+      expect(postMessage).toHaveBeenCalledTimes(1);
+    });
+    const [payload, targetOrigin] = postMessage.mock.calls[0];
+    expect(payload.type).toBe('CODECOACH_ANIMATION');
+    expect(payload.token).toBe(token);
+    expect(payload.animation.title).toBe('Searching for 4');
+    expect(payload.animation.data.target).toBe(4);
+    expect(targetOrigin).toBe('http://localhost:9000');
+
+    // The chat must never receive the animate request.
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+});
 
 describe('LessonPage layout width', () => {
   beforeEach(() => {
+    mockUseLesson.mockReturnValue({
+      lesson,
+      isLoading: false,
+      error: null,
+    });
     server.use(
       http.get('/api/courses/lessons/:lessonId/adjacent', () =>
         HttpResponse.json({ prev_id: null, next_id: null }),

--- a/frontend/src/app/learn/lesson/[lessonId]/page.tsx
+++ b/frontend/src/app/learn/lesson/[lessonId]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Header } from '@/components/header/Header';
+import { AnimateLauncher } from '@/components/animate/AnimateLauncher';
 import {
   ExerciseLessonLayout,
   LessonChrome,
@@ -95,6 +96,9 @@ export default function LessonPage() {
     }
   }, [lesson?.question_id]);
 
+  const resolvedStarterCode =
+    (linkedQuestion?.starter as any)?.[language] || lesson?.starter_code || '';
+
   const handleSendMessage = useCallback(
     async (message: string, mode: string) => {
       const lessonContext = lesson ? `${lesson.title}` : undefined;
@@ -106,9 +110,17 @@ export default function LessonPage() {
         language,
         lessonContext,
         linkedQuestion?.difficulty,
+        resolvedStarterCode,
       );
     },
-    [lesson, currentCode, language, sendMessage, linkedQuestion?.difficulty],
+    [
+      lesson,
+      currentCode,
+      language,
+      sendMessage,
+      linkedQuestion?.difficulty,
+      resolvedStarterCode,
+    ],
   );
 
   const handleMarkComplete = async () => {
@@ -301,8 +313,6 @@ export default function LessonPage() {
 
   const isExercise = lesson.type === 'exercise';
   const resolvedTestCases = linkedQuestion?.test_cases || lesson.test_cases || [];
-  const resolvedStarterCode =
-    (linkedQuestion?.starter as any)?.[language] || lesson.starter_code || '';
 
   return (
     <HydrationGuard>
@@ -315,7 +325,22 @@ export default function LessonPage() {
         <Header />
 
         <main className="flex-1 flex flex-col px-6 pt-6 pb-4 w-full min-h-0 overflow-hidden">
-          <LessonChrome lesson={lesson} prevId={prevId} nextId={nextId} />
+          <LessonChrome
+            lesson={lesson}
+            prevId={prevId}
+            nextId={nextId}
+            actions={
+              <AnimateLauncher
+                problem={lesson.title}
+                code={currentCode}
+                language={language}
+                difficulty={linkedQuestion?.difficulty}
+                lessonContext={lesson.title}
+                initialCode={resolvedStarterCode}
+                question={linkedQuestion}
+              />
+            }
+          />
 
           {isExercise ? (
             <ExerciseLessonLayout

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,10 +1,10 @@
-'use client';
+"use client";
 
-import { Header } from '@/components/header/Header';
-import { cn } from '@/lib/utils';
-import { motion } from 'framer-motion';
-import { BookOpen, Code, Globe, Rocket, Star, Zap } from 'lucide-react';
-import Link from 'next/link';
+import { Header } from "@/components/header/Header";
+import { cn } from "@/lib/utils";
+import { motion } from "framer-motion";
+import { BookOpen, Code, Globe, Play, Rocket, Star, Zap } from "lucide-react";
+import Link from "next/link";
 
 const staggerVariants = {
   hidden: { opacity: 0, y: 24 },
@@ -22,52 +22,55 @@ const staggerVariants = {
 const features = [
   {
     icon: Zap,
-    title: '100% Free',
-    description: 'No paywalls, no premium tiers. AI coaching powered by Groq, built in.',
-    accent: 'border-l-emerald-500/40',
+    title: "100% Free",
+    description:
+      "No paywalls, no premium tiers. AI coaching powered by Groq, built in.",
+    accent: "border-l-emerald-500/40",
   },
   {
     icon: BookOpen,
-    title: 'AI Coaching',
+    title: "AI Coaching",
     description:
-      'Context-aware hints and explanations powered by Groq — like a teaching assistant, 24/7.',
-    accent: 'border-l-blue-500/40',
+      "Context-aware hints and explanations powered by Groq — like a teaching assistant, 24/7.",
+    accent: "border-l-blue-500/40",
   },
   {
     icon: Code,
-    title: 'Language Curriculum',
+    title: "Language Curriculum",
     description:
-      'Structured C, Python, and Java paths blending theory with hands-on coding exercises.',
-    accent: 'border-l-violet-500/40',
+      "Structured C, Python, and Java paths blending theory with hands-on coding exercises.",
+    accent: "border-l-violet-500/40",
   },
   {
     icon: Globe,
-    title: 'Open Source & Professor-Ready',
-    description: 'Curriculum-mapped, privacy-first, and free for every institution to recommend.',
-    accent: 'border-l-amber-500/40',
+    title: "Open Source & Professor-Ready",
+    description:
+      "Curriculum-mapped, privacy-first, and free for every institution to recommend.",
+    accent: "border-l-amber-500/40",
   },
 ];
 
 const audiences = [
   {
     icon: Rocket,
-    title: 'Interview Grinders',
-    description: 'Prepare for tech internships and jobs with DSA practice.',
+    title: "Interview Grinders",
+    description: "Prepare for tech internships and jobs with DSA practice.",
   },
   {
     icon: BookOpen,
-    title: 'Struggling Students',
-    description: 'Get hand-holding through the basics with instant AI feedback.',
+    title: "Struggling Students",
+    description:
+      "Get hand-holding through the basics with instant AI feedback.",
   },
   {
     icon: Star,
-    title: 'Curious Learners',
-    description: 'Non-CS majors who want to learn programming on their own.',
+    title: "Curious Learners",
+    description: "Non-CS majors who want to learn programming on their own.",
   },
   {
     icon: Globe,
-    title: 'Professors',
-    description: 'A free, curriculum-aligned tool to recommend to your class.',
+    title: "Professors",
+    description: "A free, curriculum-aligned tool to recommend to your class.",
   },
 ];
 
@@ -120,8 +123,8 @@ export default function LandingPage() {
             }}
             className="mt-6 text-sm md:text-base text-muted-foreground/60 max-w-2xl mx-auto leading-relaxed text-balance"
           >
-            Practice DSA problems and learn programming languages through structured lessons with
-            real-time AI coaching — no payment needed.
+            Practice DSA problems and learn programming languages through
+            structured lessons with real-time AI coaching — no payment needed.
           </motion.p>
 
           <motion.div
@@ -173,7 +176,7 @@ export default function LandingPage() {
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: '-80px' }}
+            viewport={{ once: true, margin: "-80px" }}
             transition={{ duration: 0.7, ease: [0.32, 0.72, 0, 1] as const }}
             className="mb-12"
           >
@@ -181,7 +184,8 @@ export default function LandingPage() {
               Why CodeCoach AI?
             </h2>
             <p className="text-sm text-muted-foreground/50 mt-3 max-w-[45ch] leading-relaxed">
-              Everything you need to level up your coding — without burning a hole in your wallet.
+              Everything you need to level up your coding — without burning a
+              hole in your wallet.
             </p>
           </motion.div>
 
@@ -192,19 +196,19 @@ export default function LandingPage() {
                 custom={i}
                 initial="hidden"
                 whileInView="visible"
-                viewport={{ once: true, margin: '-60px' }}
+                viewport={{ once: true, margin: "-60px" }}
                 variants={staggerVariants}
               >
                 <div
                   className={cn(
-                    'group relative rounded-3xl border border-white/[0.06] bg-white/[0.02] p-7 md:p-8',
-                    'transition-all duration-700 ease-[cubic-bezier(0.32,0.72,0,1)]',
-                    'hover:bg-white/[0.04] hover:border-white/[0.10]',
-                    'h-full',
+                    "group relative rounded-3xl border border-white/[0.06] bg-white/[0.02] p-7 md:p-8",
+                    "transition-all duration-700 ease-[cubic-bezier(0.32,0.72,0,1)]",
+                    "hover:bg-white/[0.04] hover:border-white/[0.10]",
+                    "h-full",
                     feature.accent,
                   )}
                   style={{
-                    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)',
+                    boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
                   }}
                 >
                   <div className="flex items-center gap-3 mb-4">
@@ -225,13 +229,76 @@ export default function LandingPage() {
         </div>
       </section>
 
+      {/* See it in action */}
+      <section className="px-6 pb-24">
+        <div className="max-w-5xl mx-auto">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-80px" }}
+            transition={{ duration: 0.7, ease: [0.32, 0.72, 0, 1] as const }}
+            className="mb-8"
+          >
+            <h2 className="text-3xl md:text-4xl font-medium tracking-tight text-foreground/90">
+              See algorithms come alive
+            </h2>
+            <p className="text-sm text-muted-foreground/50 mt-3 max-w-[45ch] leading-relaxed">
+              Every solution runs as a step-by-step animation. Watch compares,
+              swaps, and traversals happen right in front of you.
+            </p>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-60px" }}
+            transition={{ duration: 0.8, ease: [0.32, 0.72, 0, 1] as const }}
+            className="relative overflow-hidden rounded-3xl border border-white/[0.06] bg-white/[0.02] p-8 md:p-10"
+            style={{ boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)" }}
+          >
+            <div
+              className="flex h-36 items-end gap-1.5 md:h-44"
+              aria-hidden="true"
+            >
+              {[
+                30, 60, 45, 90, 70, 25, 80, 55, 40, 95, 65, 35, 75, 50, 85, 20,
+                60, 45, 70, 30, 55, 80, 40, 65,
+              ].map((height, i) => (
+                <span
+                  key={i}
+                  className="sort-bar w-full max-w-[20px] flex-1 rounded-t-md bg-primary/50"
+                  style={{
+                    height: `${height}%`,
+                    animationDelay: `${(i % 8) * 0.18}s`,
+                  }}
+                />
+              ))}
+            </div>
+            <div className="mt-8 flex flex-wrap items-center justify-between gap-4">
+              <p className="text-xs leading-relaxed text-muted-foreground/50 max-w-md">
+                From bubble sort to Dijkstra&apos;s algorithm — pick any of the{" "}
+                {100} problems and watch the canonical solution animate step by
+                step.
+              </p>
+              <Link
+                href="/problems"
+                className="inline-flex items-center gap-2 px-5 py-2.5 text-xs font-medium text-white bg-primary/80 hover:bg-primary rounded-full transition-all duration-700 ease-[cubic-bezier(0.32,0.72,0,1)] shadow-lg shadow-primary/10"
+              >
+                <Play className="h-3.5 w-3.5" />
+                Try it on a problem
+              </Link>
+            </div>
+          </motion.div>
+        </div>
+      </section>
+
       {/* Audience */}
       <section className="px-6 pb-24">
         <div className="max-w-5xl mx-auto">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, margin: '-80px' }}
+            viewport={{ once: true, margin: "-80px" }}
             transition={{ duration: 0.7, ease: [0.32, 0.72, 0, 1] as const }}
             className="mb-12"
           >
@@ -239,7 +306,8 @@ export default function LandingPage() {
               Built for everyone
             </h2>
             <p className="text-sm text-muted-foreground/50 mt-3 max-w-[45ch] leading-relaxed">
-              Whether you&apos;re grinding for interviews or writing your first loop.
+              Whether you&apos;re grinding for interviews or writing your first
+              loop.
             </p>
           </motion.div>
 
@@ -250,13 +318,13 @@ export default function LandingPage() {
                 custom={i}
                 initial="hidden"
                 whileInView="visible"
-                viewport={{ once: true, margin: '-40px' }}
+                viewport={{ once: true, margin: "-40px" }}
                 variants={staggerVariants}
               >
                 <div
                   className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-6 transition-all duration-700 ease-[cubic-bezier(0.32,0.72,0,1)] hover:bg-white/[0.04] h-full"
                   style={{
-                    boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.06)',
+                    boxShadow: "inset 0 1px 0 rgba(255,255,255,0.06)",
                   }}
                 >
                   <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/[0.04] text-foreground/50 ring-1 ring-white/5 mb-3">
@@ -280,7 +348,7 @@ export default function LandingPage() {
         <motion.div
           initial={{ opacity: 0, y: 24 }}
           whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, margin: '-80px' }}
+          viewport={{ once: true, margin: "-80px" }}
           transition={{ duration: 0.8, ease: [0.32, 0.72, 0, 1] as const }}
           className="max-w-3xl mx-auto text-center"
         >
@@ -289,8 +357,8 @@ export default function LandingPage() {
               Start coding, for free.
             </h2>
             <p className="text-sm text-muted-foreground/50 max-w-[40ch] mx-auto leading-relaxed mb-8">
-              No credit card. No premium tier. Just you, the code, and an AI coach that&apos;s
-              powered by Groq and always awake.
+              No credit card. No premium tier. Just you, the code, and an AI
+              coach that&apos;s powered by Groq and always awake.
             </p>
             <div className="flex items-center justify-center gap-4 flex-wrap">
               <Link

--- a/frontend/src/app/problems/[id]/page.test.tsx
+++ b/frontend/src/app/problems/[id]/page.test.tsx
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import ProblemWorkspacePage from './page';
+import { Question } from '@/types';
+
+const mockAnimateLauncher = vi.hoisted(() => vi.fn());
+const mockGetQuestion = vi.hoisted(() => vi.fn());
+
+vi.mock('@/components/animate/AnimateLauncher', () => ({
+  AnimateLauncher: (props: unknown) => {
+    mockAnimateLauncher(props);
+    return <div data-testid="animate-launcher" />;
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'lcp' }),
+}));
+
+vi.mock('@/components/header/Header', () => ({
+  Header: () => <header>Header</header>,
+}));
+
+vi.mock('@/components/layout/elements/AIChatPanelContainer', () => ({
+  AIChatPanelContainer: () => <div>Chat</div>,
+}));
+
+vi.mock('@/components/layout/elements/CodeEditorContainer', () => ({
+  CodeEditorContainer: () => <div>Editor</div>,
+}));
+
+vi.mock('@/components/layout/lessons', () => ({
+  useWorkspaceMode: () => ({ ref: undefined, mode: 'wide' }),
+  AIPanelDrawer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/rescue/RescueIntervention', () => ({
+  RescueIntervention: () => <div>Rescue</div>,
+}));
+
+vi.mock('@/components/sidebar/QuestionDescriptionPanel', () => ({
+  QuestionDescriptionPanel: () => <div>Description</div>,
+}));
+
+vi.mock('@/components/ui/ResizablePanelGroup', () => ({
+  ResizablePanelGroup: ({ panels }: { panels: Array<{ children: ReactNode }> }) => (
+    <div>{panels.map((p, i) => <div key={i}>{p.children}</div>)}</div>
+  ),
+}));
+
+vi.mock('@/features/coaching/coaching.hook', () => ({
+  useCoaching: () => ({
+    messages: [],
+    isTyping: false,
+    sendMessage: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/question/question.service', () => ({
+  questionService: { getQuestion: mockGetQuestion },
+}));
+
+vi.mock('@/features/question/use-code-runner.hook', () => ({
+  useCodeRunner: () => ({
+    isRunning: false,
+    output: '',
+    testResults: [],
+    executionError: null,
+    lastSubmitResult: null,
+    handleRunCode: vi.fn(),
+    handleSubmitCode: vi.fn(),
+    isAuthenticated: true,
+  }),
+}));
+
+vi.mock('@/features/rescue/use-rescue-contract.hook', () => ({
+  useRescueContract: () => ({
+    registerActivity: vi.fn(),
+    tier: 'none',
+    checkpoints: [],
+    isSuppressed: false,
+    leaveMeAlone: vi.fn(),
+    resume: vi.fn(),
+  }),
+}));
+
+const lcpQuestion: Question = {
+  id: 'lcp',
+  title: 'Longest Common Prefix',
+  difficulty: 'easy',
+  category: 'Strings',
+  company_tags: [],
+  description: 'Write a function to find the longest common prefix string amongst an array of strings.',
+  starter: {
+    python: 'class Solution:\n    def longestCommonPrefix(self, strs):\n        pass\n',
+    javascript: '',
+    java: '',
+    cpp: '',
+    c: '',
+    go: '',
+    rust: '',
+    typescript: '',
+  },
+  examples: [
+    { input: 'strs = ["flower","flow","flight"]', output: '"fl"', explanation: 'flower, flow and flight share the prefix "fl".' },
+  ],
+  test_cases: [
+    { input: 'strs = ["dog","racecar","car"]', expected_output: '""' },
+  ],
+  hints: [],
+  solution: '',
+  time_complexity: 'O(S)',
+  space_complexity: 'O(1)',
+};
+
+describe('ProblemWorkspacePage Animate wiring', () => {
+  beforeEach(() => {
+    mockAnimateLauncher.mockClear();
+    mockGetQuestion.mockReset();
+    mockGetQuestion.mockResolvedValue(lcpQuestion);
+  });
+
+  it('passes the loaded question context to the Animate launcher', async () => {
+    render(<ProblemWorkspacePage />);
+
+    await screen.findByTestId('animate-launcher');
+
+    expect(mockAnimateLauncher).toHaveBeenCalled();
+    const lastCall = mockAnimateLauncher.mock.calls.at(-1)![0] as {
+      problem: string;
+      question: unknown;
+      difficulty: string;
+      initialCode: string;
+    };
+    const props = lastCall;
+    expect(props.problem).toBe('Longest Common Prefix');
+    expect(props.difficulty).toBe('easy');
+    expect(props.initialCode).toBe(lcpQuestion.starter.python);
+    expect(props.question).toEqual(lcpQuestion);
+  });
+});

--- a/frontend/src/app/problems/[id]/page.tsx
+++ b/frontend/src/app/problems/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Header } from '@/components/header/Header';
+import { AnimateLauncher } from '@/components/animate/AnimateLauncher';
 import { AIChatPanelContainer } from '@/components/layout/elements/AIChatPanelContainer';
 import { CodeEditorContainer } from '@/components/layout/elements/CodeEditorContainer';
 import { AIPanelDrawer, useWorkspaceMode } from '@/components/layout/lessons';
@@ -82,13 +83,27 @@ export default function ProblemWorkspacePage() {
     }
   }, [language, fullQuestion]);
 
+  const starterCode =
+    fullQuestion?.starter && typeof fullQuestion.starter === 'object'
+      ? fullQuestion.starter[language as keyof typeof fullQuestion.starter] || ''
+      : '';
+
   const handleSendMessage = useCallback(
     async (message: string, mode: string) => {
       if (!fullQuestion) return;
       rescueActivity();
-      await sendMessage(message, mode as any, fullQuestion.title, currentCode, language);
+      await sendMessage(
+        message,
+        mode as any,
+        fullQuestion.title,
+        currentCode,
+        language,
+        undefined,
+        undefined,
+        starterCode,
+      );
     },
-    [fullQuestion, currentCode, language, sendMessage, rescueActivity],
+    [fullQuestion, currentCode, language, sendMessage, rescueActivity, starterCode],
   );
 
   const handleRunCodeRescue = useCallback(
@@ -210,11 +225,7 @@ export default function ProblemWorkspacePage() {
         <CodeEditorContainer
           language={language}
           currentCode={currentCode}
-          initialCode={
-            fullQuestion.starter && typeof fullQuestion.starter === 'object'
-              ? fullQuestion.starter[language as keyof typeof fullQuestion.starter] || ''
-              : ''
-          }
+          initialCode={starterCode}
           isRunning={isRunning}
           output={output}
           error={executionError || error || ''}
@@ -258,6 +269,15 @@ export default function ProblemWorkspacePage() {
           <span className="text-xs text-foreground/60 truncate max-w-[200px]">
             {fullQuestion.title}
           </span>
+          <div className="flex-1" />
+          <AnimateLauncher
+            problem={fullQuestion.title}
+            code={currentCode}
+            language={language}
+            difficulty={fullQuestion.difficulty}
+            initialCode={starterCode}
+            question={fullQuestion}
+          />
         </div>
 
         <div ref={workspaceRef} data-testid="problem-workspace" className="flex-1 min-h-0 relative">

--- a/frontend/src/components/MainWorkspace.test.tsx
+++ b/frontend/src/components/MainWorkspace.test.tsx
@@ -362,6 +362,64 @@ describe('MainWorkspace', () => {
       questions[0].title,
       '',
       'python',
+      undefined,
+      undefined,
+      '',
+    );
+  });
+
+  it('passes the starter code as initialCode when a full question is loaded', async () => {
+    const fullQuestion: Question = {
+      id: '1',
+      title: 'Two Sum',
+      difficulty: 'easy',
+      category: 'arrays',
+      company_tags: [],
+      description: 'test',
+      examples: [],
+      hints: [],
+      starter: {
+        python: 'def two_sum(nums, target):\n    pass',
+        javascript: '',
+        java: '',
+        cpp: '',
+        c: '',
+        go: '',
+        rust: '',
+        typescript: '',
+      },
+      solution: '',
+      time_complexity: '',
+      space_complexity: '',
+      test_cases: [],
+    };
+    mockUseQuestion.mockImplementation(() => ({
+      questions,
+      selectedQuestion: questions[0],
+      fullQuestion,
+      isLoading: false,
+      isLoadingQuestion: false,
+      error: null,
+      loadQuestions: mockLoadQuestions,
+      selectQuestion: mockSelectQuestion,
+      clearError: mockClearError,
+    }));
+
+    act(() => {
+      render(<MainWorkspace />);
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Change Code'));
+    await user.click(screen.getByText('Send Message'));
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      'hello',
+      'freeform',
+      'Two Sum',
+      'new code',
+      'python',
+      undefined,
+      undefined,
+      'def two_sum(nums, target):\n    pass',
     );
   });
 

--- a/frontend/src/components/MainWorkspace.tsx
+++ b/frontend/src/components/MainWorkspace.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
+import { Sparkles } from "lucide-react";
 import { Header } from "@/components/header/Header";
 import { Sidebar } from "@/components/sidebar/Sidebar";
 import { OnboardingTour } from "@/components/onboarding/OnboardingTour";
@@ -72,6 +73,12 @@ export function MainWorkspace() {
   const displayQuestion: Question | QuestionSummary | null =
     fullQuestion || selectedQuestion;
 
+  const initialCode =
+    fullQuestion && typeof fullQuestion.starter === "object"
+      ? fullQuestion.starter[language as keyof typeof fullQuestion.starter] ||
+        ""
+      : "";
+
   const handleRunCodeWrapper = (stdin: string) => {
     handleRunCode(stdin);
   };
@@ -86,9 +93,12 @@ export function MainWorkspace() {
         displayQuestion.title,
         currentCode,
         language,
+        undefined,
+        undefined,
+        initialCode,
       );
     },
-    [displayQuestion, currentCode, language, sendMessage],
+    [displayQuestion, currentCode, language, sendMessage, initialCode],
   );
 
   if (!isMounted || isLoading) {
@@ -113,13 +123,7 @@ export function MainWorkspace() {
             <CodeEditorContainer
               language={language}
               currentCode={currentCode}
-              initialCode={
-                fullQuestion && typeof fullQuestion.starter === "object"
-                  ? fullQuestion.starter[
-                      language as keyof typeof fullQuestion.starter
-                    ] || ""
-                  : ""
-              }
+              initialCode={initialCode}
               isRunning={isRunning}
               output={output}
               error={executionError || error || ""}
@@ -149,10 +153,11 @@ export function MainWorkspace() {
             <div className="flex flex-col items-center justify-center p-4">
               <button
                 onClick={() => setIsAIChatOpen(true)}
-                className="p-3 bg-white/[0.05] hover:bg-white/[0.08] rounded-full transition-all"
                 aria-label="Open AI Panel"
+                className="inline-flex items-center gap-2 rounded-full bg-white/[0.05] hover:bg-white/[0.08] px-4 py-2 text-xs font-medium text-muted-foreground/70 hover:text-foreground ring-1 ring-white/[0.06] transition-all active:scale-[0.97]"
               >
-                <div className="w-5 h-5 bg-primary/60 rounded-full" />
+                <Sparkles className="h-3.5 w-3.5 text-primary/70" />
+                Ask Coach
               </button>
             </div>
           )}

--- a/frontend/src/components/animate/AnimateLauncher.test.tsx
+++ b/frontend/src/components/animate/AnimateLauncher.test.tsx
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  AnimateLauncher,
+  ANIMATION_MESSAGE_TYPE,
+  ANIMATION_ERROR_MESSAGE_TYPE,
+} from "./AnimateLauncher";
+import { HttpError } from "@/lib/fetch-client";
+
+const mockGenerateAnimation = vi.hoisted(() => vi.fn());
+
+vi.mock("@/features/animation/animation.service", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/features/animation/animation.service")
+    >();
+  return {
+    ...actual,
+    animationService: { generateAnimation: mockGenerateAnimation },
+  };
+});
+
+const animationFixture = {
+  type: "linear_search",
+  title: "Searching for 4",
+  data: { values: [5, 1, 2, 3, 4, 6], target: 4 },
+  steps: [],
+};
+
+describe("AnimateLauncher", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockGenerateAnimation.mockReset();
+  });
+
+  const defaultProps = {
+    problem: "Find the target",
+    code: "def search(arr, t):\n    pass",
+    language: "python",
+    initialCode: "def search(arr, t):\n    pass",
+  };
+
+  function renderLauncher(
+    overrides: Partial<Parameters<typeof AnimateLauncher>[0]> = {},
+  ) {
+    return render(<AnimateLauncher {...defaultProps} {...overrides} />);
+  }
+
+  async function openAndGetIframe(
+    overrides: Partial<Parameters<typeof AnimateLauncher>[0]> = {},
+  ) {
+    const user = userEvent.setup();
+    const view = renderLauncher(overrides);
+    await user.click(screen.getByRole("button", { name: /animate solution/i }));
+    const dialog = await screen.findByRole("dialog");
+    const iframe = within(dialog).getByTitle(
+      "Animation viewer",
+    ) as HTMLIFrameElement;
+    return { view, dialog, iframe };
+  }
+
+  it("renders an Animate button", () => {
+    renderLauncher();
+    expect(
+      screen.getByRole("button", { name: /animate solution/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens a viewer modal (no popup window) and posts the animation on iframe load", async () => {
+    mockGenerateAnimation.mockResolvedValue(animationFixture);
+    const openSpy = vi.spyOn(window, "open");
+    const { iframe } = await openAndGetIframe();
+
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(iframe.getAttribute("src")).toMatch(/viewer\.html\?token=/);
+    const token = new URL(iframe.getAttribute("src")!).searchParams.get(
+      "token",
+    );
+    expect(token).toBeTruthy();
+
+    const postMessage = vi
+      .spyOn(iframe.contentWindow!, "postMessage")
+      .mockImplementation(() => {});
+    fireEvent.load(iframe);
+
+    await waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
+    const [payload, targetOrigin] = postMessage.mock.calls[0];
+
+    expect(payload.type).toBe(ANIMATION_MESSAGE_TYPE);
+    expect(payload.token).toBe(token);
+    expect(payload.animation.type).toBe("linear_search");
+    expect(targetOrigin).toBe("http://localhost:9000");
+    expect(mockGenerateAnimation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        problem: "Find the target",
+        language: "python",
+      }),
+    );
+  });
+
+  it("passes the linked question to the animation request", async () => {
+    mockGenerateAnimation.mockResolvedValue(animationFixture);
+    const question = {
+      id: "q1",
+      title: "Two Sum",
+      difficulty: "medium" as const,
+      category: "hash_map",
+      company_tags: [],
+      description: "Find two numbers that add to target.",
+      starter: {
+        python: "def f(): pass",
+        javascript: "",
+        java: "",
+        cpp: "",
+        c: "",
+        go: "",
+        rust: "",
+        typescript: "",
+      },
+      examples: [{ input: "[2,7,11,15], 9", output: "[0,1]" }],
+      test_cases: [{ input: "[3,3], 6", expected_output: "[0,1]" }],
+      hints: [],
+      solution: "",
+      time_complexity: "",
+      space_complexity: "",
+    };
+    const { iframe } = await openAndGetIframe({ question });
+    const postMessage = vi
+      .spyOn(iframe.contentWindow!, "postMessage")
+      .mockImplementation(() => {});
+    fireEvent.load(iframe);
+    await waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
+
+    expect(mockGenerateAnimation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        question: expect.objectContaining({
+          title: "Two Sum",
+          category: "hash_map",
+          description: "Find two numbers that add to target.",
+        }),
+      }),
+    );
+  });
+
+  it("posts an error message to the viewer when generation fails", async () => {
+    mockGenerateAnimation.mockRejectedValue(new Error("boom"));
+    const { dialog } = await openAndGetIframe();
+    const iframe = within(dialog).getByTitle(
+      "Animation viewer",
+    ) as HTMLIFrameElement;
+    const postMessage = vi
+      .spyOn(iframe.contentWindow!, "postMessage")
+      .mockImplementation(() => {});
+    fireEvent.load(iframe);
+
+    await waitFor(() => expect(postMessage).toHaveBeenCalled());
+    const [payload] = postMessage.mock.calls[0];
+    expect(payload.type).toBe(ANIMATION_ERROR_MESSAGE_TYPE);
+    expect(payload.message).toBeTruthy();
+
+    expect(await within(dialog).findByRole("alert")).toBeInTheDocument();
+  });
+
+  it("posts friendly copy instead of the raw 502 when the backend cannot animate", async () => {
+    mockGenerateAnimation.mockRejectedValue(
+      new HttpError("Request failed: 502 Bad Gateway", 502, "{}"),
+    );
+    const { dialog } = await openAndGetIframe();
+    const iframe = within(dialog).getByTitle(
+      "Animation viewer",
+    ) as HTMLIFrameElement;
+    const postMessage = vi
+      .spyOn(iframe.contentWindow!, "postMessage")
+      .mockImplementation(() => {});
+    fireEvent.load(iframe);
+
+    await waitFor(() => expect(postMessage).toHaveBeenCalled());
+    const [payload] = postMessage.mock.calls[0];
+    expect(payload.type).toBe(ANIMATION_ERROR_MESSAGE_TYPE);
+    expect(payload.message).toBe("Couldn't animate this problem. Try again.");
+
+    expect(await within(dialog).findByRole("alert")).toHaveTextContent(
+      "Couldn't animate this problem",
+    );
+  });
+
+  it("closes the modal from the close button", async () => {
+    mockGenerateAnimation.mockResolvedValue(animationFixture);
+    const user = userEvent.setup();
+    const { dialog } = await openAndGetIframe();
+    await user.click(within(dialog).getByRole("button", { name: /close/i }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("is disabled when there is no code to animate", () => {
+    render(<AnimateLauncher {...defaultProps} code="" />);
+    expect(
+      screen.getByRole("button", { name: /animate solution/i }),
+    ).toBeDisabled();
+  });
+
+  it("shows the problem title in the dialog header", async () => {
+    mockGenerateAnimation.mockResolvedValue(animationFixture);
+    const { dialog } = await openAndGetIframe();
+    expect(within(dialog).getByText("Find the target")).toBeInTheDocument();
+  });
+
+  it("shows a live generation status while loading", async () => {
+    mockGenerateAnimation.mockResolvedValue(animationFixture);
+    const user = userEvent.setup();
+    const view = renderLauncher();
+    await user.click(screen.getByRole("button", { name: /animate solution/i }));
+    const dialog = await screen.findByRole("dialog");
+    const iframe = within(dialog).getByTitle(
+      "Animation viewer",
+    ) as HTMLIFrameElement;
+    const postMessage = vi
+      .spyOn(iframe.contentWindow!, "postMessage")
+      .mockImplementation(() => {});
+
+    fireEvent.load(iframe);
+
+    const status = within(dialog).getByRole("status");
+    expect(status.textContent).toMatch(/compiling|running|rendering/i);
+
+    await waitFor(() =>
+      expect(within(dialog).queryByRole("status")).not.toBeInTheDocument(),
+    );
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(view).toBeTruthy();
+  });
+
+  it("retries generation from the error state", async () => {
+    mockGenerateAnimation
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(animationFixture);
+    const user = userEvent.setup();
+    const { dialog } = await openAndGetIframe();
+    let iframe = within(dialog).getByTitle(
+      "Animation viewer",
+    ) as HTMLIFrameElement;
+    const postMessage = vi
+      .spyOn(iframe.contentWindow!, "postMessage")
+      .mockImplementation(() => {});
+
+    fireEvent.load(iframe);
+
+    await waitFor(() =>
+      expect(within(dialog).getByRole("alert")).toBeInTheDocument(),
+    );
+    expect(mockGenerateAnimation).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+
+    await user.click(
+      within(dialog).getByRole("button", { name: /try again/i }),
+    );
+
+    await waitFor(() =>
+      expect(within(dialog).queryByRole("alert")).not.toBeInTheDocument(),
+    );
+
+    iframe = within(dialog).getByTitle("Animation viewer") as HTMLIFrameElement;
+    const retryPostMessage = vi
+      .spyOn(iframe.contentWindow!, "postMessage")
+      .mockImplementation(() => {});
+    fireEvent.load(iframe);
+
+    await waitFor(() => expect(retryPostMessage).toHaveBeenCalledTimes(1));
+    expect(mockGenerateAnimation).toHaveBeenCalledTimes(2);
+    const [payload] = retryPostMessage.mock.calls[0];
+    expect(payload.type).toBe(ANIMATION_MESSAGE_TYPE);
+  });
+});

--- a/frontend/src/components/animate/AnimateLauncher.tsx
+++ b/frontend/src/components/animate/AnimateLauncher.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { Loader2, Play, RotateCcw, Sparkles } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  animationService,
+  buildAnimateQuestion,
+} from "@/features/animation/animation.service";
+import { HttpError } from "@/lib/fetch-client";
+import { Question } from "@/types";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export const ANIMATION_MESSAGE_TYPE = "CODECOACH_ANIMATION";
+export const ANIMATION_ERROR_MESSAGE_TYPE = "CODECOACH_ANIMATION_ERROR";
+
+export const ANIMATION_VIEWER_URL =
+  process.env.NEXT_PUBLIC_ANIMATION_VIEWER_URL || "http://localhost:9000";
+
+export const ANIMATION_VIEWER_PAGE = "/viewer.html";
+
+const ANIMATE_502_MESSAGE = "Couldn't animate this problem. Try again.";
+
+// Cosmetic phases shown while the backend traces, executes, and compiles the
+// animation. Indeterminate progress — the real phase boundaries live server-side.
+const GENERATION_PHASES = [
+  "Compiling your solution",
+  "Running the example input",
+  "Rendering the animation",
+];
+
+const PHASE_TICK_MS = 1400;
+
+function animationErrorMessage(err: unknown): string {
+  if (err instanceof HttpError && err.status === 502) {
+    return ANIMATE_502_MESSAGE;
+  }
+  return err instanceof Error
+    ? err.message
+    : "Failed to generate the animation.";
+}
+
+interface AnimateLauncherProps {
+  problem: string;
+  code: string;
+  language: string;
+  difficulty?: string;
+  lessonContext?: string;
+  initialCode?: string;
+  question?: Question | null;
+  disabled?: boolean;
+}
+
+export function AnimateLauncher({
+  problem,
+  code,
+  language,
+  difficulty = "medium",
+  lessonContext,
+  initialCode,
+  question,
+  disabled = false,
+}: AnimateLauncherProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [phaseIndex, setPhaseIndex] = useState(0);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  // Guards against acting on a generation that outlived its dialog session
+  // (dialog closed / unmounted while the request was in flight).
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, []);
+
+  const viewerUrl = useMemo(() => {
+    if (!token) return null;
+    const url = new URL(ANIMATION_VIEWER_PAGE, ANIMATION_VIEWER_URL);
+    url.searchParams.set("token", token);
+    return url.toString();
+  }, [token]);
+
+  useEffect(() => {
+    if (!isLoading) return;
+    setPhaseIndex(0);
+    const id = window.setInterval(
+      () => setPhaseIndex((index) => (index + 1) % GENERATION_PHASES.length),
+      PHASE_TICK_MS,
+    );
+    return () => window.clearInterval(id);
+  }, [isLoading]);
+
+  const handleClick = useCallback(() => {
+    if (!problem || !code || isLoading || disabled) return;
+    cancelledRef.current = false;
+    setError(null);
+    setToken(crypto.randomUUID());
+    setIsOpen(true);
+  }, [problem, code, isLoading, disabled]);
+
+  const handleIframeLoad = useCallback(async () => {
+    const win = iframeRef.current?.contentWindow;
+    if (!win || !token) return;
+    setIsLoading(true);
+    try {
+      const animation = await animationService.generateAnimation({
+        problem,
+        code,
+        language,
+        difficulty,
+        lessonContext,
+        initialCode,
+        question: buildAnimateQuestion(question),
+      });
+      if (cancelledRef.current) return;
+      win.postMessage(
+        { type: ANIMATION_MESSAGE_TYPE, token, animation },
+        ANIMATION_VIEWER_URL,
+      );
+    } catch (err) {
+      if (cancelledRef.current) return;
+      const message = animationErrorMessage(err);
+      win.postMessage(
+        {
+          type: ANIMATION_ERROR_MESSAGE_TYPE,
+          token,
+          message,
+        },
+        ANIMATION_VIEWER_URL,
+      );
+      setError(message);
+    } finally {
+      if (!cancelledRef.current) setIsLoading(false);
+    }
+  }, [
+    token,
+    problem,
+    code,
+    language,
+    difficulty,
+    lessonContext,
+    initialCode,
+    question,
+  ]);
+
+  const retry = useCallback(() => {
+    cancelledRef.current = false;
+    setError(null);
+    // A fresh token re-mounts the iframe (key={token}), which re-fires `load`
+    // and triggers a new generation attempt.
+    setToken(crypto.randomUUID());
+  }, []);
+
+  const isDisabled = disabled || isLoading || !problem || !code;
+  const title = question?.title || problem;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isDisabled}
+        aria-label="Animate solution"
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium tracking-wide text-emerald-300/80 hover:text-emerald-200 bg-emerald-500/10 hover:bg-emerald-500/15 ring-1 ring-emerald-500/20 rounded-full transition-all disabled:opacity-40 disabled:pointer-events-none active:scale-[0.97]"
+      >
+        {isLoading ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Play className="h-3.5 w-3.5" strokeWidth={2} />
+        )}
+        {isLoading ? "Generating…" : "Animate"}
+      </button>
+      <Dialog
+        open={isOpen}
+        onOpenChange={(open) => {
+          if (!open) cancelledRef.current = true;
+          setIsOpen(open);
+        }}
+      >
+        <DialogContent className="w-[calc(100vw-2rem)]">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Sparkles className="h-4 w-4 shrink-0 text-emerald-400/80" />
+              <span className="truncate" title={title}>
+                {title}
+              </span>
+            </DialogTitle>
+            <p className="text-[11px] uppercase tracking-widest text-muted-foreground/40">
+              Step-by-step algorithm trace
+            </p>
+          </DialogHeader>
+          <div className="relative aspect-video w-full overflow-hidden rounded-lg border border-border bg-[#0b0f19]">
+            {isLoading && !error && (
+              <div
+                role="status"
+                aria-live="polite"
+                className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-[#0b0f19]/80 text-xs text-muted-foreground"
+              >
+                <Loader2 className="h-5 w-5 animate-spin text-emerald-400/80" />
+                <span className="text-muted-foreground/80">
+                  {GENERATION_PHASES[phaseIndex]}
+                  <span aria-hidden="true">…</span>
+                </span>
+                <div className="flex items-center gap-1.5" aria-hidden="true">
+                  {GENERATION_PHASES.map((_, i) => (
+                    <span
+                      key={i}
+                      className={`h-1 w-6 rounded-full transition-colors ${
+                        i === phaseIndex ? "bg-emerald-400/70" : "bg-white/10"
+                      }`}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+            {viewerUrl && (
+              <iframe
+                key={token}
+                ref={iframeRef}
+                title="Animation viewer"
+                src={viewerUrl}
+                onLoad={handleIframeLoad}
+                className="h-full w-full"
+                allowFullScreen
+              />
+            )}
+          </div>
+          {error && (
+            <div
+              role="alert"
+              className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-destructive/25 bg-destructive/5 px-3 py-2.5"
+            >
+              <span className="text-[11px] leading-tight text-destructive/90">
+                {error}
+              </span>
+              <button
+                type="button"
+                onClick={retry}
+                className="inline-flex items-center gap-1.5 rounded-full bg-destructive/10 px-3 py-1.5 text-[11px] font-medium text-destructive/90 ring-1 ring-destructive/20 transition-all hover:bg-destructive/15 active:scale-[0.97]"
+              >
+                <RotateCcw className="h-3 w-3" />
+                Try again
+              </button>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/frontend/src/components/chat/AIChatPanel.test.tsx
+++ b/frontend/src/components/chat/AIChatPanel.test.tsx
@@ -41,6 +41,9 @@ describe("AIChatPanel", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /debug/i })).toBeInTheDocument();
     expect(
+      screen.queryByRole("button", { name: /animate/i }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.getByPlaceholderText(
         "Ask a question or describe your approach...",
       ),
@@ -75,6 +78,17 @@ describe("AIChatPanel", () => {
 
     await user.click(screen.getByRole("button", { name: /explain/i }));
     expect(onSendMessage).toHaveBeenCalledWith("", "explain");
+  });
+
+  it("does not send animate messages through the chat", async () => {
+    const onSendMessage = vi.fn();
+    const user = userEvent.setup();
+    render(<AIChatPanel {...defaultProps} onSendMessage={onSendMessage} />);
+
+    expect(
+      screen.queryByRole("button", { name: /animate/i }),
+    ).not.toBeInTheDocument();
+    expect(onSendMessage).not.toHaveBeenCalled();
   });
 
   it("disables inputs when isTyping", () => {

--- a/frontend/src/components/layout/lessons/ExerciseLessonLayout.tsx
+++ b/frontend/src/components/layout/lessons/ExerciseLessonLayout.tsx
@@ -1,16 +1,20 @@
-'use client';
+"use client";
 
-import React, { useEffect, useState } from 'react';
-import { CodeEditorContainer } from '@/components/layout/elements';
-import { TestCaseResultView } from '@/features/code-execution/code-execution.types';
-import { cn } from '@/lib/utils';
-import { ChatMessage, Language, LessonSummary, Question } from '@/types';
-import { AICoachPane } from './AICoachPane';
-import { AIPanelDrawer } from './AIPanelDrawer';
-import { ExerciseDescriptionPane, ExerciseTestCase } from './ExerciseDescriptionPane';
-import { PanelResizer } from './PanelResizer';
-import { useResizablePanels } from './useResizablePanels';
-import { useWorkspaceMode } from './useWorkspaceMode';
+import React, { useEffect, useState } from "react";
+import { Sparkles } from "lucide-react";
+import { CodeEditorContainer } from "@/components/layout/elements";
+import { TestCaseResultView } from "@/features/code-execution/code-execution.types";
+import { cn } from "@/lib/utils";
+import { ChatMessage, Language, LessonSummary, Question } from "@/types";
+import { AICoachPane } from "./AICoachPane";
+import { AIPanelDrawer } from "./AIPanelDrawer";
+import {
+  ExerciseDescriptionPane,
+  ExerciseTestCase,
+} from "./ExerciseDescriptionPane";
+import { PanelResizer } from "./PanelResizer";
+import { useResizablePanels } from "./useResizablePanels";
+import { useWorkspaceMode } from "./useWorkspaceMode";
 
 interface ExerciseLessonLayoutProps {
   lesson: LessonSummary;
@@ -74,14 +78,14 @@ export function ExerciseLessonLayout({
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   useEffect(() => {
-    if (mode === 'wide' && drawerOpen) {
+    if (mode === "wide" && drawerOpen) {
       openAI();
       setDrawerOpen(false);
     }
   }, [mode, drawerOpen, openAI]);
 
-  const isWide = mode === 'wide';
-  const isStacked = mode === 'stacked';
+  const isWide = mode === "wide";
+  const isStacked = mode === "stacked";
   const showSideColumn = isWide && isAIOpen;
   const showDrawer = !isWide && drawerOpen;
 
@@ -103,7 +107,7 @@ export function ExerciseLessonLayout({
         workspaceRef.current = el;
         modeRef(el);
       }}
-      className={cn('flex-1 flex min-h-0 relative', isStacked && 'flex-col')}
+      className={cn("flex-1 flex min-h-0 relative", isStacked && "flex-col")}
       data-testid="exercise-layout-workspace"
     >
       {isDragging && (
@@ -156,9 +160,9 @@ export function ExerciseLessonLayout({
           <PanelResizer
             boundary="description"
             label="Resize lesson description"
-            onMouseDown={startDrag('description')}
+            onMouseDown={startDrag("description")}
             onResizeBy={resizeBy}
-            isActive={activeBoundary === 'description'}
+            isActive={activeBoundary === "description"}
           />
 
           <div className="flex-1 min-w-0 flex flex-col min-h-0">
@@ -185,9 +189,9 @@ export function ExerciseLessonLayout({
           <PanelResizer
             boundary="ai"
             label="Resize AI coach panel"
-            onMouseDown={startDrag('ai')}
+            onMouseDown={startDrag("ai")}
             onResizeBy={resizeBy}
-            isActive={activeBoundary === 'ai'}
+            isActive={activeBoundary === "ai"}
           />
           <div
             data-testid="ai-pane"
@@ -201,15 +205,16 @@ export function ExerciseLessonLayout({
         !showDrawer && (
           <div
             className={`flex flex-col items-center justify-center p-4 ${
-              isStacked ? 'absolute bottom-4 right-4 z-30' : ''
+              isStacked ? "absolute bottom-4 right-4 z-30" : ""
             }`}
           >
             <button
               onClick={() => (isWide ? openAI() : setDrawerOpen(true))}
-              className="p-3 bg-white/[0.05] hover:bg-white/[0.08] rounded-full transition-all"
               aria-label="Open AI Panel"
+              className="inline-flex items-center gap-2 rounded-full bg-white/[0.05] hover:bg-white/[0.08] px-4 py-2 text-xs font-medium text-muted-foreground/70 hover:text-foreground ring-1 ring-white/[0.06] transition-all active:scale-[0.97]"
             >
-              <div className="w-5 h-5 bg-primary/60 rounded-full" />
+              <Sparkles className="h-3.5 w-3.5 text-primary/70" />
+              Ask Coach
             </button>
           </div>
         )

--- a/frontend/src/components/layout/lessons/LessonChrome.tsx
+++ b/frontend/src/components/layout/lessons/LessonChrome.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { ReactNode } from 'react';
 import { ArrowLeft, ArrowRight, BookOpen, Code } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { LessonSummary } from '@/types';
@@ -7,9 +8,15 @@ interface LessonChromeProps {
   lesson: LessonSummary;
   prevId: string | null;
   nextId: string | null;
+  actions?: ReactNode;
 }
 
-export function LessonChrome({ lesson, prevId, nextId }: LessonChromeProps) {
+export function LessonChrome({
+  lesson,
+  prevId,
+  nextId,
+  actions,
+}: LessonChromeProps) {
   const isExercise = lesson.type === 'exercise';
 
   return (
@@ -52,6 +59,7 @@ export function LessonChrome({ lesson, prevId, nextId }: LessonChromeProps) {
       </div>
 
       <div className="flex items-center gap-1">
+        {actions}
         {prevId && (
           <Link
             href={`/learn/lesson/${prevId}`}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-4xl translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border border-border bg-background p-4 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-3 top-3 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-sm font-semibold leading-none tracking-wide",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-xs text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/frontend/src/components/visualization/AnimationScriptRenderer.test.tsx
+++ b/frontend/src/components/visualization/AnimationScriptRenderer.test.tsx
@@ -97,6 +97,76 @@ describe("AnimationScriptRenderer", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders a code comparison animation with user and solution code", () => {
+    const comparison: AnimationScript = {
+      type: "code_comparison",
+      title: "Your code vs the solution",
+      data: {
+        language: "python",
+        user_code: ["def find(nums, target):", "    return nums.index(target)"],
+        solution_code: [
+          "def find(nums, target):",
+          "    for i, n in enumerate(nums):",
+          "        if n == target:",
+          "            return i",
+        ],
+      },
+      steps: [
+        {
+          operation: "compare_code",
+          line_number: 2,
+          user_line: "    return nums.index(target)",
+          solution_line: "    for i, n in enumerate(nums):",
+          result: "mismatch",
+          narration: "You return immediately, but the solution scans each element.",
+        },
+      ],
+    };
+    render(<AnimationScriptRenderer script={comparison} />);
+    expect(screen.getByText("Your code vs the solution")).toBeInTheDocument();
+    expect(screen.getByText("Your code")).toBeInTheDocument();
+    expect(screen.getByText("Solution code")).toBeInTheDocument();
+    expect(
+      screen.getByText("You return immediately, but the solution scans each element."),
+    ).toBeInTheDocument();
+  });
+
+  it("highlights the active comparison line in the code comparison", () => {
+    const comparison: AnimationScript = {
+      type: "code_comparison",
+      title: "Your code vs the solution",
+      data: {
+        language: "python",
+        user_code: ["def find(nums, target):", "    return nums.index(target)"],
+        solution_code: [
+          "def find(nums, target):",
+          "    for i, n in enumerate(nums):",
+        ],
+      },
+      steps: [
+        {
+          operation: "compare_code",
+          line_number: 2,
+          user_line: "    return nums.index(target)",
+          solution_line: "    for i, n in enumerate(nums):",
+          result: "mismatch",
+          narration: "Different approach.",
+        },
+      ],
+    };
+    const { container } = render(
+      <AnimationScriptRenderer script={comparison} />,
+    );
+    const active = container.querySelectorAll("[data-active-line='true']");
+    expect(active).toHaveLength(2);
+    const text = Array.from(active).map((node) => node.textContent ?? "");
+    expect(text.join(" ")).toContain("    return nums.index(target)");
+    expect(text.join(" ")).toContain("    for i, n in enumerate(nums):");
+    active.forEach((node) => {
+      expect(node.textContent).not.toContain("def find");
+    });
+  });
+
   it("renders a plain trace for unsupported animation types", () => {
     const unknown: AnimationScript = {
       type: "quantum_sort",

--- a/frontend/src/components/visualization/AnimationScriptRenderer.tsx
+++ b/frontend/src/components/visualization/AnimationScriptRenderer.tsx
@@ -4,6 +4,7 @@ import { ComponentType } from "react";
 import { AnimationScript, AnimationStep } from "@/types";
 import { AnimationPlayer } from "./AnimationPlayer";
 import { LinearSearchVisualizer } from "./LinearSearchVisualizer";
+import { CodeComparisonVisualizer } from "./CodeComparisonVisualizer";
 
 export interface VisualizerProps {
   script: AnimationScript;
@@ -13,6 +14,7 @@ export interface VisualizerProps {
 
 const VISUALIZERS: Record<string, ComponentType<VisualizerProps>> = {
   linear_search: LinearSearchVisualizer,
+  code_comparison: CodeComparisonVisualizer,
 };
 
 function FallbackTrace({ script }: { script: AnimationScript }) {
@@ -35,7 +37,7 @@ export function AnimationScriptRenderer({ script }: { script: AnimationScript })
   const steps = Array.isArray(script?.steps) ? script.steps : [];
   if (steps.length === 0) return null;
 
-  const Visualizer = VISUALIZERS[script.type];
+  const Visualizer = script.type ? VISUALIZERS[script.type] : undefined;
   if (!Visualizer) return <FallbackTrace script={script} />;
 
   return (

--- a/frontend/src/components/visualization/CodeComparisonVisualizer.tsx
+++ b/frontend/src/components/visualization/CodeComparisonVisualizer.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { AnimationScript, AnimationStep } from "@/types";
+import { cn } from "@/lib/utils";
+
+interface CodeComparisonVisualizerProps {
+  script: AnimationScript;
+  step: AnimationStep;
+  stepIndex: number;
+}
+
+function CodeColumn({
+  label,
+  lines,
+  activeLine,
+  isMatch,
+  isMismatch,
+}: {
+  label: string;
+  lines: string[];
+  activeLine: number | null;
+  isMatch: boolean;
+  isMismatch: boolean;
+}) {
+  const lineClass = (index: number) => {
+    if (index !== activeLine) {
+      return "border-transparent text-muted-foreground/60";
+    }
+    if (isMatch) {
+      return "border-emerald-500/50 bg-emerald-500/10 text-emerald-300";
+    }
+    if (isMismatch) {
+      return "border-destructive/50 bg-destructive/10 text-destructive-foreground/90";
+    }
+    return "border-primary/40 bg-primary/10 text-foreground/90";
+  };
+
+  return (
+    <div className="flex-1 min-w-0">
+      <div className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground/50">
+        {label}
+      </div>
+      <pre className="max-h-48 overflow-y-auto overflow-x-auto rounded-lg border border-white/[0.06] bg-black/20 p-3 font-mono text-xs leading-5">
+        {lines.map((line, i) => (
+          <div
+            key={i}
+            data-active-line={i === activeLine ? "true" : "false"}
+            className={cn(
+              "whitespace-pre border-l-2 py-px pl-2 transition-colors",
+              lineClass(i),
+            )}
+          >
+            <span className="mr-3 select-none tabular-nums text-muted-foreground/30">
+              {i + 1}
+            </span>
+            {line || " "}
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}
+
+export function CodeComparisonVisualizer({
+  script,
+  step,
+}: CodeComparisonVisualizerProps) {
+  const data = script.data ?? {};
+  const userCode = Array.isArray(data.user_code)
+    ? (data.user_code as string[])
+    : [];
+  const solutionCode = Array.isArray(data.solution_code)
+    ? (data.solution_code as string[])
+    : [];
+  const activeLine =
+    typeof step.line_number === "number" ? step.line_number - 1 : null;
+  const isMatch = step.result === "match";
+  const isMismatch = step.result === "mismatch";
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-white/[0.06] bg-white/[0.02] p-4">
+      <div className="flex items-center justify-between">
+        <span className="inline-flex items-center rounded-full bg-white/[0.05] px-2.5 py-1 text-xs font-medium text-foreground/80">
+          {script.title || "Your code vs the solution"}
+        </span>
+        {isMismatch && (
+          <span className="text-[10px] text-destructive/80">
+            Differs from the solution
+          </span>
+        )}
+        {isMatch && (
+          <span className="text-[10px] text-emerald-300/80">
+            Matches the solution
+          </span>
+        )}
+      </div>
+
+      <div className="flex gap-3">
+        <CodeColumn
+          label="Your code"
+          lines={userCode}
+          activeLine={activeLine}
+          isMatch={isMatch}
+          isMismatch={isMismatch}
+        />
+        <CodeColumn
+          label="Solution code"
+          lines={solutionCode}
+          activeLine={activeLine}
+          isMatch={isMatch}
+          isMismatch={isMismatch}
+        />
+      </div>
+
+      <p
+        aria-live="polite"
+        className="text-xs leading-relaxed text-muted-foreground/70"
+      >
+        {step.narration}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/visualization/index.ts
+++ b/frontend/src/components/visualization/index.ts
@@ -1,4 +1,5 @@
 export { AnimationPlayer } from "./AnimationPlayer";
 export { AnimationScriptRenderer } from "./AnimationScriptRenderer";
 export { LinearSearchVisualizer } from "./LinearSearchVisualizer";
+export { CodeComparisonVisualizer } from "./CodeComparisonVisualizer";
 export type { VisualizerProps } from "./AnimationScriptRenderer";

--- a/frontend/src/features/animation/animation.service.ts
+++ b/frontend/src/features/animation/animation.service.ts
@@ -1,0 +1,68 @@
+import { HttpClient } from "@/lib/http-client";
+import { FetchClient } from "@/lib/fetch-client";
+import { AnimationScript, Question } from "@/types";
+
+export interface AnimateQuestionInput {
+  id?: string;
+  title?: string;
+  description?: string;
+  category?: string;
+  difficulty?: string;
+  examples?: unknown[];
+  test_cases?: unknown[];
+  constraints?: string[];
+  starter?: unknown;
+}
+
+export interface GenerateAnimationRequest {
+  problem: string;
+  code: string;
+  language: string;
+  difficulty?: string;
+  lessonContext?: string;
+  initialCode?: string;
+  question?: AnimateQuestionInput;
+}
+
+function toQuestionInput(question: Question): AnimateQuestionInput {
+  return {
+    id: question.id,
+    title: question.title,
+    description: question.description,
+    category: question.category,
+    difficulty: question.difficulty,
+    examples: question.examples,
+    test_cases: question.test_cases,
+    starter: question.starter,
+  };
+}
+
+export class AnimationService {
+  constructor(private http: HttpClient) {}
+
+  async generateAnimation(
+    request: GenerateAnimationRequest,
+  ): Promise<AnimationScript> {
+    const data = await this.http.post<{ animation: AnimationScript }>(
+      "/api/coach/animate",
+      {
+        problem: request.problem,
+        code: request.code,
+        language: request.language.toLowerCase(),
+        difficulty: request.difficulty ?? "medium",
+        lesson_context: request.lessonContext,
+        initial_code: request.initialCode,
+        question: request.question ?? null,
+      },
+    );
+    return data.animation;
+  }
+}
+
+export function buildAnimateQuestion(
+  question?: Question | null,
+): AnimateQuestionInput | undefined {
+  return question ? toQuestionInput(question) : undefined;
+}
+
+export const animationService = new AnimationService(new FetchClient());

--- a/frontend/src/features/coaching/coaching.hook.ts
+++ b/frontend/src/features/coaching/coaching.hook.ts
@@ -37,6 +37,7 @@ export function useCoaching(): CoachingFeature {
       language: string,
       lessonContext?: string,
       difficulty?: string,
+      initialCode?: string,
     ) => {
       const userMessage: ChatMessage = {
         id: Date.now().toString(),
@@ -67,6 +68,7 @@ export function useCoaching(): CoachingFeature {
             difficulty || "medium",
             lessonContext,
             chatHistory,
+            initialCode,
           );
 
           const assistantMessage: ChatMessage = {

--- a/frontend/src/features/coaching/coaching.service.test.ts
+++ b/frontend/src/features/coaching/coaching.service.test.ts
@@ -74,6 +74,53 @@ describe('CoachingService', () => {
       expect(result.structured).toBeNull();
     });
 
+    it('passes initial_code when provided', async () => {
+      vi.mocked(http.post).mockResolvedValue({
+        response: 'Animating your code',
+        structured: null,
+      });
+
+      await service.getCoachResponse(
+        defaultArgs.problem,
+        defaultArgs.language,
+        defaultArgs.code,
+        defaultArgs.message,
+        'animate',
+        defaultArgs.difficulty,
+        undefined,
+        undefined,
+        'def two_sum(nums, target):\n    pass',
+      );
+
+      expect(http.post).toHaveBeenCalledWith(
+        '/api/coach/',
+        expect.objectContaining({
+          mode: 'animate',
+          initial_code: 'def two_sum(nums, target):\n    pass',
+        }),
+      );
+    });
+
+    it('omits initial_code when not provided', async () => {
+      vi.mocked(http.post).mockResolvedValue({
+        response: 'Ok',
+        structured: null,
+      });
+
+      await service.getCoachResponse(
+        defaultArgs.problem,
+        defaultArgs.language,
+        defaultArgs.code,
+        defaultArgs.message,
+        defaultArgs.mode,
+        defaultArgs.difficulty,
+      );
+
+      expect(vi.mocked(http.post).mock.calls[0][1]).not.toHaveProperty(
+        'initial_code',
+      );
+    });
+
     it('defaults difficulty to medium', async () => {
       vi.mocked(http.post).mockResolvedValue({
         response: 'Okay',

--- a/frontend/src/features/coaching/coaching.service.ts
+++ b/frontend/src/features/coaching/coaching.service.ts
@@ -11,6 +11,7 @@ export interface CoachingRequest {
   difficulty?: string;
   lesson_context?: string;
   chat_history?: { role: string; content: string }[];
+  initial_code?: string;
 }
 
 export interface CoachingResponse {
@@ -30,6 +31,7 @@ export class CoachingService {
     difficulty: string = "medium",
     lessonContext?: string,
     chatHistory?: { role: string; content: string }[],
+    initialCode?: string,
   ): Promise<CoachingResponse> {
     const body: CoachingRequest = {
       problem,
@@ -44,6 +46,9 @@ export class CoachingService {
     }
     if (chatHistory && chatHistory.length > 0) {
       body.chat_history = chatHistory;
+    }
+    if (initialCode !== undefined) {
+      body.initial_code = initialCode;
     }
     const data = await this.http.post<{
       response: string;

--- a/frontend/src/features/coaching/coaching.types.ts
+++ b/frontend/src/features/coaching/coaching.types.ts
@@ -1,6 +1,12 @@
 import { StructuredCoachingResponse, ChatMessage } from "@/types";
 
-export type CoachingMode = "hint" | "review" | "explain" | "debug" | "freeform";
+export type CoachingMode =
+  | "hint"
+  | "review"
+  | "explain"
+  | "debug"
+  | "freeform"
+  | "animate";
 
 export interface CoachingRequest {
   problem: string;
@@ -9,6 +15,7 @@ export interface CoachingRequest {
   message: string;
   mode: CoachingMode;
   difficulty?: string;
+  initial_code?: string;
 }
 
 export interface CoachingResponse {
@@ -32,6 +39,7 @@ export interface CoachingActions {
     language: string,
     lessonContext?: string,
     difficulty?: string,
+    initialCode?: string,
   ) => Promise<void>;
   clearMessages: () => void;
   clearError: () => void;

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -53,6 +53,31 @@ export const handlers = [
       language: "python",
     });
   }),
+  http.post("/api/coach/animate", () => {
+    return HttpResponse.json({
+      animation: {
+        type: "linear_search",
+        title: "Searching for 4",
+        data: { values: [5, 1, 2, 3, 4, 6], target: 4 },
+        steps: [
+          {
+            operation: "compare",
+            index: 0,
+            value: 5,
+            result: "mismatch",
+            narration: "5 is not the target, continue searching.",
+          },
+          {
+            operation: "compare",
+            index: 4,
+            value: 4,
+            result: "match",
+            narration: "Found the target 4 at index 4.",
+          },
+        ],
+      },
+    });
+  }),
   http.get("/health", () => {
     return HttpResponse.json({ status: "healthy" });
   }),

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -45,7 +45,8 @@ export type AnimationOperation =
   | "insert"
   | "remove"
   | "mark"
-  | "output";
+  | "output"
+  | "compare_code";
 
 export type AnimationResult =
   | "checking"
@@ -53,18 +54,62 @@ export type AnimationResult =
   | "mismatch"
   | "complete";
 
+export type SceneShapeType = "rect" | "ellipse" | "line" | "polygon" | "text";
+
+export interface SceneShape {
+  id: string;
+  type: SceneShapeType;
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  radius?: number;
+  points?: [number, number][];
+  text?: string;
+  fontSize?: number;
+  fill?: string;
+  stroke?: string;
+  lineWidth?: number;
+  opacity?: number;
+}
+
+export type MotionOpName =
+  | "appear"
+  | "disappear"
+  | "move"
+  | "fill"
+  | "stroke"
+  | "scale"
+  | "rotate"
+  | "label";
+
+export interface MotionOp {
+  target: string;
+  op: MotionOpName;
+  to?: unknown;
+  duration: number;
+}
+
 export interface AnimationStep {
-  operation: AnimationOperation;
+  // Generic scene fields (current contract)
+  narration: string;
+  shapes?: SceneShape[];
+  motion?: MotionOp[];
+  // Legacy typed-frame fields (kept optional for backward compatibility)
+  operation?: AnimationOperation | null;
   index?: number | null;
   from_index?: number | null;
   to_index?: number | null;
   value?: unknown;
+  line_number?: number | null;
+  user_line?: string | null;
+  solution_line?: string | null;
   result?: AnimationResult | null;
-  narration: string;
 }
 
 export interface AnimationScript {
-  type: string;
+  // `type` is legacy; the current contract is a generic declarative scene.
+  type?: string;
   title?: string;
   data: Record<string, unknown>;
   steps: AnimationStep[];

--- a/motion-canvas-lab/.gitignore
+++ b/motion-canvas-lab/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+output/
+.vite/
+*.log

--- a/motion-canvas-lab/package.json
+++ b/motion-canvas-lab/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "codecoach-motion-canvas-lab",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Isolated Motion Canvas playground for experimenting with algorithm animations. Completely independent of the CodeCoach frontend app.",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@motion-canvas/2d": "^3.17.2",
+    "@motion-canvas/core": "^3.17.2",
+    "@motion-canvas/ffmpeg": "^3.17.2",
+    "@motion-canvas/ui": "^3.17.2"
+  },
+  "devDependencies": {
+    "@motion-canvas/vite-plugin": "^3.17.2",
+    "typescript": "^5.6.3",
+    "vite": "^6.0.7"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "@ffmpeg-installer/linux-x64",
+      "@ffprobe-installer/linux-x64"
+    ]
+  }
+}

--- a/motion-canvas-lab/pnpm-lock.yaml
+++ b/motion-canvas-lab/pnpm-lock.yaml
@@ -1,0 +1,1308 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@motion-canvas/2d':
+        specifier: ^3.17.2
+        version: 3.17.2
+      '@motion-canvas/core':
+        specifier: ^3.17.2
+        version: 3.17.2
+      '@motion-canvas/ffmpeg':
+        specifier: ^3.17.2
+        version: 3.17.2(vite@6.4.3)
+      '@motion-canvas/ui':
+        specifier: ^3.17.2
+        version: 3.17.2
+    devDependencies:
+      '@motion-canvas/vite-plugin':
+        specifier: ^3.17.2
+        version: 3.17.2(vite@6.4.3)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.7
+        version: 6.4.3
+
+packages:
+
+  '@codemirror/language@6.12.4':
+    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+
+  '@codemirror/state@6.7.1':
+    resolution: {integrity: sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==}
+
+  '@codemirror/view@6.43.8':
+    resolution: {integrity: sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ffmpeg-installer/darwin-arm64@4.1.5':
+    resolution: {integrity: sha512-hYqTiP63mXz7wSQfuqfFwfLOfwwFChUedeCVKkBtl/cliaTM7/ePI9bVzfZ2c+dWu3TqCwLDRWNSJ5pqZl8otA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ffmpeg-installer/darwin-x64@4.1.0':
+    resolution: {integrity: sha512-Z4EyG3cIFjdhlY8wI9aLUXuH8nVt7E9SlMVZtWvSPnm2sm37/yC2CwjUzyCQbJbySnef1tQwGG2Sx+uWhd9IAw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ffmpeg-installer/ffmpeg@1.1.0':
+    resolution: {integrity: sha512-Uq4rmwkdGxIa9A6Bd/VqqYbT7zqh1GrT5/rFwCwKM70b42W5gIjWeVETq6SdcL0zXqDtY081Ws/iJWhr1+xvQg==}
+
+  '@ffmpeg-installer/linux-arm64@4.1.4':
+    resolution: {integrity: sha512-dljEqAOD0oIM6O6DxBW9US/FkvqvQwgJ2lGHOwHDDwu/pX8+V0YsDL1xqHbj1DMX/+nP9rxw7G7gcUvGspSoKg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ffmpeg-installer/linux-arm@4.1.3':
+    resolution: {integrity: sha512-NDf5V6l8AfzZ8WzUGZ5mV8O/xMzRag2ETR6+TlGIsMHp81agx51cqpPItXPib/nAZYmo55Bl2L6/WOMI3A5YRg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@ffmpeg-installer/linux-ia32@4.1.0':
+    resolution: {integrity: sha512-0LWyFQnPf+Ij9GQGD034hS6A90URNu9HCtQ5cTqo5MxOEc7Rd8gLXrJvn++UmxhU0J5RyRE9KRYstdCVUjkNOQ==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@ffmpeg-installer/linux-x64@4.1.0':
+    resolution: {integrity: sha512-Y5BWhGLU/WpQjOArNIgXD3z5mxxdV8c41C+U15nsE5yF8tVcdCGet5zPs5Zy3Ta6bU7haGpIzryutqCGQA/W8A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@ffmpeg-installer/win32-ia32@4.1.0':
+    resolution: {integrity: sha512-FV2D7RlaZv/lrtdhaQ4oETwoFUsUjlUiasiZLDxhEUPdNDWcH1OU9K1xTvqz+OXLdsmYelUDuBS/zkMOTtlUAw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ffmpeg-installer/win32-x64@4.1.0':
+    resolution: {integrity: sha512-Drt5u2vzDnIONf4ZEkKtFlbvwj6rI3kxw1Ck9fpudmtgaZIHD4ucsWB2lCZBXRxJgXR+2IMSti+4rtM4C4rXgg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@ffprobe-installer/darwin-arm64@5.0.1':
+    resolution: {integrity: sha512-vwNCNjokH8hfkbl6m95zICHwkSzhEvDC3GVBcUp5HX8+4wsX10SP3B+bGur7XUzTIZ4cQpgJmEIAx6TUwRepMg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ffprobe-installer/darwin-x64@5.1.0':
+    resolution: {integrity: sha512-J+YGscZMpQclFg31O4cfVRGmDpkVsQ2fZujoUdMAAYcP0NtqpC49Hs3SWJpBdsGB4VeqOt5TTm1vSZQzs1NkhA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ffprobe-installer/ffprobe@2.1.2':
+    resolution: {integrity: sha512-ZNvwk4f2magF42Zji2Ese16SMj9BS7Fui4kRjg6gTYTxY3gWZNpg85n4MIfQyI9nimHg4x/gT6FVkp/bBDuBwg==}
+    engines: {node: '>=14.21.2'}
+
+  '@ffprobe-installer/linux-arm64@5.2.0':
+    resolution: {integrity: sha512-X1VvWtlLs6ScP73biVLuHD5ohKJKsMTa0vafCESOen4mOoNeLAYbxOVxDWAdFz9cpZgRiloFj5QD6nDj8E28yQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ffprobe-installer/linux-arm@5.2.0':
+    resolution: {integrity: sha512-PF5HqEhCY7WTWHtLDYbA/+rLS+rhslWvyBlAG1Fk8VzVlnRdl93o6hy7DE2kJgxWQbFaR3ZktPQGEzfkrmQHvQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@ffprobe-installer/linux-ia32@5.2.0':
+    resolution: {integrity: sha512-TFVK5sasXyXhbIG7LtPRDmtkrkOsInwKcL43iEvEw+D9vCS2rc//mn9/0Q+BR0UoJEiMK4+ApYr/3LLVUBPOCQ==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@ffprobe-installer/linux-x64@5.2.0':
+    resolution: {integrity: sha512-D3UeqTLYPNs7pBWPLUYGehPdRVqU8eACox4OZy3pZUZatxye2YKlvBwEfaLdL1v2Z4FOAlLUhms0kY8m8kqSRA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@ffprobe-installer/win32-ia32@5.1.0':
+    resolution: {integrity: sha512-5O3vOoNRxmut0/Nu9vSazTdSHasrr+zPT2B3Hm7kjmO3QVFcIfVImS6ReQnZeSy8JPJOqXts5kX5x/3KOX54XQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ffprobe-installer/win32-x64@5.1.0':
+    resolution: {integrity: sha512-jMGYeAgkrdn4e2vvYt/qakgHRE3CPju4bn5TmdPfoAm1BlX1mY9cyMd8gf5vSzI8gH8Zq5WQAyAkmekX/8TSTg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@marijn/find-cluster-break@1.0.3':
+    resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
+
+  '@motion-canvas/2d@3.17.2':
+    resolution: {integrity: sha512-Q2DMYSmJMTN8vvLcpofHEMuYEjx60z4hjlwbWJnWx3xnb7DU5suovJ47qM2sk46al/RDXJIz6rfALTr33brKaw==}
+
+  '@motion-canvas/core@3.17.2':
+    resolution: {integrity: sha512-9M4NxNVR9LLxZ+ykTznMcbMlKjbe2NkmDIlFDl2uOyVkK5wFiRwF7k13a1I/n3BVxJJoKPt9UOQF/wn3LrBXJA==}
+
+  '@motion-canvas/ffmpeg@3.17.2':
+    resolution: {integrity: sha512-D4Q8ZTa45zRnNsi5V0MKLOsY3wndfUkHh/DPrMS6ffDDxkmaEFmIpDaOgM9x7N341ECkUDHxy0VSYUnAXjsxog==}
+
+  '@motion-canvas/ui@3.17.2':
+    resolution: {integrity: sha512-gbsdbFP60IhgckZei7NDuqQWekfLX+mUjyYpAEOe4OZSyIhoavZo+jako+liD9E7+dYu67E9YRjT+/BesLV7Pg==}
+
+  '@motion-canvas/vite-plugin@3.17.2':
+    resolution: {integrity: sha512-7XrGFoyS6XWdvQN9J6Ch8ehLWD3eBX+sv4L6xxH5As5kF5YA+1MAPZ+QxMNUCcW0tp1VjE+rQkQWsZfXa7BR/g==}
+    peerDependencies:
+      vite: 4.x || 5.x
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@preact/signals-core@1.14.4':
+    resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
+
+  '@preact/signals@1.3.4':
+    resolution: {integrity: sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==}
+    peerDependencies:
+      preact: 10.x
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chroma-js@2.4.4':
+    resolution: {integrity: sha512-/DTccpHTaKomqussrn+ciEvfW4k6NAHzNzs/sts1TCqg333qNxOhy8TNIoQCmbGG3Tl8KdEhkGAssb1n3mTXiQ==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/hast@2.3.10':
+    resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@wooorm/starry-night@1.7.0':
+    resolution: {integrity: sha512-ktO0nkddrovIoNW2jAUT+Cdd9n1bWjy1Ir4CdcmgTaT6E94HLlQfu7Yv62falclBEwvsuVp3bSBw23wtta1fNw==}
+
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
+
+  async@0.2.10:
+    resolution: {integrity: sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  chroma-js@2.4.2:
+    resolution: {integrity: sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A==}
+
+  code-fns@0.8.2:
+    resolution: {integrity: sha512-3VVeq3cnWxWiWKFLsVo+XWsOXBSW2gAx2uv0ViETLNmNuygEPHlCeDAv/Zy7xXqPgXtgLZyvIJZmx+ojTgOIGA==}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esm@3.2.25:
+    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
+    engines: {node: '>=6'}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  fluent-ffmpeg@2.1.3:
+    resolution: {integrity: sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==}
+    engines: {node: '>=18'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  import-meta-resolve@2.2.2:
+    resolution: {integrity: sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  mathjax-full@3.2.2:
+    resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
+    deprecated: Version 4 replaces this package with the scoped package @mathjax/src
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  mhchemparser@4.2.1:
+    resolution: {integrity: sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mj-context-menu@0.6.1:
+    resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  parse-svg-path@0.1.2:
+    resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  speech-rule-engine@4.1.4:
+    resolution: {integrity: sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==}
+    hasBin: true
+
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vscode-oniguruma@1.7.0:
+    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
+
+  vscode-textmate@9.3.2:
+    resolution: {integrity: sha512-n2uGbUcrjhUEBH16uGA0TvUfhWwliFZ1e3+pTjrkim1Mt7ydB41lV08aUvsi70OlzDWp6X7Bx3w/x3fAXIsN0Q==}
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
+  wicked-good-xpath@1.3.0:
+    resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
+
+snapshots:
+
+  '@codemirror/language@6.12.4':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.8
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/state@6.7.1':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.3
+
+  '@codemirror/view@6.43.8':
+    dependencies:
+      '@codemirror/state': 6.7.1
+      crelt: 1.0.7
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@ffmpeg-installer/darwin-arm64@4.1.5':
+    optional: true
+
+  '@ffmpeg-installer/darwin-x64@4.1.0':
+    optional: true
+
+  '@ffmpeg-installer/ffmpeg@1.1.0':
+    optionalDependencies:
+      '@ffmpeg-installer/darwin-arm64': 4.1.5
+      '@ffmpeg-installer/darwin-x64': 4.1.0
+      '@ffmpeg-installer/linux-arm': 4.1.3
+      '@ffmpeg-installer/linux-arm64': 4.1.4
+      '@ffmpeg-installer/linux-ia32': 4.1.0
+      '@ffmpeg-installer/linux-x64': 4.1.0
+      '@ffmpeg-installer/win32-ia32': 4.1.0
+      '@ffmpeg-installer/win32-x64': 4.1.0
+
+  '@ffmpeg-installer/linux-arm64@4.1.4':
+    optional: true
+
+  '@ffmpeg-installer/linux-arm@4.1.3':
+    optional: true
+
+  '@ffmpeg-installer/linux-ia32@4.1.0':
+    optional: true
+
+  '@ffmpeg-installer/linux-x64@4.1.0':
+    optional: true
+
+  '@ffmpeg-installer/win32-ia32@4.1.0':
+    optional: true
+
+  '@ffmpeg-installer/win32-x64@4.1.0':
+    optional: true
+
+  '@ffprobe-installer/darwin-arm64@5.0.1':
+    optional: true
+
+  '@ffprobe-installer/darwin-x64@5.1.0':
+    optional: true
+
+  '@ffprobe-installer/ffprobe@2.1.2':
+    optionalDependencies:
+      '@ffprobe-installer/darwin-arm64': 5.0.1
+      '@ffprobe-installer/darwin-x64': 5.1.0
+      '@ffprobe-installer/linux-arm': 5.2.0
+      '@ffprobe-installer/linux-arm64': 5.2.0
+      '@ffprobe-installer/linux-ia32': 5.2.0
+      '@ffprobe-installer/linux-x64': 5.2.0
+      '@ffprobe-installer/win32-ia32': 5.1.0
+      '@ffprobe-installer/win32-x64': 5.1.0
+
+  '@ffprobe-installer/linux-arm64@5.2.0':
+    optional: true
+
+  '@ffprobe-installer/linux-arm@5.2.0':
+    optional: true
+
+  '@ffprobe-installer/linux-ia32@5.2.0':
+    optional: true
+
+  '@ffprobe-installer/linux-x64@5.2.0':
+    optional: true
+
+  '@ffprobe-installer/win32-ia32@5.1.0':
+    optional: true
+
+  '@ffprobe-installer/win32-x64@5.1.0':
+    optional: true
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@marijn/find-cluster-break@1.0.3': {}
+
+  '@motion-canvas/2d@3.17.2':
+    dependencies:
+      '@codemirror/language': 6.12.4
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@motion-canvas/core': 3.17.2
+      code-fns: 0.8.2
+      mathjax-full: 3.2.2
+      parse-svg-path: 0.1.2
+
+  '@motion-canvas/core@3.17.2':
+    dependencies:
+      '@types/chroma-js': 2.4.4
+      chroma-js: 2.4.2
+
+  '@motion-canvas/ffmpeg@3.17.2(vite@6.4.3)':
+    dependencies:
+      '@ffmpeg-installer/ffmpeg': 1.1.0
+      '@ffprobe-installer/ffprobe': 2.1.2
+      '@motion-canvas/core': 3.17.2
+      '@motion-canvas/vite-plugin': 3.17.2(vite@6.4.3)
+      fluent-ffmpeg: 2.1.3
+    transitivePeerDependencies:
+      - debug
+      - vite
+
+  '@motion-canvas/ui@3.17.2':
+    dependencies:
+      '@motion-canvas/core': 3.17.2
+      '@preact/signals': 1.3.4(preact@10.29.8)
+      preact: 10.29.8
+    transitivePeerDependencies:
+      - preact-render-to-string
+
+  '@motion-canvas/vite-plugin@3.17.2(vite@6.4.3)':
+    dependencies:
+      fast-glob: 3.3.3
+      follow-redirects: 1.16.0
+      mime-types: 2.1.35
+      source-map: 0.6.1
+      vite: 6.4.3
+    transitivePeerDependencies:
+      - debug
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@preact/signals-core@1.14.4': {}
+
+  '@preact/signals@1.3.4(preact@10.29.8)':
+    dependencies:
+      '@preact/signals-core': 1.14.4
+      preact: 10.29.8
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
+
+  '@types/chroma-js@2.4.4': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/hast@2.3.10':
+    dependencies:
+      '@types/unist': 2.0.11
+
+  '@types/unist@2.0.11': {}
+
+  '@wooorm/starry-night@1.7.0':
+    dependencies:
+      '@types/hast': 2.3.10
+      import-meta-resolve: 2.2.2
+      vscode-oniguruma: 1.7.0
+      vscode-textmate: 9.3.2
+
+  '@xmldom/xmldom@0.9.10': {}
+
+  async@0.2.10: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  chroma-js@2.4.2: {}
+
+  code-fns@0.8.2:
+    dependencies:
+      '@wooorm/starry-night': 1.7.0
+
+  commander@13.1.0: {}
+
+  crelt@1.0.7: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  esm@3.2.25: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  fluent-ffmpeg@2.1.3:
+    dependencies:
+      async: 0.2.10
+      which: 1.3.1
+
+  follow-redirects@1.16.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  import-meta-resolve@2.2.2: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  isexe@2.0.0: {}
+
+  mathjax-full@3.2.2:
+    dependencies:
+      esm: 3.2.25
+      mhchemparser: 4.2.1
+      mj-context-menu: 0.6.1
+      speech-rule-engine: 4.1.4
+
+  merge2@1.4.1: {}
+
+  mhchemparser@4.2.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mj-context-menu@0.6.1: {}
+
+  nanoid@3.3.18: {}
+
+  parse-svg-path@0.1.2: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  preact@10.29.8: {}
+
+  queue-microtask@1.2.3: {}
+
+  reusify@1.1.0: {}
+
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.6.1: {}
+
+  speech-rule-engine@4.1.4:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
+      commander: 13.1.0
+      wicked-good-xpath: 1.3.0
+
+  style-mod@4.1.3: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  typescript@5.9.3: {}
+
+  vite@6.4.3:
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vscode-oniguruma@1.7.0: {}
+
+  vscode-textmate@9.3.2: {}
+
+  w3c-keyname@2.2.8: {}
+
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
+
+  wicked-good-xpath@1.3.0: {}

--- a/motion-canvas-lab/src/motion-canvas-env.d.ts
+++ b/motion-canvas-lab/src/motion-canvas-env.d.ts
@@ -1,0 +1,9 @@
+// Ambient module declarations for the Motion Canvas Vite plugin's virtual
+// query modules. `*?scene` is declared by @motion-canvas/core/project; the
+// `?project` loader (used by the chrome-less viewer entry) is not, so we
+// declare it here to satisfy `tsc --noEmit`.
+declare module '*?project' {
+  import type {Project} from '@motion-canvas/core';
+  const value: Project;
+  export = value;
+}

--- a/motion-canvas-lab/src/project.meta
+++ b/motion-canvas-lab/src/project.meta
@@ -1,0 +1,32 @@
+{
+  "version": 0,
+  "shared": {
+    "background": null,
+    "range": [
+      0,
+      null
+    ],
+    "size": {
+      "x": 1920,
+      "y": 1080
+    },
+    "audioOffset": 0
+  },
+  "preview": {
+    "fps": 30,
+    "resolutionScale": 1
+  },
+  "rendering": {
+    "fps": 60,
+    "resolutionScale": 1,
+    "colorSpace": "srgb",
+    "exporter": {
+      "name": "@motion-canvas/core/image-sequence",
+      "options": {
+        "fileType": "image/png",
+        "quality": 100,
+        "groupByScene": false
+      }
+    }
+  }
+}

--- a/motion-canvas-lab/src/project.ts
+++ b/motion-canvas-lab/src/project.ts
@@ -1,0 +1,8 @@
+import {makeProject} from '@motion-canvas/core';
+
+import testingPapers from './scenes/testing-papers?scene';
+import viewer from './scenes/viewer?scene';
+
+export default makeProject({
+  scenes: [viewer, testingPapers],
+});

--- a/motion-canvas-lab/src/scenes/testing-papers.meta
+++ b/motion-canvas-lab/src/scenes/testing-papers.meta
@@ -1,0 +1,5 @@
+{
+  "version": 0,
+  "timeEvents": [],
+  "seed": 2114181808
+}

--- a/motion-canvas-lab/src/scenes/testing-papers.tsx
+++ b/motion-canvas-lab/src/scenes/testing-papers.tsx
@@ -1,0 +1,208 @@
+import {makeScene2D, Rect, Txt, Polygon, Line} from '@motion-canvas/2d';
+import {all, chain, createRef, waitFor, Vector2} from '@motion-canvas/core';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TESTING PAPERS — the single file you edit while experimenting with Motion
+// Canvas. Nothing here touches the real CodeCoach app. Change the fixture data
+// below (TEST_VALUES / TEST_TARGET) or add your own scenes to play around.
+//
+// To run:
+//   cd motion-canvas-lab && pnpm install && pnpm dev
+// Then open the printed URL (default http://localhost:9000) in your browser.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TEST_VALUES = [5, 1, 2, 3, 4, 6];
+const TEST_TARGET = 4;
+
+// Pause (seconds) after each comparison so the eye can register it.
+const STEP_DELAY = 0.6;
+// One second of tween for color/scale changes.
+const TWEEN_SECONDS = 0.25;
+
+const IDLE_FILL = '#1e293b';
+const IDLE_STROKE = '#334155';
+const CHECKING_FILL = '#1d4ed8';
+const CHECKING_STROKE = '#3b82f6';
+const MISMATCH_FILL = '#7f1d1d';
+const MISMATCH_STROKE = '#ef4444';
+const MATCH_FILL = '#14532d';
+const MATCH_STROKE = '#22c55e';
+const TEXT_IDLE = '#94a3b8';
+const TEXT_ACTIVE = '#ffffff';
+
+export default makeScene2D(function* (view) {
+  view.fill('#0b0f19');
+
+  const title = createRef<Txt>();
+  const narration = createRef<Txt>();
+  const pointer = createRef<Polygon>();
+  const cells: Rect[] = [];
+  const labels: Txt[] = [];
+
+  const cellSize = new Vector2(88, 88);
+  const gap = 12;
+  const totalWidth =
+    cellsWidth(TEST_VALUES.length, cellSize.x, gap);
+  const startX = -totalWidth / 2 + cellSize.x / 2;
+
+  view.add(
+    <Txt
+      ref={title}
+      text={`Linear Search for ${TEST_TARGET}`}
+      fontSize={42}
+      fontWeight={700}
+      fill={'#e2e8f0'}
+      fontFamily={'JetBrains Mono, monospace'}
+      y={-280}
+      opacity={0}
+    />,
+  );
+
+  view.add(
+    <Txt
+      ref={narration}
+      text={''}
+      fontSize={26}
+      fill={'#94a3b8'}
+      fontFamily={'JetBrains Mono, monospace'}
+      y={260}
+      opacity={0}
+      textAlign={'center'}
+    />,
+  );
+
+  TEST_VALUES.forEach((value, index) => {
+    const x = startX + index * (cellSize.x + gap);
+    const cell = createRef<Rect>();
+    const label = createRef<Txt>();
+
+    view.add(
+      <Rect
+        ref={cell}
+        width={cellSize.x}
+        height={cellSize.y}
+        radius={12}
+        fill={IDLE_FILL}
+        stroke={IDLE_STROKE}
+        lineWidth={2}
+        x={x}
+        y={0}
+        opacity={0}
+        scale={0.6}
+      />,
+    );
+    view.add(
+      <Txt
+        ref={label}
+        text={String(value)}
+        fontSize={36}
+        fill={TEXT_IDLE}
+        fontFamily={'JetBrains Mono, monospace'}
+        x={x}
+        y={0}
+        opacity={0}
+      />,
+    );
+
+    cells.push(cell());
+    labels.push(label());
+  });
+
+  view.add(
+    <Polygon
+      ref={pointer}
+      sides={3}
+      radius={14}
+      fill={'#facc15'}
+      y={-cellSize.y / 2 - 34}
+      x={startX}
+      opacity={0}
+    />,
+  );
+
+  // Small legend line under the array.
+  view.add(
+    <Line
+      points={[
+        [-totalWidth / 2, cellSize.y / 2 + 26],
+        [totalWidth / 2, cellSize.y / 2 + 26],
+      ]}
+      stroke={'#1e293b'}
+      lineWidth={2}
+      opacity={0}
+    />,
+  );
+
+  // ── Intro ──────────────────────────────────────────────────────────────────
+  yield* all(
+    title().opacity(1, 0.5),
+    narration().opacity(1, 0.5),
+    pointer().opacity(1, 0.5),
+  );
+  yield* narration().text('We scan the array left to right, comparing each value to the target.', 0.3);
+  yield* waitFor(0.4);
+
+  // Pop in the cells.
+  yield* all(
+    ...cells.map((cell, i) => chain(waitFor(i * 0.08), cell.scale(1, TWEEN_SECONDS), cell.opacity(1, TWEEN_SECONDS))),
+    ...labels.map((label, i) => chain(waitFor(i * 0.08), label.opacity(1, TWEEN_SECONDS))),
+  );
+  yield* waitFor(0.3);
+
+  // ── Comparisons ─────────────────────────────────────────────────────────────
+  for (let i = 0; i < TEST_VALUES.length; i++) {
+    const value = TEST_VALUES[i];
+    const isMatch = value === TEST_TARGET;
+
+    yield* all(
+      pointer().position(new Vector2(startX + i * (cellSize.x + gap), pointer().position().y), 0.35),
+      narration().text(
+        `Compare index ${i} (value ${value}) against target ${TEST_TARGET}…`,
+        0.3,
+      ),
+    );
+
+    if (isMatch) {
+      yield* all(
+        cells[i].fill(MATCH_FILL, TWEEN_SECONDS),
+        cells[i].stroke(MATCH_STROKE, TWEEN_SECONDS),
+        labels[i].fill(TEXT_ACTIVE, TWEEN_SECONDS),
+      );
+      yield* narration().text('Found it! The value equals the target.', 0.3);
+      yield* waitFor(STEP_DELAY + 0.4);
+      break;
+    }
+
+    // Checking flash.
+    yield* all(
+      cells[i].fill(CHECKING_FILL, TWEEN_SECONDS),
+      cells[i].stroke(CHECKING_STROKE, TWEEN_SECONDS),
+      labels[i].fill(TEXT_ACTIVE, TWEEN_SECONDS),
+    );
+    yield* waitFor(STEP_DELAY / 2);
+
+    // Not a match → mismatch.
+    yield* all(
+      cells[i].fill(MISMATCH_FILL, TWEEN_SECONDS),
+      cells[i].stroke(MISMATCH_STROKE, TWEEN_SECONDS),
+      labels[i].fill(TEXT_ACTIVE, TWEEN_SECONDS),
+    );
+    yield* narration().text(`${value} ≠ ${TEST_TARGET} — keep going.`, 0.3);
+    yield* waitFor(STEP_DELAY);
+  }
+
+  // ── Outro ───────────────────────────────────────────────────────────────────
+  yield* narration().text('Done.', 0.3);
+  yield* waitFor(0.6);
+  yield* all(
+    ...view
+      .children()
+      .map((child) => child.opacity(0, 0.4)),
+  );
+  yield* waitFor(0.2);
+});
+
+/** Total width needed to lay out `count` cells with a fixed gap. */
+function cellsWidth(count: number, cell: number, gap: number): number {
+  return count * cell + (count - 1) * gap;
+}

--- a/motion-canvas-lab/src/scenes/viewer.meta
+++ b/motion-canvas-lab/src/scenes/viewer.meta
@@ -1,0 +1,5 @@
+{
+  "version": 0,
+  "timeEvents": [],
+  "seed": 1779360006
+}

--- a/motion-canvas-lab/src/scenes/viewer.tsx
+++ b/motion-canvas-lab/src/scenes/viewer.tsx
@@ -1,0 +1,503 @@
+import {makeScene2D, Rect, Circle, Line, Txt, View2D} from '@motion-canvas/2d';
+import {all, createRef, waitFor, Vector2, ThreadGenerator} from '@motion-canvas/core';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// VIEWER SCENE — the runtime the CodeCoach app opens in the in-app modal.
+//
+// The opener (CodeCoach Animate launcher) opens this page with ?token=<nonce>,
+// fetches an animation from /api/coach/animate, then posts it here via
+// postMessage:
+//
+//   { type: "CODECOACH_ANIMATION", token, animation }
+//
+// or on failure:
+//
+//   { type: "CODECOACH_ANIMATION_ERROR", token, message }
+//
+// The animation is a GENERIC declarative scene: vector primitives (shapes)
+// plus a per-step motion timeline. There are no animation-type or subject
+// catalogs — the model authors the subject and the algorithm visuals fresh
+// for every question, and this engine renders whatever data it receives.
+//
+// If no message arrives (e.g. the lab is opened directly), the scene falls
+// back to a small built-in demo so `pnpm dev` always shows something.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MESSAGE_TYPE = 'CODECOACH_ANIMATION';
+const ERROR_MESSAGE_TYPE = 'CODECOACH_ANIMATION_ERROR';
+const STEP_MESSAGE_TYPE = 'CODECOACH_VIEWER_STEP';
+const WAIT_TIMEOUT_MS = 5_000;
+const WAIT_TICK_MS = 200;
+
+// Broadcast the current step to the page's own DOM overlay (see
+// viewer-player.ts). The overlay renders a narration bar, a step counter and a
+// scrubber; it cannot read the scene's internal step index itself.
+function postViewerStep(state: {
+  state: 'running' | 'complete' | 'error';
+  step?: number;
+  total?: number;
+  narration?: string;
+}): void {
+  window.postMessage({type: STEP_MESSAGE_TYPE, ...state}, window.location.origin);
+}
+
+type ShapeType = 'rect' | 'ellipse' | 'line' | 'polygon' | 'text';
+
+interface SceneShape {
+  id: string;
+  type: ShapeType;
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  radius?: number;
+  points?: [number, number][];
+  text?: string;
+  fontSize?: number;
+  fill?: string;
+  stroke?: string;
+  lineWidth?: number;
+  opacity?: number;
+}
+
+type MotionOpName =
+  | 'appear'
+  | 'disappear'
+  | 'move'
+  | 'fill'
+  | 'stroke'
+  | 'scale'
+  | 'rotate'
+  | 'label';
+
+interface MotionOp {
+  target: string;
+  op: MotionOpName;
+  to?: unknown;
+  duration: number;
+}
+
+interface AnimationStepData {
+  narration?: string;
+  shapes?: SceneShape[];
+  motion?: MotionOp[];
+}
+
+interface AnimationData {
+  title?: string;
+  data?: Record<string, unknown>;
+  steps: AnimationStepData[];
+}
+
+const DEMO_ANIMATION: AnimationData = {
+  title: 'Two cars race to the target',
+  steps: [
+    {
+      narration: 'Two cars race toward the destination.',
+      shapes: [
+        {id: 'road', type: 'line', x: 0, y: 120, points: [[-900, 0], [900, 0]], stroke: '#334155', lineWidth: 8},
+        {id: 'flag_pole', type: 'line', x: 760, y: 120, points: [[0, -180], [0, 0]], stroke: '#facc15', lineWidth: 6},
+        {id: 'flag', type: 'polygon', x: 760, y: 120, points: [[0, -180], [80, -160], [0, -140]], fill: '#facc15'},
+        {id: 'car1_body', type: 'rect', x: -760, y: 60, width: 180, height: 56, radius: 14, fill: '#ef4444'},
+        {id: 'car1_cabin', type: 'polygon', x: -760, y: 60, points: [[-40, -28], [0, -70], [60, -70], [90, -28]], fill: '#7f1d1d'},
+        {id: 'car1_wheel1', type: 'ellipse', x: -830, y: 104, width: 48, height: 48, fill: '#0f172a'},
+        {id: 'car1_wheel2', type: 'ellipse', x: -690, y: 104, width: 48, height: 48, fill: '#0f172a'},
+      ],
+      motion: [
+        {target: 'road', op: 'appear', duration: 0.4},
+        {target: 'flag_pole', op: 'appear', duration: 0.4},
+        {target: 'flag', op: 'appear', duration: 0.4},
+        {target: 'car1_body', op: 'appear', duration: 0.4},
+        {target: 'car1_cabin', op: 'appear', duration: 0.4},
+        {target: 'car1_wheel1', op: 'appear', duration: 0.4},
+        {target: 'car1_wheel2', op: 'appear', duration: 0.4},
+      ],
+    },
+    {
+      narration: 'The red car pulls ahead.',
+      shapes: [
+        {id: 'car2_body', type: 'rect', x: -760, y: 190, width: 180, height: 56, radius: 14, fill: '#3b82f6'},
+        {id: 'car2_cabin', type: 'polygon', x: -760, y: 190, points: [[-40, -28], [0, -70], [60, -70], [90, -28]], fill: '#1e3a8a'},
+        {id: 'car2_wheel1', type: 'ellipse', x: -830, y: 234, width: 48, height: 48, fill: '#0f172a'},
+        {id: 'car2_wheel2', type: 'ellipse', x: -690, y: 234, width: 48, height: 48, fill: '#0f172a'},
+      ],
+      motion: [
+        {target: 'car2_body', op: 'appear', duration: 0.4},
+        {target: 'car2_cabin', op: 'appear', duration: 0.4},
+        {target: 'car2_wheel1', op: 'appear', duration: 0.4},
+        {target: 'car2_wheel2', op: 'appear', duration: 0.4},
+        {target: 'car1_body', op: 'move', to: [300, 60], duration: 2.4},
+        {target: 'car1_cabin', op: 'move', to: [300, 60], duration: 2.4},
+        {target: 'car1_wheel1', op: 'move', to: [230, 104], duration: 2.4},
+        {target: 'car1_wheel2', op: 'move', to: [370, 104], duration: 2.4},
+      ],
+    },
+    {
+      narration: 'The blue car catches up.',
+      motion: [
+        {target: 'car2_body', op: 'move', to: [480, 190], duration: 3.0},
+        {target: 'car2_cabin', op: 'move', to: [480, 190], duration: 3.0},
+        {target: 'car2_wheel1', op: 'move', to: [410, 234], duration: 3.0},
+        {target: 'car2_wheel2', op: 'move', to: [550, 234], duration: 3.0},
+      ],
+    },
+  ],
+};
+
+let receivedAnimation: AnimationData | null = null;
+let receivedError: string | null = null;
+
+// Register the message bridge at module scope (not on the first playback tick).
+// The CodeCoach app posts the animation as soon as the viewer iframe fires its
+// `load` event, which can beat the scene generator's first frame — registering
+// here guarantees the payload is never missed.
+const token = new URLSearchParams(window.location.search).get('token');
+setupMessageBridge(token);
+
+function setupMessageBridge(token: string | null): void {
+  window.addEventListener('message', (event: MessageEvent) => {
+    const data = event.data;
+    if (!data || typeof data !== 'object') return;
+    // The animation payload only ever comes from the embedding CodeCoach app.
+    // Accept it only when a token was requested AND the sender is the parent
+    // frame; direct opens of viewer.html run the built-in demo instead.
+    if (!token) return;
+    if (event.source !== window.parent) return;
+    if (data.token !== token) return;
+    if (data.type === MESSAGE_TYPE && data.animation) {
+      receivedAnimation = data.animation as AnimationData;
+    } else if (data.type === ERROR_MESSAGE_TYPE) {
+      receivedError = typeof data.message === 'string' ? data.message : 'Failed to generate the animation.';
+    }
+  });
+}
+
+const STEP_HOLD = 0.4;
+
+function buildShapeNode(shape: SceneShape, ref: any, baseOpacity: number): any {
+  const common: Record<string, unknown> = {
+    x: shape.x ?? 0,
+    y: shape.y ?? 0,
+    fill: shape.fill,
+    stroke: shape.stroke,
+    lineWidth: shape.lineWidth,
+    opacity: baseOpacity,
+  };
+  // Rect/ellipse shapes may carry a value in their "text" field (e.g. an array
+  // cell "5"); render that label as a child so it moves/scales with the shape.
+  const label =
+    shape.text && (shape.type === 'rect' || shape.type === 'ellipse') ? (
+      <Txt
+        text={shape.text}
+        fontSize={shape.fontSize ?? 28}
+        fontFamily={'JetBrains Mono, monospace'}
+        fill={'#e2e8f0'}
+        textAlign={'center'}
+      />
+    ) : null;
+  switch (shape.type) {
+    case 'rect':
+      return (
+        <Rect
+          ref={ref}
+          width={shape.width}
+          height={shape.height}
+          radius={shape.radius}
+          {...common}
+        >
+          {label}
+        </Rect>
+      );
+    case 'ellipse':
+      return (
+        <Circle ref={ref} width={shape.width} height={shape.height} {...common}>
+          {label}
+        </Circle>
+      );
+    case 'line':
+      return <Line ref={ref} points={shape.points as any} {...common} />;
+    case 'polygon':
+      return <Line ref={ref} points={shape.points as any} closed {...common} />;
+    case 'text':
+      return (
+        <Txt
+          ref={ref}
+          text={shape.text}
+          fontSize={shape.fontSize}
+          fontFamily={'JetBrains Mono, monospace'}
+          textAlign={'center'}
+          {...common}
+        />
+      );
+  }
+}
+
+function applyMotion(node: any, op: MotionOp): any {
+  const duration = op.duration;
+  switch (op.op) {
+    case 'appear':
+      return node.opacity(1, duration);
+    case 'disappear':
+      return node.opacity(0, duration);
+    case 'move':
+      return node.position(new Vector2((op.to as [number, number])[0], (op.to as [number, number])[1]), duration);
+    case 'fill':
+      return node.fill(op.to as string, duration);
+    case 'stroke':
+      return node.stroke(op.to as string, duration);
+    case 'scale':
+      return node.scale(op.to as number, duration);
+    case 'rotate':
+      return node.rotation(op.to as number, duration);
+    case 'label':
+      if (typeof node.text === 'function') {
+        return node.text(op.to as string, duration);
+      }
+      return node.opacity(node.opacity(), 0);
+  }
+}
+
+function* renderGenericScene(
+  view: View2D,
+  animation: AnimationData,
+): ThreadGenerator {
+  view.fill('#0b0f19');
+
+  const steps = Array.isArray(animation.steps) ? animation.steps : [];
+  const title = animation.title || 'Algorithm trace';
+
+  const titleRef = createRef<Txt>();
+  const narration = createRef<Txt>();
+  const progress = createRef<Txt>();
+
+  view.add(
+    <Txt
+      ref={titleRef}
+      text={title}
+      fontSize={40}
+      fontWeight={700}
+      fill={'#e2e8f0'}
+      fontFamily={'JetBrains Mono, monospace'}
+      y={-300}
+      opacity={0}
+      textAlign={'center'}
+    />,
+  );
+  view.add(
+    <Txt
+      ref={narration}
+      text={''}
+      fontSize={24}
+      fill={'#94a3b8'}
+      fontFamily={'JetBrains Mono, monospace'}
+      y={280}
+      opacity={0}
+      textAlign={'center'}
+    />,
+  );
+  view.add(
+    <Txt
+      ref={progress}
+      text={`0 / ${steps.length}`}
+      fontSize={20}
+      fill={'#64748b'}
+      fontFamily={'JetBrains Mono, monospace'}
+      y={340}
+      opacity={0}
+      textAlign={'center'}
+    />,
+  );
+
+  yield* all(
+    titleRef().opacity(1, 0.5),
+    narration().opacity(1, 0.5),
+    progress().opacity(1, 0.5),
+  );
+  yield* waitFor(0.3);
+
+  const nodes = new Map<string, any>();
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    const shapes = Array.isArray(step.shapes) ? step.shapes : [];
+    const motion = Array.isArray(step.motion) ? step.motion : [];
+
+    const appearing = new Set(
+      motion.filter((op) => op.op === 'appear').map((op) => op.target),
+    );
+
+    for (const shape of shapes) {
+      const ref = createRef<any>();
+      const baseOpacity = appearing.has(shape.id) ? 0 : shape.opacity ?? 1;
+      const node = buildShapeNode(shape, ref, baseOpacity);
+      view.add(node);
+      nodes.set(shape.id, ref());
+    }
+
+    yield* narration().text(step.narration || '...', 0.25);
+    yield* progress().text(`${i + 1} / ${Math.max(steps.length, 1)}`, 0.2);
+    postViewerStep({
+      state: 'running',
+      step: i + 1,
+      total: steps.length,
+      narration: step.narration || '',
+    });
+    if (motion.length > 0) {
+      yield* all(
+        ...motion
+          .filter((op) => nodes.has(op.target))
+          .map((op) => applyMotion(nodes.get(op.target), op)),
+      );
+    }
+    yield* waitFor(STEP_HOLD);
+  }
+
+  postViewerStep({state: 'complete', total: steps.length});
+  yield* narration().text('Animation complete.', 0.3);
+  yield* waitFor(0.5);
+  yield* all(...view.children().map((child) => child.opacity(0, 0.4)));
+  yield* waitFor(0.2);
+}
+
+function* renderNarrationTimeline(
+  view: View2D,
+  animation: AnimationData,
+): ThreadGenerator {
+  view.fill('#0b0f19');
+  const title = animation.title || 'Algorithm trace';
+  const steps = Array.isArray(animation.steps) ? animation.steps : [];
+
+  const titleRef = createRef<Txt>();
+  const card = createRef<Rect>();
+  const textRef = createRef<Txt>();
+  const progress = createRef<Txt>();
+
+  view.add(
+    <Txt
+      ref={titleRef}
+      text={title}
+      fontSize={40}
+      fontWeight={700}
+      fill={'#e2e8f0'}
+      fontFamily={'JetBrains Mono, monospace'}
+      y={-260}
+      opacity={0}
+    />,
+  );
+  view.add(
+    <Rect
+      ref={card}
+      width={820}
+      height={260}
+      radius={20}
+      fill={'#111827'}
+      stroke={'#1f2937'}
+      lineWidth={2}
+      y={40}
+      opacity={0}
+    />,
+  );
+  view.add(
+    <Txt
+      ref={textRef}
+      text={''}
+      fontSize={28}
+      fill={'#e2e8f0'}
+      fontFamily={'JetBrains Mono, monospace'}
+      width={720}
+      textWrap={true}
+      textAlign={'center'}
+      y={40}
+      opacity={0}
+    />,
+  );
+  view.add(
+    <Txt
+      ref={progress}
+      text={'1 / ' + Math.max(steps.length, 1)}
+      fontSize={20}
+      fill={'#64748b'}
+      fontFamily={'JetBrains Mono, monospace'}
+      y={210}
+      opacity={0}
+    />,
+  );
+
+  yield* all(
+    titleRef().opacity(1, 0.5),
+    card().opacity(1, 0.5),
+    textRef().opacity(1, 0.5),
+    progress().opacity(1, 0.5),
+  );
+  yield* waitFor(0.4);
+
+  const frames = steps.length > 0 ? steps : [{narration: 'No steps were provided for this animation.'}];
+  for (let i = 0; i < frames.length; i++) {
+    const frame = frames[i];
+    yield* textRef().text(frame.narration || '...', 0.3);
+    yield* progress().text(`${i + 1} / ${frames.length}`, 0.2);
+    postViewerStep({
+      state: 'running',
+      step: i + 1,
+      total: frames.length,
+      narration: frame.narration || '',
+    });
+    yield* waitFor(1.1);
+  }
+
+  postViewerStep({state: 'complete', total: frames.length});
+  yield* textRef().text('Animation complete.', 0.3);
+  yield* waitFor(0.6);
+  yield* all(...view.children().map((child) => child.opacity(0, 0.4)));
+  yield* waitFor(0.2);
+}
+
+function isLegacyShape(animation: AnimationData): boolean {
+  const steps = Array.isArray(animation.steps) ? animation.steps : [];
+  return steps.some((step) => (step as any).operation !== undefined);
+}
+
+export default makeScene2D(function* (view) {
+  // Re-running loops (loop:true) must start from a clean canvas, otherwise
+  // shapes from the previous pass accumulate.
+  view.removeChildren();
+
+  // Wait a bounded amount of TIMELINE time for the animation payload. A
+  // wall-clock deadline (performance.now()) must not be used here: the scene's
+  // duration is measured by fast-forwarding the generator, during which the
+  // real clock barely advances, so a wall-clock loop would report an unbounded
+  // timeline and break the overlay scrubber.
+  const waitTicks = Math.ceil(WAIT_TIMEOUT_MS / WAIT_TICK_MS);
+  for (let i = 0; i < waitTicks && !receivedAnimation && !receivedError; i++) {
+    yield* waitFor(WAIT_TICK_MS / 1000);
+  }
+
+  if (receivedError) {
+    postViewerStep({state: 'error', narration: receivedError});
+    view.fill('#0b0f19');
+    const errorText = createRef<Txt>();
+    view.add(
+      <Txt
+        ref={errorText}
+        text={receivedError}
+        fontSize={30}
+        fill={'#f87171'}
+        fontFamily={'JetBrains Mono, monospace'}
+        textAlign={'center'}
+        width={760}
+        textWrap={true}
+        opacity={0}
+      />,
+    );
+    yield* errorText().opacity(1, 0.4);
+    yield* waitFor(3);
+    return;
+  }
+
+  const animation = receivedAnimation || DEMO_ANIMATION;
+  if (isLegacyShape(animation)) {
+    yield* renderNarrationTimeline(view, animation);
+  } else {
+    yield* renderGenericScene(view, animation);
+  }
+});

--- a/motion-canvas-lab/src/viewer-player.ts
+++ b/motion-canvas-lab/src/viewer-player.ts
@@ -1,0 +1,299 @@
+import {PlaybackState, Player, Stage} from '@motion-canvas/core';
+
+import project from './viewer-project?project';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CHROME-ENABLED VIEWER ENTRY — used by viewer.html.
+//
+// Renders the viewer project to a full-viewport canvas using the embeddable
+// `Player` + `Stage` from @motion-canvas/core, and adds a lightweight DOM
+// overlay (rendered OUTSIDE the canvas) with the playback controls the scene
+// cannot provide itself:
+//
+//   • narration bar + step counter (fed by CODECOACH_VIEWER_STEP messages that
+//     the scene broadcasts on every step)
+//   • play / pause, restart, and 0.5×–2× speed
+//   • a time-based scrubber for jumping to any point of the animation
+//   • keyboard shortcuts: Space (play/pause), ← / → (seek ±1s), R (restart),
+//     1–4 (speed)
+//
+// The scene (scenes/viewer.tsx) owns the postMessage handshake: it waits for a
+// CODECOACH_ANIMATION / CODECOACH_ANIMATION_ERROR message (token-gated) and
+// falls back to a built-in demo when opened directly.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const STEP_MESSAGE_TYPE = 'CODECOACH_VIEWER_STEP';
+
+interface StepState {
+  state: 'running' | 'complete' | 'error';
+  step?: number;
+  total?: number;
+  narration?: string;
+}
+
+const SPEEDS = [
+  {label: '0.5×', value: 0.5},
+  {label: '1×', value: 1},
+  {label: '1.5×', value: 1.5},
+  {label: '2×', value: 2},
+];
+
+const SEEK_STEP_SECONDS = 1;
+
+function icon(svg: string): string {
+  return `<svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">${svg}</svg>`;
+}
+
+function fmtTime(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(s / 60);
+  return `${m}:${String(s % 60).padStart(2, '0')}`;
+}
+
+// Under loop:true the player's `playback.duration` is just the growing playback
+// frame counter (it resets to the current frame on every recalculation), so it
+// cannot bound the scrubber. The scene's own timeline (lastFrame - firstFrame)
+// is the real length; cap it defensively in case a scene reports an unbounded
+// timeline.
+const MAX_TIMELINE_SECONDS = 120;
+
+function timelineMaxFrames(player: Player): number {
+  const cap = player.status.secondsToFrames(MAX_TIMELINE_SECONDS);
+  const scene = player.playback.currentScene;
+  if (scene) {
+    const frames = scene.lastFrame - scene.firstFrame;
+    if (Number.isFinite(frames) && frames > 1) {
+      return Math.max(1, Math.min(frames, cap));
+    }
+  }
+  return cap;
+}
+
+function buildOverlay(player: Player): void {
+  const overlay = document.createElement('div');
+  overlay.id = 'viewer-overlay';
+
+  // Narration bar (top)
+  const narration = document.createElement('div');
+  narration.id = 'viewer-narration';
+  const stepChip = document.createElement('span');
+  stepChip.id = 'viewer-step-chip';
+  stepChip.textContent = '';
+  const narrationText = document.createElement('span');
+  narrationText.id = 'viewer-narration-text';
+  narrationText.textContent = 'Preparing the animation…';
+  narration.append(stepChip, narrationText);
+  overlay.append(narration);
+
+  // Control bar (bottom)
+  const controls = document.createElement('div');
+  controls.id = 'viewer-controls';
+  controls.setAttribute('role', 'toolbar');
+  controls.setAttribute('aria-label', 'Animation controls');
+
+  const restart = document.createElement('button');
+  restart.type = 'button';
+  restart.className = 'viewer-btn';
+  restart.setAttribute('aria-label', 'Restart animation');
+  restart.title = 'Restart (R)';
+  restart.innerHTML = icon(
+    '<path d="M12 5V2L7 6l5 4V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/>',
+  );
+
+  const play = document.createElement('button');
+  play.type = 'button';
+  play.id = 'viewer-play';
+  play.className = 'viewer-btn viewer-btn-primary';
+  play.setAttribute('aria-label', 'Play animation');
+  play.title = 'Play / Pause (Space)';
+  play.innerHTML = icon('<path d="M8 5v14l11-7z"/>');
+
+  const scrubber = document.createElement('input');
+  scrubber.type = 'range';
+  scrubber.id = 'viewer-scrubber';
+  scrubber.min = '0';
+  scrubber.max = '100';
+  scrubber.value = '0';
+  scrubber.step = '1';
+  scrubber.setAttribute('aria-label', 'Animation progress');
+
+  const timeLabel = document.createElement('span');
+  timeLabel.id = 'viewer-time';
+  timeLabel.textContent = '0:00 / 0:00';
+
+  const speedGroup = document.createElement('div');
+  speedGroup.id = 'viewer-speed';
+  speedGroup.setAttribute('role', 'group');
+  speedGroup.setAttribute('aria-label', 'Playback speed');
+  for (const speed of SPEEDS) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'viewer-speed-btn';
+    btn.dataset.speed = String(speed.value);
+    btn.textContent = speed.label;
+    btn.setAttribute('aria-label', `Speed ${speed.label}`);
+    btn.title = `Speed ${speed.label}`;
+    btn.addEventListener('click', () => {
+      player.setSpeed(speed.value);
+      if (player.status.state === PlaybackState.Paused) player.togglePlayback(true);
+    });
+    speedGroup.append(btn);
+  }
+
+  controls.append(restart, play, scrubber, timeLabel, speedGroup);
+  overlay.append(controls);
+  document.body.append(overlay);
+
+  const formatNarration = (state: StepState): string => {
+    const step =
+      typeof state.step === 'number' && typeof state.total === 'number'
+        ? `${state.step} / ${state.total}`
+        : '';
+    if (state.state === 'error') return 'Generation failed';
+    if (state.state === 'complete') return 'Complete';
+    return step || '';
+  };
+
+  const setNarration = (state: StepState): void => {
+    narration.classList.toggle('viewer-narration-error', state.state === 'error');
+    narration.classList.toggle('viewer-narration-complete', state.state === 'complete');
+    stepChip.textContent = formatNarration(state);
+    stepChip.style.display = formatNarration(state) ? '' : 'none';
+    narrationText.textContent = state.narration || '';
+  };
+
+  const setProgress = (frame: number, duration: number): void => {
+    const maxFrames = Math.max(1, Math.min(duration, timelineMaxFrames(player)));
+    scrubber.max = String(maxFrames);
+    scrubber.value = String(Math.min(frame, maxFrames));
+    const total = player.status.framesToSeconds(maxFrames);
+    const current = player.status.time;
+    timeLabel.textContent = `${fmtTime(current)} / ${fmtTime(total)}`;
+  };
+
+  play.addEventListener('click', () => player.togglePlayback());
+  restart.addEventListener('click', () => {
+    player.requestReset();
+    player.togglePlayback(true);
+  });
+
+  let scrubbing = false;
+  scrubber.addEventListener('pointerdown', () => {
+    scrubbing = true;
+  });
+  scrubber.addEventListener('pointerup', () => {
+    scrubbing = false;
+  });
+  scrubber.addEventListener('input', () => {
+    const frame = Math.min(Number(scrubber.value), Number(scrubber.max));
+    player.requestSeek(frame);
+    timeLabel.textContent = `${fmtTime(player.status.framesToSeconds(frame))} / ${fmtTime(
+      player.status.framesToSeconds(Number(scrubber.max)),
+    )}`;
+  });
+
+  player.onFrameChanged.subscribe((frame) => {
+    if (!scrubbing) setProgress(frame, player.playback.duration);
+  });
+  player.onDurationChanged.subscribe((duration) => {
+    setProgress(player.playback.frame, duration);
+  });
+  player.onStateChanged.subscribe((state) => {
+    const playing = !state.paused;
+    play.innerHTML = playing
+      ? icon('<path d="M6 5h4v14H6zM14 5h4v14h-4z"/>')
+      : icon('<path d="M8 5v14l11-7z"/>');
+    play.setAttribute('aria-label', playing ? 'Pause animation' : 'Play animation');
+    for (const btn of speedGroup.querySelectorAll<HTMLButtonElement>('.viewer-speed-btn')) {
+      const isActive = Math.abs(Number(btn.dataset.speed) - state.speed) < 0.01;
+      btn.classList.toggle('viewer-speed-btn-active', isActive);
+      btn.setAttribute('aria-pressed', String(isActive));
+    }
+  });
+
+  window.addEventListener('message', (event: MessageEvent) => {
+    if (event.source !== window) return;
+    const data = event.data;
+    if (!data || typeof data !== 'object' || data.type !== STEP_MESSAGE_TYPE) return;
+    const state: StepState = {
+      state: data.state === 'error' ? 'error' : data.state === 'complete' ? 'complete' : 'running',
+      step: data.step,
+      total: data.total,
+      narration: typeof data.narration === 'string' ? data.narration : '',
+    };
+    setNarration(state);
+  });
+
+  window.addEventListener('keydown', (event: KeyboardEvent) => {
+    const target = event.target as HTMLElement | null;
+    const isFormControl =
+      target instanceof HTMLInputElement || target instanceof HTMLButtonElement;
+    const hasModifier = event.ctrlKey || event.metaKey || event.altKey;
+    if (event.key === ' ') {
+      if (isFormControl || hasModifier) return;
+      event.preventDefault();
+      player.togglePlayback();
+    } else if (event.key.toLowerCase() === 'r') {
+      if (isFormControl || hasModifier) return;
+      event.preventDefault();
+      player.requestReset();
+      player.togglePlayback(true);
+    } else if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+      if (target instanceof HTMLInputElement || hasModifier) return;
+      event.preventDefault();
+      const delta =
+        (event.key === 'ArrowRight' ? SEEK_STEP_SECONDS : -SEEK_STEP_SECONDS) *
+        player.status.fps;
+      player.requestSeek(Math.round(player.playback.frame + delta));
+      player.togglePlayback(false);
+    } else if (/^[1-4]$/.test(event.key)) {
+      if (isFormControl || hasModifier) return;
+      event.preventDefault();
+      player.setSpeed(SPEEDS[Number(event.key) - 1].value);
+      if (player.status.state === PlaybackState.Paused) player.togglePlayback(true);
+    }
+  });
+}
+
+declare global {
+  interface Window {
+    __viewerOverlayBuilt?: boolean;
+  }
+}
+
+async function main(): Promise<void> {
+  const stage = new Stage();
+  const canvas = stage.finalBuffer;
+  canvas.id = 'stage-canvas';
+  document.body.appendChild(canvas);
+
+  const settings = project.meta.getFullRenderingSettings();
+  stage.configure(settings);
+
+  const player = new Player(
+    project,
+    settings,
+    {
+      loop: true,
+      paused: false,
+      muted: false,
+      volume: 1,
+      speed: 1,
+    },
+    0,
+  );
+  player.onRender.subscribe(async () => {
+    await stage.render(player.playback.currentScene, player.playback.previousScene);
+  });
+
+  // Guard against HMR / double-invocation stacking a second overlay (and its
+  // global keydown/message listeners) on top of the first.
+  if (!window.__viewerOverlayBuilt) {
+    buildOverlay(player);
+    window.__viewerOverlayBuilt = true;
+  }
+
+  player.togglePlayback(true);
+}
+
+void main();

--- a/motion-canvas-lab/src/viewer-project.meta
+++ b/motion-canvas-lab/src/viewer-project.meta
@@ -1,0 +1,32 @@
+{
+  "version": 0,
+  "shared": {
+    "background": null,
+    "range": [
+      0,
+      null
+    ],
+    "size": {
+      "x": 1920,
+      "y": 1080
+    },
+    "audioOffset": 0
+  },
+  "preview": {
+    "fps": 30,
+    "resolutionScale": 1
+  },
+  "rendering": {
+    "fps": 60,
+    "resolutionScale": 1,
+    "colorSpace": "srgb",
+    "exporter": {
+      "name": "@motion-canvas/core/image-sequence",
+      "options": {
+        "fileType": "image/png",
+        "quality": 100,
+        "groupByScene": false
+      }
+    }
+  }
+}

--- a/motion-canvas-lab/src/viewer-project.ts
+++ b/motion-canvas-lab/src/viewer-project.ts
@@ -1,0 +1,10 @@
+import {makeProject} from '@motion-canvas/core';
+
+import viewer from './scenes/viewer?scene';
+
+// Project used by the chrome-less embedded viewer (viewer.html). It contains
+// ONLY the data-driven viewer scene — never the testing-papers playground —
+// so the app's animation modal plays the animation and nothing else.
+export default makeProject({
+  scenes: [viewer],
+});

--- a/motion-canvas-lab/tsconfig.json
+++ b/motion-canvas-lab/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@motion-canvas/2d/tsconfig.project.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "types": ["@motion-canvas/core/project", "vite/client"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/motion-canvas-lab/viewer.html
+++ b/motion-canvas-lab/viewer.html
@@ -1,0 +1,247 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CodeCoach — Animation Viewer</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        background: #0b0f19;
+        overflow: hidden;
+      }
+      #stage-canvas {
+        width: 100vw;
+        height: 100vh;
+        object-fit: contain;
+        display: block;
+        background: #0b0f19;
+      }
+
+      /* Playback overlay (controls live outside the canvas) */
+      #viewer-overlay {
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: center;
+        padding: 16px;
+        font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+        color: #e2e8f0;
+      }
+
+      /* Narration bar */
+      #viewer-narration {
+        pointer-events: none;
+        max-width: min(680px, calc(100vw - 48px));
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 8px 14px;
+        border-radius: 999px;
+        background: rgba(2, 6, 23, 0.72);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        backdrop-filter: blur(8px);
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+        font-size: 13px;
+        line-height: 1.4;
+      }
+
+      #viewer-step-chip {
+        flex-shrink: 0;
+        padding: 2px 10px;
+        border-radius: 999px;
+        background: rgba(16, 185, 129, 0.16);
+        border: 1px solid rgba(16, 185, 129, 0.28);
+        color: #6ee7b7;
+        font-size: 11px;
+        font-weight: 600;
+        white-space: nowrap;
+      }
+
+      #viewer-narration-text {
+        color: #cbd5e1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      #viewer-narration.viewer-narration-error {
+        border-color: rgba(248, 113, 113, 0.35);
+      }
+
+      #viewer-narration.viewer-narration-error #viewer-step-chip {
+        background: rgba(248, 113, 113, 0.14);
+        border-color: rgba(248, 113, 113, 0.35);
+        color: #fca5a5;
+      }
+
+      #viewer-narration.viewer-narration-complete #viewer-step-chip {
+        background: rgba(56, 189, 248, 0.14);
+        border-color: rgba(56, 189, 248, 0.3);
+        color: #7dd3fc;
+      }
+
+      /* Control bar */
+      #viewer-controls {
+        pointer-events: auto;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 14px;
+        border-radius: 999px;
+        background: rgba(2, 6, 23, 0.82);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        backdrop-filter: blur(8px);
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+      }
+
+      .viewer-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border: none;
+        border-radius: 999px;
+        background: transparent;
+        color: #94a3b8;
+        cursor: pointer;
+        transition: background 0.15s ease, color 0.15s ease, transform 0.1s ease;
+      }
+
+      .viewer-btn:hover {
+        background: rgba(255, 255, 255, 0.08);
+        color: #e2e8f0;
+      }
+
+      .viewer-btn:active {
+        transform: scale(0.94);
+      }
+
+      .viewer-btn:focus-visible,
+      .viewer-speed-btn:focus-visible,
+      #viewer-scrubber:focus-visible {
+        outline: 2px solid #10b981;
+        outline-offset: 2px;
+      }
+
+      .viewer-btn-primary {
+        width: 44px;
+        height: 44px;
+        background: rgba(16, 185, 129, 0.18);
+        color: #34d399;
+      }
+
+      .viewer-btn-primary:hover {
+        background: rgba(16, 185, 129, 0.3);
+        color: #6ee7b7;
+      }
+
+      #viewer-scrubber {
+        width: min(320px, 30vw);
+        height: 4px;
+        -webkit-appearance: none;
+        appearance: none;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.12);
+        cursor: pointer;
+      }
+
+      #viewer-scrubber::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        background: #34d399;
+        border: 2px solid #0b0f19;
+        box-shadow: 0 0 0 1px rgba(52, 211, 153, 0.4);
+      }
+
+      #viewer-scrubber::-moz-range-thumb {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: #34d399;
+        border: 2px solid #0b0f19;
+      }
+
+      #viewer-time {
+        min-width: 88px;
+        text-align: center;
+        font-size: 11px;
+        color: #64748b;
+        white-space: nowrap;
+        font-variant-numeric: tabular-nums;
+      }
+
+      #viewer-speed {
+        display: flex;
+        gap: 4px;
+        padding-left: 6px;
+        border-left: 1px solid rgba(255, 255, 255, 0.08);
+      }
+
+      .viewer-speed-btn {
+        padding: 4px 10px;
+        border: none;
+        border-radius: 999px;
+        background: transparent;
+        color: #64748b;
+        font-size: 11px;
+        font-family: inherit;
+        cursor: pointer;
+        transition: background 0.15s ease, color 0.15s ease;
+      }
+
+      .viewer-speed-btn:hover {
+        color: #cbd5e1;
+      }
+
+      .viewer-speed-btn-active {
+        background: rgba(255, 255, 255, 0.1);
+        color: #e2e8f0;
+      }
+
+      @media (max-width: 640px) {
+        #viewer-overlay {
+          padding: 10px;
+        }
+
+        #viewer-narration {
+          font-size: 11px;
+          padding: 6px 12px;
+        }
+
+        #viewer-controls {
+          gap: 6px;
+          padding: 8px 10px;
+        }
+
+        #viewer-scrubber {
+          width: 40vw;
+        }
+
+        #viewer-time {
+          display: none;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        #viewer-narration,
+        #viewer-controls {
+          backdrop-filter: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module" src="/src/viewer-player.ts"></script>
+  </body>
+</html>

--- a/motion-canvas-lab/vite.config.ts
+++ b/motion-canvas-lab/vite.config.ts
@@ -1,0 +1,35 @@
+import {defineConfig, type PluginOption} from 'vite';
+import motionCanvas from '@motion-canvas/vite-plugin';
+import ffmpeg from '@motion-canvas/ffmpeg';
+
+// The chrome-less viewer (viewer.html) imports `./src/viewer-project?project`,
+// which the Motion Canvas plugin resolves generically at build time, so it does
+// not need to be listed in `project` (that list is only for the editor's
+// project index and rollup inputs). We DO add viewer.html itself as a rollup
+// input here, otherwise `vite build` would only emit the project modules.
+const viewerProjectPlugin: PluginOption = {
+  name: 'codecoach-viewer-html-entry',
+  enforce: 'post',
+  config(config) {
+    return {
+      build: {
+        rollupOptions: {
+          input: {
+            ...config.build?.rollupOptions?.input,
+            viewer: new URL('./viewer.html', import.meta.url).pathname,
+          },
+        },
+      },
+    };
+  },
+};
+
+export default defineConfig({
+  plugins: [
+    motionCanvas({
+      project: ['./src/project.ts'],
+    }),
+    ffmpeg(),
+    viewerProjectPlugin,
+  ],
+});


### PR DESCRIPTION
## Summary
Sprint deliverable: step-by-step algorithm animations with full playback control, plus UX polish.

## What's in it
- **Animation viewer** (`motion-canvas-lab/`): DOM overlay outside the canvas with a narration bar + step counter, play/pause, restart, 0.5×–2× speed, a time-based scrubber, and keyboard shortcuts (Space / ←→ / R / 1-4). Timeline is bounded from the scene's real length. The message bridge is token-gated and origin-checked (no `*` postMessage).
- **Canonical-solution pipeline** (backend): 100-question reference-solution catalog, trace instrumenter/parser, family compilers, `solution_animation_service` — the animation is always of the intended optimal solution, executed against `examples[0]`, never the user's typed code.
- **AnimateLauncher**: dialog header with problem title, indeterminate generation stepper, error card with Retry, abort guards when the dialog closes mid-flight.
- **UX**: labeled "Ask Coach" button, homepage animation-preview section.
- **E2E/a11y**: keyboard-focus and animation-preview coverage.

## Fixes found in review (all gated)
- Trace errors (`parse_trace` ValueError) now degrade to `None` instead of bubbling to a 500 / unnecessary LLM fallback.
- `maximum_depth_of_binary_tree` depth bug (`i.bit_length()` → `(i+1).bit_length()`).
- Graph edge-list vs adjacency-list misclassification when edge count == vertex count.
- Hidden `test_cases` are stripped before question data reaches the third-party model.
- Animate response-schema failures map to 502 (established "no valid animation" contract) instead of a 500 leaking internals.
- Broken `NoAnimationProvider` test now overrides `get_animation_script` (the method the endpoint calls).

## Verification
- Backend: ruff clean; 591 unit + security tests pass. Integration/contract/admin tiers error locally only on a pre-existing asyncpg/pgbouncer prepared-statement issue (`DuplicatePreparedStatementError`), affecting all DB-backed tests equally, unrelated to this change.
- Frontend: typecheck, lint (0), 571 unit tests, prettier clean; e2e accessibility (5) + viewer-render (1) green in isolation; viewer overlay verified via a probe spec.
- Docker: backend + frontend containers rebuilt and serving.

## Known pre-existing flakes (unrelated)
- `homepage.spec.ts` (4 tests) asserts stale marketing text on the landing page.
- `animate-flow.spec.ts:272` fails only in parallel runs (auth-state flake).

## Deferred follow-ups (tracked here, not blocking)
- Cache canonical-trace animations (currently re-executes in Piston per request).
- Align validator caps (120/40) with the prompt contract (60/20).
- Homepage/anim A11y: gate the homepage sort-pulse preview for prefers-reduced-motion (CSS now done); viewer reduced-motion only reduces blur, not the animation itself.