### PR TITLE
fix(groq): migrate deprecated llama models to openai gpt-oss

### DIFF
--- a/Progress.md
+++ b/Progress.md
@@ -73,7 +73,7 @@ codebase. Feature-by-feature status with checkboxes lives in [Ideas.md](./Ideas.
 - **Database:** Supabase PostgreSQL (async SQLAlchemy) — the **only** database; Alembic migrations
 - **Cache / Limits:** Redis for request/rate-limit usage tracking
 - **Code Execution:** Piston (self-hosted Docker container)
-- **AI:** Groq (llama-3.3-70b-versatile, llama-3.1-8b-instant; `animate` mode override) with per-user daily token metering
+- **AI:** Groq (openai/gpt-oss-120b, openai/gpt-oss-20b; `animate` mode override) with per-user daily token metering
 - **Auth:** Email/password (bcrypt + JWT) + Supabase OAuth (Google)
 - **Rate Limiting:** slowapi per-minute per-user limit (default 60/min), per-mode coach/run/submit limits
 - **Migrations:** `backend/alembic/versions/` — initial schema, admin tables, usage/request tracking, user plan column, skill-graph tables

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ State is kept in sync with code (see [Progress.md](./Progress.md) and [Ideas.md]
 | **Styling** | Tailwind CSS 3, `tailwind-merge`, `clsx`, shadcn/ui |
 | **Animation** | Motion Canvas (Vite viewer on `:9000`) + `AnimationPlayer` |
 | **Code Execution** | Piston (self-hosted Docker, `PistonService` adapter) |
-| **AI Coach** | Groq (`llama-3.3-70b-versatile` / `llama-3.1-8b-instant`, animate override) via `api.groq.com/openai/v1` |
+| **AI Coach** | Groq (`openai/gpt-oss-120b` / `openai/gpt-oss-20b`, animate override) via `api.groq.com/openai/v1` |
 | **Database** | Supabase PostgreSQL (async SQLAlchemy) — **the only database** |
 | **Cache / Limits** | Redis 7-alpine |
 | **Auth** | JWT (python-jose), bcrypt, Supabase OAuth (Google) |
@@ -273,9 +273,11 @@ DATABASE_URL=postgresql://postgres.<ref>.<region>.pooler.supabase.com:6543/postg
 # DIRECT_URL=postgresql://postgres.<ref>.<region>.pooler.supabase.com:5432/postgres
 
 # Optional Groq model overrides (defaults)
-# GROQ_MODEL_EASY=llama-3.1-8b-instant
-# GROQ_MODEL_STREAM=llama-3.1-8b-instant
-# GROQ_MODEL_ANIMATE=llama-3.3-70b-versatile
+# GROQ_MODEL_EASY=openai/gpt-oss-20b
+# GROQ_MODEL_MEDIUM=openai/gpt-oss-120b
+# GROQ_MODEL_HARD=openai/gpt-oss-120b
+# GROQ_MODEL_STREAM=openai/gpt-oss-20b
+# GROQ_MODEL_ANIMATE=openai/gpt-oss-120b
 DAILY_TOKEN_INPUT_CAP=250000
 DAILY_TOKEN_OUTPUT_CAP=125000
 USER_RATE_LIMIT_PER_MINUTE=60

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,11 +3,11 @@
 GROQ_API_KEY=your_groq_api_key_here
 
 # Groq model overrides (optional — defaults shown)
-# GROQ_MODEL_EASY=llama-3.1-8b-instant
-# GROQ_MODEL_MEDIUM=llama-3.3-70b-versatile
-# GROQ_MODEL_HARD=llama-3.3-70b-versatile
-# GROQ_MODEL_STREAM=llama-3.1-8b-instant
-# GROQ_MODEL_ANIMATE=llama-3.3-70b-versatile
+# GROQ_MODEL_EASY=openai/gpt-oss-20b
+# GROQ_MODEL_MEDIUM=openai/gpt-oss-120b
+# GROQ_MODEL_HARD=openai/gpt-oss-120b
+# GROQ_MODEL_STREAM=openai/gpt-oss-20b
+# GROQ_MODEL_ANIMATE=openai/gpt-oss-120b
 
 # Per-user daily token caps (optional — defaults shown)
 # DAILY_TOKEN_INPUT_CAP=250000

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -20,11 +20,11 @@ class Settings(BaseSettings):
 
     # Groq (primary AI provider for coaching)
     GROQ_API_KEY: Optional[str] = None
-    GROQ_MODEL_EASY: str = "llama-3.1-8b-instant"
-    GROQ_MODEL_MEDIUM: str = "llama-3.3-70b-versatile"
-    GROQ_MODEL_HARD: str = "llama-3.3-70b-versatile"
-    GROQ_MODEL_STREAM: str = "llama-3.1-8b-instant"
-    GROQ_MODEL_ANIMATE: str = "llama-3.3-70b-versatile"
+    GROQ_MODEL_EASY: str = "openai/gpt-oss-20b"
+    GROQ_MODEL_MEDIUM: str = "openai/gpt-oss-120b"
+    GROQ_MODEL_HARD: str = "openai/gpt-oss-120b"
+    GROQ_MODEL_STREAM: str = "openai/gpt-oss-20b"
+    GROQ_MODEL_ANIMATE: str = "openai/gpt-oss-120b"
 
     # Per-user token metering (daily caps)
     DAILY_TOKEN_INPUT_CAP: int = 250_000

--- a/backend/app/services/groq_service.py
+++ b/backend/app/services/groq_service.py
@@ -28,11 +28,11 @@ class GroqService(CoachingProvider):
 
     BASE_URL = "https://api.groq.com/openai/v1"
     DEFAULT_MODELS = {
-        "easy": "llama-3.1-8b-instant",
-        "medium": "llama-3.3-70b-versatile",
-        "hard": "llama-3.3-70b-versatile",
-        "stream": "llama-3.1-8b-instant",
-        "animate": "llama-3.3-70b-versatile",
+        "easy": "openai/gpt-oss-20b",
+        "medium": "openai/gpt-oss-120b",
+        "hard": "openai/gpt-oss-120b",
+        "stream": "openai/gpt-oss-20b",
+        "animate": "openai/gpt-oss-120b",
     }
 
     def __init__(

--- a/backend/tests/integration/test_debug_endpoints.py
+++ b/backend/tests/integration/test_debug_endpoints.py
@@ -25,7 +25,7 @@ class TestDebugGroqStatus:
     def test_groq_status_valid(self, test_client: TestClient, test_env_vars):
         body = {
             "object": "list",
-            "data": [{"id": "llama-3.3-70b-versatile", "active": True}],
+            "data": [{"id": "openai/gpt-oss-120b", "active": True}],
         }
         with _mock_httpx_get(200, body) as _:
             os.environ["GROQ_API_KEY"] = "gsk_" + "x" * 40
@@ -36,7 +36,7 @@ class TestDebugGroqStatus:
             assert data["valid"] is True
             assert data["api_key_present"] is True
             assert data["api_key_format_valid"] is True
-            assert "llama-3.3-70b-versatile" in data["models"]
+            assert "openai/gpt-oss-120b" in data["models"]
 
     def test_groq_status_missing_key(self, test_client: TestClient, test_env_vars):
         if "GROQ_API_KEY" in os.environ:

--- a/backend/tests/unit/test_groq_service.py
+++ b/backend/tests/unit/test_groq_service.py
@@ -140,11 +140,11 @@ class TestGroqServiceInit:
             from app.services.groq_service import GroqService
 
             service = GroqService()
-            assert service.models["easy"] == "llama-3.1-8b-instant"
-            assert service.models["medium"] == "llama-3.3-70b-versatile"
-            assert service.models["hard"] == "llama-3.3-70b-versatile"
-            assert service.models["stream"] == "llama-3.1-8b-instant"
-            assert service.models["animate"] == "llama-3.3-70b-versatile"
+            assert service.models["easy"] == "openai/gpt-oss-20b"
+            assert service.models["medium"] == "openai/gpt-oss-120b"
+            assert service.models["hard"] == "openai/gpt-oss-120b"
+            assert service.models["stream"] == "openai/gpt-oss-20b"
+            assert service.models["animate"] == "openai/gpt-oss-120b"
 
     def test_model_map_env_overrides(self):
         with patch.dict(
@@ -161,7 +161,7 @@ class TestGroqServiceInit:
             service = GroqService()
             assert service.models["easy"] == "custom-easy"
             assert service.models["medium"] == "custom-medium"
-            assert service.models["hard"] == "llama-3.3-70b-versatile"
+            assert service.models["hard"] == "openai/gpt-oss-120b"
             assert service.models["animate"] == "custom-animate"
 
 
@@ -211,7 +211,7 @@ class TestGroqServiceStructured:
             {
                 "user_id": "user-1",
                 "provider": "groq",
-                "model": "llama-3.3-70b-versatile",
+                "model": "openai/gpt-oss-120b",
                 "endpoint": "coach",
                 "input_tokens": 12,
                 "output_tokens": 34,
@@ -243,8 +243,8 @@ class TestGroqServiceStructured:
             difficulty="easy",
         )
         call = mock_async_client.post.call_args
-        assert call.kwargs["json"]["model"] == "llama-3.1-8b-instant"
-        assert recorder.calls[0]["model"] == "llama-3.1-8b-instant"
+        assert call.kwargs["json"]["model"] == "openai/gpt-oss-20b"
+        assert recorder.calls[0]["model"] == "openai/gpt-oss-20b"
 
     @pytest.mark.asyncio
     async def test_structured_uses_hard_model(self, mock_async_client):
@@ -268,7 +268,7 @@ class TestGroqServiceStructured:
             difficulty="hard",
         )
         call = mock_async_client.post.call_args
-        assert call.kwargs["json"]["model"] == "llama-3.3-70b-versatile"
+        assert call.kwargs["json"]["model"] == "openai/gpt-oss-120b"
 
     @pytest.mark.asyncio
     async def test_structured_payload_uses_max_completion_tokens(
@@ -770,7 +770,7 @@ class TestGroqServiceStreaming:
             {
                 "user_id": "user-1",
                 "provider": "groq",
-                "model": "llama-3.1-8b-instant",
+                "model": "openai/gpt-oss-20b",
                 "endpoint": "coach_stream",
                 "input_tokens": 5,
                 "output_tokens": 7,
@@ -805,7 +805,7 @@ class TestGroqServiceStreaming:
         call = mock_instance.stream.call_args
         assert call.kwargs["json"]["stream"] is True
         assert call.kwargs["json"]["stream_options"] == {"include_usage": True}
-        assert call.kwargs["json"]["model"] == "llama-3.1-8b-instant"
+        assert call.kwargs["json"]["model"] == "openai/gpt-oss-20b"
 
     @pytest.mark.asyncio
     async def test_stream_429_maps_to_429(self):
@@ -1091,7 +1091,7 @@ class TestGroqServiceAnimateScript:
         call = mock_async_client.post.call_args
         # Animate needs a capable model regardless of problem difficulty; it
         # must never fall back to the fast 8b model.
-        assert call.kwargs["json"]["model"] == "llama-3.3-70b-versatile"
+        assert call.kwargs["json"]["model"] == "openai/gpt-oss-120b"
 
     @pytest.mark.asyncio
     async def test_animate_payload_uses_raised_max_completion_tokens(

--- a/backend/tests/unit/test_sql_usage_repository.py
+++ b/backend/tests/unit/test_sql_usage_repository.py
@@ -122,7 +122,7 @@ class TestSqlUsageRepository:
         await repo.add_event(
             user_id=user_id,
             provider="groq",
-            model="llama-3.3-70b-versatile",
+            model="openai/gpt-oss-120b",
             endpoint="coach",
             input_tokens=12,
             output_tokens=34,
@@ -131,7 +131,7 @@ class TestSqlUsageRepository:
         assert len(events) == 1
         event = events[0]
         assert event.provider == "groq"
-        assert event.model == "llama-3.3-70b-versatile"
+        assert event.model == "openai/gpt-oss-120b"
         assert event.endpoint == "coach"
         assert event.input_tokens == 12
         assert event.output_tokens == 34

--- a/backend/tests/unit/test_usage_service.py
+++ b/backend/tests/unit/test_usage_service.py
@@ -51,7 +51,7 @@ class TestUsageServiceRecord:
         await service.record(
             user_id="user-1",
             provider="groq",
-            model="llama-3.3-70b-versatile",
+            model="openai/gpt-oss-120b",
             endpoint="coach",
             input_tokens=10,
             output_tokens=20,
@@ -59,7 +59,7 @@ class TestUsageServiceRecord:
         await service.record(
             user_id="user-1",
             provider="groq",
-            model="llama-3.1-8b-instant",
+            model="openai/gpt-oss-20b",
             endpoint="coach",
             input_tokens=5,
             output_tokens=7,


### PR DESCRIPTION
Migrate Groq models that shutdown 2026-08-16 for free/developer tier.

Per https://console.groq.com/docs/deprecations:
- llama-3.1-8b-instant -> openai/gpt-oss-20b (easy/stream)
- llama-3.3-70b-versatile -> openai/gpt-oss-120b (medium/hard/animate)

Changes: config, groq_service, docs, tests (9 files). Verified via direct import and ruff. Isolated from motion work.