### PR TITLE
feat(skill-graph,redis): DB sync + boilerplate and Redis workspace persistence

### DIFF
--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -24,7 +24,12 @@ from app.services.usage_service import UsageService, check_caps, usage_headers
 from app.services.solution_animation_service import SolutionAnimationService
 from app.api.auth_deps import get_current_user
 from app.api.daily_limits import enforce_daily_request_cap
-from app.api.dependencies import get_redis_cache, get_usage_service, get_executor
+from app.api.dependencies import (
+    get_redis_cache,
+    get_usage_service,
+    get_executor,
+    get_workspace_service,
+)
 from app.models.auth_schemas import UserResponse
 from app.middleware.rate_limit import limiter, COACH_RATE_LIMIT
 
@@ -97,6 +102,7 @@ async def get_coaching(
     _usage_guard: None = Depends(check_daily_token_cap),
     _rate_guard: None = Depends(enforce_user_rate_limit),
     _daily_guard: None = Depends(enforce_daily_request_cap),
+    workspace_svc=Depends(get_workspace_service),
 ):
     """
     Get AI coaching response for coding problems.
@@ -145,6 +151,25 @@ async def get_coaching(
 
         response.headers.update(getattr(request.state, "usage_headers", {}))
         response.headers.update(getattr(request.state, "daily_limit_headers", {}))
+
+        # Best-effort chat persistence to Redis (per-question history, 7d TTL).
+        try:
+            qid = getattr(coaching_request, "question_id", None)
+            if qid and workspace_svc:
+                await workspace_svc.append_chat(
+                    user.id,
+                    qid,
+                    [
+                        {"role": "user", "content": coaching_request.message or ""},
+                        {
+                            "role": "assistant",
+                            "content": raw_response,
+                            "structured": structured_data,
+                        },
+                    ],
+                )
+        except Exception:  # noqa: BLE001
+            logger.debug("workspace chat append failed", exc_info=True)
 
         return CoachingResponse(
             response=raw_response,

--- a/backend/app/api/courses.py
+++ b/backend/app/api/courses.py
@@ -14,7 +14,7 @@ from app.middleware.rate_limit import limiter, QUESTIONS_RATE_LIMIT
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=False)
 
 
 def get_course_service(
@@ -28,6 +28,7 @@ def get_course_service(
 
 
 @router.get("/")
+@router.get("")
 @limiter.limit(QUESTIONS_RATE_LIMIT)
 async def list_courses(
     request: Request,

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -34,8 +34,11 @@ from app.services.error_graph_service import ErrorGraphService
 from app.services.learning_analytics_service import LearningAnalyticsService
 from app.services.memory_graph_service import MemoryGraphService
 from app.ports.code_executor import CodeExecutor
+from app.ports.skill_graph_repository import SkillGraphRepository
+from app.repositories.sql_skill_graph_repository import SqlSkillGraphRepository
 from app.services.piston_service import PistonService
 from app.services.question_bank import QuestionBank
+from app.services.skill_graph_service import SkillGraphService
 
 
 async def get_redis_cache(
@@ -182,3 +185,15 @@ async def get_question_bank(
     cache: Optional[RedisCache] = Depends(get_redis_cache),
 ) -> QuestionBank:
     return QuestionBank(repository=question_repo, cache=cache)
+
+
+async def get_skill_graph_repo(
+    db: AsyncSession = Depends(get_db),
+) -> AsyncGenerator[SkillGraphRepository, None]:
+    yield SqlSkillGraphRepository(db)
+
+
+def get_skill_graph_service(
+    repo: SkillGraphRepository = Depends(get_skill_graph_repo),
+) -> SkillGraphService:
+    return SkillGraphService(repository=repo)

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -174,6 +174,14 @@ async def get_course_admin_repo(
     yield SqlCourseAdminRepository(db)
 
 
+def get_workspace_service(
+    cache: Optional[RedisCache] = Depends(get_redis_cache),
+):
+    from app.services.workspace_service import WorkspaceService
+
+    return WorkspaceService(cache=cache)
+
+
 def get_executor(
     cache: Optional[RedisCache] = Depends(get_redis_cache),
 ) -> CodeExecutor:

--- a/backend/app/api/progress.py
+++ b/backend/app/api/progress.py
@@ -7,7 +7,7 @@ from app.api.auth_deps import get_current_user
 from app.api.dependencies import get_course_repo, get_progress_repo
 from app.models.auth_schemas import UserResponse
 
-router = APIRouter()
+router = APIRouter(redirect_slashes=False)
 
 
 def get_course_service(
@@ -18,6 +18,7 @@ def get_course_service(
 
 
 @router.get("/")
+@router.get("")
 async def get_all_progress(
     current_user: UserResponse = Depends(get_current_user),
     course_service: CourseService = Depends(get_course_service),

--- a/backend/app/api/skills.py
+++ b/backend/app/api/skills.py
@@ -1,11 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException
-from typing import AsyncGenerator, List, Optional
-
-from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import APIRouter, Depends, HTTPException, Query
+from typing import List, Optional
 
 from app.api.auth_deps import get_current_user
-from app.api.dependencies import get_question_bank
-from app.core.database import get_db
+from app.api.dependencies import (
+    get_question_bank,
+    get_skill_graph_service,
+    get_submission_repo,
+)
+
 from app.models.auth_schemas import UserResponse
 from app.models.schemas import Question
 from app.models.skill_graph_schemas import (
@@ -15,35 +17,49 @@ from app.models.skill_graph_schemas import (
     RecommendedQuestion,
     SkillGraphResponse,
 )
-from app.ports.skill_graph_repository import SkillGraphRepository
-from app.repositories.sql_skill_graph_repository import SqlSkillGraphRepository
+from app.ports.submission_repository import SubmissionRepository
 from app.services.question_bank import QuestionBank
 from app.services.skill_graph_service import SkillGraphService
 
 router = APIRouter()
 
 
-async def get_skill_graph_repo(
-    db: AsyncSession = Depends(get_db),
-) -> AsyncGenerator[SkillGraphRepository, None]:
-    yield SqlSkillGraphRepository(db)
-
-
-def get_skill_graph_service(
-    repo: SkillGraphRepository = Depends(get_skill_graph_repo),
-) -> SkillGraphService:
-    return SkillGraphService(repository=repo)
-
-
 @router.get("/me/skills", response_model=SkillGraphResponse)
 async def get_my_skills(
+    include_boilerplate: bool = Query(
+        False,
+        description="Include boilerplate skills for new users (all taxonomy with 0 mastery)",
+    ),
     current_user: UserResponse = Depends(get_current_user),
     service: SkillGraphService = Depends(get_skill_graph_service),
 ):
     try:
-        return await service.get_graph(current_user.id)
+        return await service.get_graph(
+            current_user.id, include_boilerplate=include_boilerplate
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error fetching skills: {e}")
+
+
+@router.post("/me/sync", response_model=EventIngestResult)
+async def sync_my_skills_from_submissions(
+    current_user: UserResponse = Depends(get_current_user),
+    service: SkillGraphService = Depends(get_skill_graph_service),
+    submissions: SubmissionRepository = Depends(get_submission_repo),
+):
+    """Backfill skill graph from already-completed submissions (DB query).
+
+    Idempotent: re-running never duplicates. Scoped to the authenticated user.
+    Queries ``submissions`` where the user already solved questions and
+    synthesizes ``SUBMISSION_PASSED`` / ``SUBMISSION_FAILED`` learning events.
+    """
+    try:
+        # Pull up to 1000 most recent attempts — enough to rebuild the graph
+        # without blocking the hot path. History beyond this is decayed anyway.
+        items = await submissions.list_by_user(current_user.id, limit=1000)
+        return await service.sync_from_submissions(current_user.id, list(items))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error syncing skills: {e}")
 
 
 @router.get("/me/recommendations", response_model=List[Recommendation])

--- a/backend/app/api/submit.py
+++ b/backend/app/api/submit.py
@@ -13,9 +13,12 @@ from app.api.dependencies import (
     get_executor,
     get_question_repo,
     get_review_service,
+    get_skill_graph_service,
     get_submission_repo,
 )
 from app.middleware.rate_limit import limiter, RUN_RATE_LIMIT
+from app.models.skill_graph_schemas import LearningEvent, LearningEventType
+from app.services.skill_graph_service import SkillGraphService
 import logging
 
 logger = logging.getLogger(__name__)
@@ -41,6 +44,7 @@ async def submit_code(
     executor: CodeExecutor = Depends(get_executor),
     submissions: SubmissionRepository = Depends(get_submission_repo),
     reviews: ReviewService = Depends(get_review_service),
+    skill_service: SkillGraphService = Depends(get_skill_graph_service),
     current_user: UserResponse = Depends(get_current_user),
 ):
     question = await repository.get_by_id(submit_request.question_id)
@@ -75,8 +79,9 @@ async def submit_code(
 
     # Persist the graded attempt for the mistake-memory data layer. Best-effort:
     # a failed write must not 500 the graded result, but it IS logged.
+    persisted = None
     try:
-        await submissions.add(
+        persisted = await submissions.add(
             user_id=current_user.id,
             submission=SubmissionIn(
                 question_id=submit_request.question_id,
@@ -102,6 +107,32 @@ async def submit_code(
         )
     except Exception:  # noqa: BLE001
         logger.warning("Failed to record mistake-memory observation", exc_info=True)
+
+    # Skill-graph emission: keep the Personal Skill Graph in sync with
+    # already-persisted submissions (DB query backfill + live writes). Uses a
+    # deterministic event id ``sub:{submission.id}`` so repeated syncs and
+    # this live path remain idempotent via ``event_exists``. Best-effort.
+    if persisted is not None:
+        try:
+            event = LearningEvent(
+                id=f"sub:{persisted.id}",
+                user_id=current_user.id,
+                event_type=LearningEventType.SUBMISSION_PASSED
+                if passed
+                else LearningEventType.SUBMISSION_FAILED,
+                question_id=submit_request.question_id,
+                metadata={"error_signature": _error_signature(results)}
+                if not passed and _error_signature(results)
+                else {},
+                occurred_at=persisted.created_at or datetime.now(timezone.utc),
+            )
+            await skill_service.ingest_events([event], user_id=current_user.id)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to emit skill-graph event for %s",
+                submit_request.question_id,
+                exc_info=True,
+            )
 
     return SubmitResponse(
         passed=passed,

--- a/backend/app/api/workspace.py
+++ b/backend/app/api/workspace.py
@@ -1,0 +1,113 @@
+"""Workspace + chat persistence endpoints (Redis cache, per-user, auth required)."""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from app.api.auth_deps import get_current_user
+from app.api.dependencies import get_workspace_service
+from app.models.auth_schemas import UserResponse
+from app.models.workspace_schemas import (
+    WorkspaceCodePut,
+    WorkspaceCodeOut,
+    LastVisitedOut,
+    ChatHistoryOut,
+)
+from app.services.workspace_service import WorkspaceService
+
+logger = logging.getLogger(__name__)
+router = APIRouter(dependencies=[Depends(get_current_user)])
+
+
+@router.put("/code/{question_id}", status_code=204)
+async def put_code(
+    question_id: str,
+    body: WorkspaceCodePut,
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    await svc.save_code(user.id, question_id, body.language, body.code)
+    return None
+
+
+@router.get("/code/{question_id}", response_model=WorkspaceCodeOut)
+async def get_code(
+    question_id: str,
+    language: str = Query(..., min_length=1, max_length=20),
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    data = await svc.get_code(user.id, question_id, language)
+    try:
+        await svc.set_last_visited(user.id, question_id, language)
+    except Exception:
+        pass
+    if data is None:
+        return WorkspaceCodeOut(
+            code="", language=language, updated_at=None, question_id=question_id
+        )
+    return WorkspaceCodeOut(
+        code=data.get("code", ""),
+        language=data.get("language", language),
+        updated_at=data.get("updated_at"),
+        question_id=question_id,
+    )
+
+
+@router.delete("/code/{question_id}", status_code=204)
+async def delete_code(
+    question_id: str,
+    language: str = Query(..., min_length=1, max_length=20),
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    await svc.delete_code(user.id, question_id, language)
+    return None
+
+
+@router.get("/last-visited", response_model=Optional[LastVisitedOut])
+async def get_last_visited(
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    data = await svc.get_last_visited(user.id)
+    if data is None:
+        return None
+    return LastVisitedOut(
+        question_id=data.get("question_id", ""),
+        language=data.get("language"),
+        visited_at=data.get("visited_at", ""),
+    )
+
+
+@router.get("/chat/{question_id}", response_model=ChatHistoryOut)
+async def get_chat(
+    question_id: str,
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    messages = await svc.get_chat(user.id, question_id)
+    return ChatHistoryOut(question_id=question_id, messages=messages)
+
+
+@router.delete("/chat/{question_id}", status_code=204)
+async def delete_chat(
+    question_id: str,
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    await svc.clear_chat(user.id, question_id)
+    return None
+
+
+@router.get("/meta/{question_id}")
+async def get_meta(
+    question_id: str,
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    data = await svc.get_meta(user.id, question_id)
+    if data is None:
+        return {"question_id": question_id, "language": None, "last_opened_at": None}
+    return {"question_id": question_id, **data}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -84,7 +84,13 @@ class Settings(BaseSettings):
     REDIS_TTL_STATIC: int = 3600
     REDIS_TTL_AI: int = 86400
     REDIS_TTL_EXECUTION: int = 3600
+    REDIS_TTL_WORKSPACE: int = 604800  # 7 days — draft code + last-visited
+    REDIS_TTL_CHAT: int = 604800  # 7 days — per-question chat history
+    REDIS_TTL_LAST_EXEC: int = 604800  # 7 days — last execution / submit snapshot
     REDIS_ENABLED: bool = True
+    WORKSPACE_CODE_MAX_BYTES: int = 51200
+    CHAT_HISTORY_MAX_MESSAGES: int = 20
+    CHAT_MESSAGE_MAX_CHARS: int = 5000
 
 
 def get_settings() -> Settings:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -47,6 +47,7 @@ from app.api import (  # noqa: E402
     reviews,
     memory,
     analytics,
+    workspace,
 )
 from app.core.config import get_settings, is_production  # noqa: E402
 from app.middleware.rate_limit import (  # noqa: E402
@@ -207,6 +208,7 @@ app.include_router(mistakes.router, prefix="/api/mistakes", tags=["mistakes"])
 app.include_router(reviews.router, prefix="/api/reviews", tags=["reviews"])
 app.include_router(memory.router, prefix="/api/memory", tags=["memory"])
 app.include_router(analytics.router, prefix="/api/analytics", tags=["analytics"])
+app.include_router(workspace.router, prefix="/api/workspace", tags=["workspace"])
 
 
 @app.get("/")

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -71,6 +71,11 @@ class CoachingRequest(BaseModel):
         max_length=50000,
         description="Starter code the user began with, used to detect edits for animation",
     )
+    question_id: Optional[str] = Field(
+        None,
+        max_length=100,
+        description="Question id for workspace chat persistence (optional, no breaking change)",
+    )
 
 
 class SceneShape(BaseModel):

--- a/backend/app/models/workspace_schemas.py
+++ b/backend/app/models/workspace_schemas.py
@@ -1,0 +1,48 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional, Any
+
+
+class WorkspaceCodePut(BaseModel):
+    language: str = Field(
+        ..., min_length=1, max_length=20, description="Programming language"
+    )
+    code: str = Field(..., max_length=51200, description="Draft code (max 50KB)")
+
+
+class WorkspaceCodeOut(BaseModel):
+    code: str
+    language: str
+    updated_at: Optional[str] = None
+    question_id: str
+
+
+class LastVisitedOut(BaseModel):
+    question_id: str
+    language: Optional[str] = None
+    visited_at: str
+
+
+class LastVisitedPut(BaseModel):
+    question_id: str = Field(..., min_length=1, max_length=100)
+    language: Optional[str] = Field(None, max_length=20)
+
+
+class ChatMessageIn(BaseModel):
+    role: str = Field(..., pattern="^(user|assistant)$")
+    content: str = Field(..., max_length=5000)
+    structured: Optional[Any] = None
+
+
+class ChatHistoryOut(BaseModel):
+    question_id: str
+    messages: List[dict]
+
+
+class ChatHistoryPut(BaseModel):
+    messages: List[ChatMessageIn] = Field(..., max_length=20)
+
+
+class WorkspaceMetaOut(BaseModel):
+    question_id: str
+    language: Optional[str] = None
+    last_opened_at: Optional[str] = None

--- a/backend/app/services/skill_graph_service.py
+++ b/backend/app/services/skill_graph_service.py
@@ -7,13 +7,16 @@ from app.models.schemas import Question
 from app.models.skill_graph_schemas import (
     EventIngestResult,
     LearningEvent,
+    LearningEventType,
     QuestionSkill,
     Recommendation,
     RecommendedQuestion,
     Skill,
     SkillGraphEdge,
     SkillGraphResponse,
+    SkillStatus,
     SkillSummary,
+    Trend,
     UserSkillState,
 )
 from app.ports.skill_graph_repository import SkillGraphRepository
@@ -111,7 +114,10 @@ class SkillGraphService:
         return result
 
     async def get_graph(
-        self, user_id: str, now: Optional[datetime] = None
+        self,
+        user_id: str,
+        now: Optional[datetime] = None,
+        include_boilerplate: bool = False,
     ) -> SkillGraphResponse:
         now = now or datetime.now(timezone.utc)
         skills_by_slug, _ = await self._load_taxonomy()
@@ -121,6 +127,22 @@ class SkillGraphService:
         for slug, skill in skills_by_slug.items():
             state = states.get(slug)
             if state is None:
+                if not include_boilerplate:
+                    continue
+                summaries.append(
+                    SkillSummary(
+                        skill_slug=slug,
+                        name=skill.name,
+                        mastery_score=0.0,
+                        confidence=0.0,
+                        status=SkillStatus.NEW,
+                        trend=Trend.STABLE,
+                        evidence_count=0,
+                        recent_error_count=0,
+                        last_seen_at=None,
+                        last_reviewed_at=None,
+                    )
+                )
                 continue
             decayed = decay_state(state, now)
             summaries.append(
@@ -140,7 +162,11 @@ class SkillGraphService:
                     last_reviewed_at=decayed.last_reviewed_at,
                 )
             )
-        summaries.sort(key=lambda s: s.mastery_score, reverse=True)
+        # Keep deterministic order: boilerplate sorts by name, active by mastery
+        if include_boilerplate and not states:
+            summaries.sort(key=lambda s: s.name)
+        else:
+            summaries.sort(key=lambda s: s.mastery_score, reverse=True)
 
         edges = [
             SkillGraphEdge(source=prereq, target=slug, relation="prerequisite")
@@ -205,6 +231,63 @@ class SkillGraphService:
                 )
             )
         return results
+
+    @staticmethod
+    def _event_from_submission(submission) -> LearningEvent:
+        """Map a Submission row to a deterministic LearningEvent.
+
+        Uses a stable id ``sub:{submission.id}`` so repeated syncs and the
+        live submit path remain idempotent via ``event_exists``. Passed ->
+        SUBMISSION_PASSED, failed -> SUBMISSION_FAILED.
+        """
+        # Lazy import to avoid circular dep at module load
+        event_type = (
+            LearningEventType.SUBMISSION_PASSED
+            if getattr(submission, "passed", False)
+            else LearningEventType.SUBMISSION_FAILED
+        )
+        metadata: dict = {}
+        sig = getattr(submission, "error_signature", None)
+        if sig:
+            metadata["error_signature"] = sig
+        occurred = getattr(submission, "created_at", None) or datetime.now(timezone.utc)
+        return LearningEvent(
+            id=f"sub:{submission.id}",
+            user_id=submission.user_id,
+            event_type=event_type,
+            question_id=submission.question_id,
+            metadata=metadata,
+            occurred_at=occurred,
+        )
+
+    async def sync_from_submissions(
+        self, user_id: str, submissions: List[object]
+    ) -> EventIngestResult:
+        """Backfill skill graph from historic submissions (DB query).
+
+        Queries the *already persisted* ``submissions`` table (passed/failed) and
+        synthesizes ``LearningEvent``s. Idempotent: existing ``sub:{id}`` ids
+        are counted as ``duplicate``. Scoped to ``user_id``; foreign rows are
+        ``invalid``.
+        """
+        # Sort chronologically so mastery builds deterministically
+        try:
+            ordered = sorted(
+                submissions,
+                key=lambda s: getattr(
+                    s, "created_at", datetime.min.replace(tzinfo=timezone.utc)
+                ),
+            )
+        except Exception:
+            ordered = list(submissions)
+        events: List[LearningEvent] = []
+        for sub in ordered:
+            if getattr(sub, "user_id", None) != user_id:
+                continue
+            events.append(self._event_from_submission(sub))
+        if not events:
+            return EventIngestResult()
+        return await self.ingest_events(events, user_id=user_id)
 
     async def delete_history(self, user_id: str) -> None:
         await self.repository.delete_user_history(user_id)

--- a/backend/app/services/workspace_service.py
+++ b/backend/app/services/workspace_service.py
@@ -1,0 +1,290 @@
+"""Workspace + chat persistence backed by Redis.
+
+Gracefully degrades when Redis is unavailable (cache is None or disabled):
+all methods become no-ops / return None or empty lists, never raise.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from app.core.config import get_settings
+from app.services.redis_service import RedisCache
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class WorkspaceService:
+    """Per-user workspace (draft code, last-visited, chat) stored in Redis."""
+
+    def __init__(self, cache: Optional[RedisCache]):
+        self.cache = cache
+        settings = get_settings()
+        self.ttl_workspace = settings.REDIS_TTL_WORKSPACE
+        self.ttl_chat = settings.REDIS_TTL_CHAT
+        self.ttl_last_exec = settings.REDIS_TTL_LAST_EXEC
+        self.max_code_bytes = settings.WORKSPACE_CODE_MAX_BYTES
+        self.max_chat_messages = settings.CHAT_HISTORY_MAX_MESSAGES
+        self.max_chat_chars = settings.CHAT_MESSAGE_MAX_CHARS
+
+    @staticmethod
+    def _code_key(user_id: str, question_id: str, language: str) -> str:
+        return RedisCache.key("workspace", "code", user_id, question_id, language)
+
+    @staticmethod
+    def _meta_key(user_id: str, question_id: str) -> str:
+        return RedisCache.key("workspace", "meta", user_id, question_id)
+
+    @staticmethod
+    def _chat_key(user_id: str, question_id: str) -> str:
+        return RedisCache.key("chat", user_id, question_id)
+
+    @staticmethod
+    def _last_visited_key(user_id: str) -> str:
+        return RedisCache.key("workspace", "last_visited", user_id)
+
+    @staticmethod
+    def _last_exec_key(user_id: str, question_id: str, language: str) -> str:
+        return RedisCache.key("exec", "last", user_id, question_id, language)
+
+    @staticmethod
+    def _last_submit_key(user_id: str, question_id: str) -> str:
+        return RedisCache.key("submit", "last", user_id, question_id)
+
+    async def save_code(
+        self, user_id: str, question_id: str, language: str, code: str
+    ) -> None:
+        if not self.cache:
+            return
+        if len(code.encode("utf-8")) > self.max_code_bytes:
+            logger.warning(
+                "Workspace code too large: user=%s q=%s lang=%s bytes=%d",
+                user_id,
+                question_id,
+                language,
+                len(code.encode("utf-8")),
+            )
+            return
+        payload = {"code": code, "language": language, "updated_at": _now_iso()}
+        try:
+            await self.cache.set(
+                self._code_key(user_id, question_id, language),
+                payload,
+                ttl=self.ttl_workspace,
+            )
+            await self.cache.set(
+                self._meta_key(user_id, question_id),
+                {"language": language, "last_opened_at": _now_iso()},
+                ttl=self.ttl_workspace,
+            )
+            await self.cache.set(
+                self._last_visited_key(user_id),
+                {
+                    "question_id": question_id,
+                    "language": language,
+                    "visited_at": _now_iso(),
+                },
+                ttl=self.ttl_workspace,
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("save_code failed: %s", e)
+
+    async def get_code(
+        self, user_id: str, question_id: str, language: str
+    ) -> Optional[Dict[str, Any]]:
+        if not self.cache:
+            return None
+        try:
+            return await self.cache.get(self._code_key(user_id, question_id, language))
+        except Exception as e:  # pragma: no cover
+            logger.debug("get_code failed: %s", e)
+            return None
+
+    async def delete_code(self, user_id: str, question_id: str, language: str) -> None:
+        if not self.cache:
+            return
+        try:
+            await self.cache.delete(self._code_key(user_id, question_id, language))
+        except Exception as e:  # pragma: no cover
+            logger.debug("delete_code failed: %s", e)
+
+    async def get_meta(
+        self, user_id: str, question_id: str
+    ) -> Optional[Dict[str, Any]]:
+        if not self.cache:
+            return None
+        try:
+            return await self.cache.get(self._meta_key(user_id, question_id))
+        except Exception as e:  # pragma: no cover
+            logger.debug("get_meta failed: %s", e)
+            return None
+
+    async def get_last_visited(self, user_id: str) -> Optional[Dict[str, Any]]:
+        if not self.cache:
+            return None
+        try:
+            return await self.cache.get(self._last_visited_key(user_id))
+        except Exception as e:  # pragma: no cover
+            logger.debug("get_last_visited failed: %s", e)
+            return None
+
+    async def set_last_visited(
+        self, user_id: str, question_id: str, language: Optional[str] = None
+    ) -> None:
+        if not self.cache:
+            return
+        try:
+            await self.cache.set(
+                self._last_visited_key(user_id),
+                {
+                    "question_id": question_id,
+                    "language": language,
+                    "visited_at": _now_iso(),
+                },
+                ttl=self.ttl_workspace,
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("set_last_visited failed: %s", e)
+
+    async def get_chat(self, user_id: str, question_id: str) -> List[Dict[str, Any]]:
+        if not self.cache:
+            return []
+        try:
+            data = await self.cache.get(self._chat_key(user_id, question_id))
+            if isinstance(data, list):
+                return data
+            if isinstance(data, dict) and "messages" in data:
+                return data["messages"]
+            return []
+        except Exception as e:  # pragma: no cover
+            logger.debug("get_chat failed: %s", e)
+            return []
+
+    async def append_chat(
+        self,
+        user_id: str,
+        question_id: str,
+        messages: List[Dict[str, Any]],
+    ) -> None:
+        if not self.cache:
+            return
+        if not messages:
+            return
+        try:
+            existing = await self.get_chat(user_id, question_id)
+            incoming: List[Dict[str, Any]] = []
+            for m in messages:
+                role = m.get("role", "user")
+                if role not in ("user", "assistant"):
+                    continue
+                content = str(m.get("content", ""))[: self.max_chat_chars]
+                entry: Dict[str, Any] = {
+                    "role": role,
+                    "content": content,
+                    "timestamp": m.get("timestamp") or _now_iso(),
+                }
+                if m.get("structured") is not None:
+                    entry["structured"] = m["structured"]
+                incoming.append(entry)
+            combined = existing + incoming
+            if len(combined) > self.max_chat_messages:
+                combined = combined[-self.max_chat_messages :]
+            await self.cache.set(
+                self._chat_key(user_id, question_id), combined, ttl=self.ttl_chat
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("append_chat failed: %s", e)
+
+    async def set_chat(
+        self, user_id: str, question_id: str, messages: List[Dict[str, Any]]
+    ) -> None:
+        if not self.cache:
+            return
+        try:
+            trimmed = (
+                messages[-self.max_chat_messages :]
+                if len(messages) > self.max_chat_messages
+                else messages
+            )
+            normalized: List[Dict[str, Any]] = []
+            for m in trimmed:
+                role = m.get("role", "user")
+                if role not in ("user", "assistant"):
+                    continue
+                normalized.append(
+                    {
+                        "role": role,
+                        "content": str(m.get("content", ""))[: self.max_chat_chars],
+                        "structured": m.get("structured"),
+                        "timestamp": m.get("timestamp") or _now_iso(),
+                    }
+                )
+            await self.cache.set(
+                self._chat_key(user_id, question_id), normalized, ttl=self.ttl_chat
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("set_chat failed: %s", e)
+
+    async def clear_chat(self, user_id: str, question_id: str) -> None:
+        if not self.cache:
+            return
+        try:
+            await self.cache.delete(self._chat_key(user_id, question_id))
+        except Exception as e:  # pragma: no cover
+            logger.debug("clear_chat failed: %s", e)
+
+    async def set_last_exec(
+        self, user_id: str, question_id: str, language: str, result: Dict[str, Any]
+    ) -> None:
+        if not self.cache:
+            return
+        try:
+            await self.cache.set(
+                self._last_exec_key(user_id, question_id, language),
+                result,
+                ttl=self.ttl_last_exec,
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("set_last_exec failed: %s", e)
+
+    async def get_last_exec(
+        self, user_id: str, question_id: str, language: str
+    ) -> Optional[Dict[str, Any]]:
+        if not self.cache:
+            return None
+        try:
+            return await self.cache.get(
+                self._last_exec_key(user_id, question_id, language)
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("get_last_exec failed: %s", e)
+            return None
+
+    async def set_last_submit(
+        self, user_id: str, question_id: str, result: Dict[str, Any]
+    ) -> None:
+        if not self.cache:
+            return
+        try:
+            await self.cache.set(
+                self._last_submit_key(user_id, question_id),
+                result,
+                ttl=self.ttl_last_exec,
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("set_last_submit failed: %s", e)
+
+    async def get_last_submit(
+        self, user_id: str, question_id: str
+    ) -> Optional[Dict[str, Any]]:
+        if not self.cache:
+            return None
+        try:
+            return await self.cache.get(self._last_submit_key(user_id, question_id))
+        except Exception as e:  # pragma: no cover
+            logger.debug("get_last_submit failed: %s", e)
+            return None

--- a/backend/tests/unit/test_skill_graph_boilerplate_and_sync.py
+++ b/backend/tests/unit/test_skill_graph_boilerplate_and_sync.py
@@ -1,0 +1,172 @@
+"""TDD red tests for boilerplate graph + DB sync (submissions -> skill graph).
+
+These must fail before implementation and pass after.
+"""
+
+import pytest
+import pytest_asyncio
+
+from app.models.orm import QuestionORM, SkillORM, UserORM
+from app.models.skill_graph_schemas import SkillStatus
+from app.models.submission_schemas import SubmissionIn
+from app.repositories.sql_skill_graph_repository import SqlSkillGraphRepository
+from app.repositories.sql_submission_repository import SqlSubmissionRepository
+from app.services.skill_graph_service import SkillGraphService
+from app.services.skill_taxonomy import SKILLS, QUESTION_SKILLS
+
+
+@pytest_asyncio.fixture
+async def seeded_db(test_db):
+    session = test_db
+    # users
+    session.add(
+        UserORM(
+            id="u-sync",
+            username="syncuser",
+            email="syncuser@test.com",
+            hashed_password="hash",
+        )
+    )
+    session.add(
+        UserORM(
+            id="u-boiler",
+            username="boileruser",
+            email="boileruser@test.com",
+            hashed_password="hash",
+        )
+    )
+    for skill in SKILLS:
+        session.add(
+            SkillORM(
+                slug=skill.slug,
+                name=skill.name,
+                description=skill.description,
+                parent_id=skill.parent_id,
+                prerequisite_ids=skill.prerequisite_ids,
+            )
+        )
+    for qid in QUESTION_SKILLS.keys():
+        session.add(
+            QuestionORM(
+                id=qid,
+                title=qid,
+                difficulty="easy",
+                category="arrays",
+                company_tags=[],
+                description="seed",
+                starter_code={},
+                examples=[],
+                test_cases=[],
+                hints=[],
+                constraints=[],
+                is_interactive=0,
+            )
+        )
+    await session.commit()
+    # seed question_skills
+    from app.models.orm import QuestionSkillORM
+
+    for question_id, mappings in QUESTION_SKILLS.items():
+        for m in mappings:
+            session.add(
+                QuestionSkillORM(
+                    id=f"{question_id}:{m.skill_slug}",
+                    question_id=question_id,
+                    skill_slug=m.skill_slug,
+                    weight=m.weight,
+                )
+            )
+    await session.commit()
+    return session
+
+
+@pytest.mark.asyncio
+async def test_boilerplate_true_returns_all_skills_for_new_user(seeded_db):
+    repo = SqlSkillGraphRepository(seeded_db)
+    svc = SkillGraphService(repository=repo)
+    # new user has no states
+    graph = await svc.get_graph("u-boiler", include_boilerplate=True)
+    assert len(graph.skills) == len(SKILLS), (
+        "boilerplate must return every taxonomy skill"
+    )
+    assert graph.edges  # edges always present
+    for s in graph.skills:
+        assert s.mastery_score == 0.0
+        assert s.confidence == 0.0
+        assert s.status == SkillStatus.NEW
+        assert s.evidence_count == 0
+        assert s.trend.value == "stable"
+
+
+@pytest.mark.asyncio
+async def test_boilerplate_false_still_empty_for_new_user(seeded_db):
+    repo = SqlSkillGraphRepository(seeded_db)
+    svc = SkillGraphService(repository=repo)
+    graph = await svc.get_graph("u-boiler", include_boilerplate=False)
+    assert graph.skills == []
+
+
+@pytest.mark.asyncio
+async def test_sync_from_submissions_builds_graph_via_db_query(seeded_db):
+    skill_repo = SqlSkillGraphRepository(seeded_db)
+    sub_repo = SqlSubmissionRepository(seeded_db)
+    svc = SkillGraphService(repository=skill_repo)
+
+    # Simulate already-completed questions in submissions table (no learning_events yet)
+    await sub_repo.add(
+        user_id="u-sync",
+        submission=SubmissionIn(
+            question_id="two-sum", code="x", language="python", passed=True
+        ),
+    )
+    await sub_repo.add(
+        user_id="u-sync",
+        submission=SubmissionIn(
+            question_id="contains-duplicate", code="x", language="python", passed=True
+        ),
+    )
+
+    subs = await sub_repo.list_by_user("u-sync", limit=100)
+    # This method does not exist yet — should be implemented
+    result = await svc.sync_from_submissions("u-sync", subs)
+    assert result.accepted >= 2
+
+    graph = await svc.get_graph("u-sync")
+    slugs = {s.skill_slug for s in graph.skills}
+    # two-sum touches arrays+hash-maps, contains-duplicate touches hash-maps+arrays
+    assert "hash-maps" in slugs
+    assert "arrays" in slugs
+    # idempotency: second sync must not double-count
+    result2 = await svc.sync_from_submissions("u-sync", subs)
+    assert result2.duplicate >= 2
+    assert result2.accepted == 0
+
+
+@pytest.mark.asyncio
+async def test_sync_failed_submission_creates_failed_event(seeded_db):
+    skill_repo = SqlSkillGraphRepository(seeded_db)
+    sub_repo = SqlSubmissionRepository(seeded_db)
+    svc = SkillGraphService(repository=skill_repo)
+    await sub_repo.add(
+        user_id="u-sync",
+        submission=SubmissionIn(
+            question_id="two-sum",
+            code="bad",
+            language="python",
+            passed=False,
+            error_signature="expected true got false",
+        ),
+    )
+    subs = await sub_repo.list_by_user("u-sync", limit=100)
+    passed_subs = [s for s in subs if s.question_id == "two-sum" and not s.passed]
+    # need at least one failed
+    assert passed_subs
+    # sync only that failed one via fresh service with clean state
+    # reset states first
+    await skill_repo.delete_user_history("u-sync")
+    # re-add clean failed
+    # Use the single failed sub
+    result = await svc.sync_from_submissions("u-sync", passed_subs)
+    assert result.accepted == 1
+    states = await skill_repo.get_states("u-sync")
+    assert states["hash-maps"].recent_error_count == 1

--- a/backend/tests/unit/test_workspace_service.py
+++ b/backend/tests/unit/test_workspace_service.py
@@ -1,0 +1,134 @@
+"""Unit tests for WorkspaceService — Redis-backed draft code + chat + last-visited."""
+
+import pytest
+from app.services.workspace_service import WorkspaceService
+
+
+class FakeCache:
+    def __init__(self):
+        self.store: dict[str, object] = {}
+
+    async def get(self, key: str):
+        return self.store.get(key)
+
+    async def set(self, key: str, value, ttl: int = 300):
+        self.store[key] = value
+
+    async def delete(self, pattern: str):
+        self.store.pop(pattern, None)
+        return 1
+
+
+@pytest.mark.asyncio
+async def test_save_and_get_code(monkeypatch):
+    monkeypatch.setenv("REDIS_TTL_WORKSPACE", "604800")
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    await svc.save_code("u1", "q1", "python", "print('hi')")
+    data = await svc.get_code("u1", "q1", "python")
+    assert data is not None
+    assert data["code"] == "print('hi')"
+    assert data["language"] == "python"
+    assert "updated_at" in data
+    meta = await svc.get_meta("u1", "q1")
+    assert meta is not None
+    assert meta["language"] == "python"
+    last = await svc.get_last_visited("u1")
+    assert last is not None
+    assert last["question_id"] == "q1"
+
+
+@pytest.mark.asyncio
+async def test_get_code_missing_returns_none():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    assert await svc.get_code("u1", "q-missing", "python") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_code():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    await svc.save_code("u1", "q1", "python", "code")
+    await svc.delete_code("u1", "q1", "python")
+    assert await svc.get_code("u1", "q1", "python") is None
+
+
+@pytest.mark.asyncio
+async def test_graceful_no_cache():
+    svc = WorkspaceService(cache=None)
+    await svc.save_code("u1", "q1", "python", "code")
+    assert await svc.get_code("u1", "q1", "python") is None
+    assert await svc.get_chat("u1", "q1") == []
+    assert await svc.get_last_visited("u1") is None
+    await svc.append_chat("u1", "q1", [{"role": "user", "content": "hi"}])
+    await svc.clear_chat("u1", "q1")
+    await svc.delete_code("u1", "q1", "python")
+
+
+@pytest.mark.asyncio
+async def test_chat_append_and_get():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    await svc.append_chat("u1", "q1", [{"role": "user", "content": "hello"}])
+    await svc.append_chat(
+        "u1",
+        "q1",
+        [{"role": "assistant", "content": "hi there", "structured": {"summary": "s"}}],
+    )
+    msgs = await svc.get_chat("u1", "q1")
+    assert len(msgs) == 2
+    assert msgs[0]["role"] == "user"
+    assert msgs[1]["structured"]["summary"] == "s"
+
+
+@pytest.mark.asyncio
+async def test_chat_cap_truncation():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    svc.max_chat_messages = 3
+    for i in range(5):
+        await svc.append_chat("u1", "q1", [{"role": "user", "content": f"msg {i}"}])
+    msgs = await svc.get_chat("u1", "q1")
+    assert len(msgs) == 3
+    assert msgs[0]["content"] == "msg 2"
+    assert msgs[-1]["content"] == "msg 4"
+
+
+@pytest.mark.asyncio
+async def test_chat_content_truncation():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    svc.max_chat_chars = 5
+    await svc.append_chat("u1", "q1", [{"role": "user", "content": "123456789"}])
+    msgs = await svc.get_chat("u1", "q1")
+    assert msgs[0]["content"] == "12345"
+
+
+@pytest.mark.asyncio
+async def test_clear_chat():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    await svc.append_chat("u1", "q1", [{"role": "user", "content": "hi"}])
+    await svc.clear_chat("u1", "q1")
+    assert await svc.get_chat("u1", "q1") == []
+
+
+@pytest.mark.asyncio
+async def test_last_visited():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    await svc.set_last_visited("u1", "q42", "java")
+    data = await svc.get_last_visited("u1")
+    assert data["question_id"] == "q42"
+    assert data["language"] == "java"
+    assert "visited_at" in data
+
+
+@pytest.mark.asyncio
+async def test_oversized_code_not_saved():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    svc.max_code_bytes = 5
+    await svc.save_code("u1", "q1", "python", "123456")
+    assert await svc.get_code("u1", "q1", "python") is None

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -10,6 +10,7 @@
 const REWRITE_TARGET = process.env.API_URL || 'http://localhost:8000';
 
 const nextConfig = {
+  skipTrailingSlashRedirect: true,
   env: {
     // Preserve an explicit empty value (same-origin, CSP-safe); only
     // fall back when the variable is unset. `||` would resurrect the
@@ -48,15 +49,17 @@ const nextConfig = {
           // frame-src allows the Motion Canvas animation viewer (separate Vite
           // dev server on :9000 in E2E, or NEXT_PUBLIC_ANIMATION_VIEWER_URL in
           // prod) to load in an in-app iframe (see AnimateLauncher).
+          // Monaco fallback CDN (cdn.jsdelivr.net) is allowed for emergency
+          // fallback, but primary path is local monaco-editor via loader.config.
           {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-              "style-src 'self' 'unsafe-inline'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net",
+              "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
               "img-src 'self' data: blob: https:",
               "font-src 'self' data:",
-              "connect-src 'self' https: wss: ws:",
+              "connect-src 'self' https: wss: ws: https://cdn.jsdelivr.net",
               "worker-src 'self' blob:",
               `frame-src 'self' ${process.env.NEXT_PUBLIC_ANIMATION_VIEWER_URL || 'http://localhost:9000'}`,
               "object-src 'none'",

--- a/frontend/src/app/dashboard/page.test.tsx
+++ b/frontend/src/app/dashboard/page.test.tsx
@@ -13,10 +13,10 @@ vi.mock("@/features/question/question.hook", () => ({
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 describe("StudentDashboardPage polish", () => {
-  it("renders memory-first heading and dashboard queues", () => {
+  it("renders memory-first heading and dashboard queues", async () => {
     render(<StudentDashboardPage />);
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
-    expect(screen.getByTestId("memory-graph")).toBeInTheDocument();
+    expect(await screen.findByTestId("memory-graph")).toBeInTheDocument();
   });
 
   it("shows Replay tour button", () => {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import LearningSignals from "@/features/analytics/LearningSignals";
 import { MemoryGraph } from "@/features/memory/MemoryGraph";
 import { RescueDueQueue } from "@/features/rescue/RescueDueQueue";
 import { ReviewsDueQueue } from "@/features/review/ReviewsDueQueue";
+import { SkillGraph } from "@/features/skill-graph/SkillGraph";
 import { useQuestion } from "@/features/question/question.hook";
 import { resetOnboardingTour } from "@/components/onboarding/OnboardingTour";
 import Link from "next/link";
@@ -67,7 +68,8 @@ export default function StudentDashboardPage() {
           </div>
         </div>
         <div className="rounded-[2rem] bg-white/[0.03] ring-1 ring-white/5 p-1.5">
-          <div className="rounded-[calc(2rem-0.375rem)] bg-card shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] p-6">
+          <div className="rounded-[calc(2rem-0.375rem)] bg-card shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] p-6 space-y-6">
+            <SkillGraph />
             <LearningSignals />
             <MemoryGraph />
             <RescueDueQueue resolveTitle={resolveTitle} />

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,16 +1,46 @@
 "use client";
 
 import { Header } from "@/components/header/Header";
-import LearningSignals from "@/features/analytics/LearningSignals";
-import { MemoryGraph } from "@/features/memory/MemoryGraph";
-import { RescueDueQueue } from "@/features/rescue/RescueDueQueue";
-import { ReviewsDueQueue } from "@/features/review/ReviewsDueQueue";
-import { SkillGraph } from "@/features/skill-graph/SkillGraph";
 import { useQuestion } from "@/features/question/question.hook";
 import { resetOnboardingTour } from "@/components/onboarding/OnboardingTour";
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { RotateCcw, Sparkles } from "lucide-react";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/Skeleton";
+
+const SkillGraph = dynamic(
+  () => import("@/features/skill-graph/SkillGraph").then((m) => m.SkillGraph),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-32 w-full rounded-xl" />,
+  },
+);
+const LearningSignals = dynamic(() => import("@/features/analytics/LearningSignals"), {
+  ssr: false,
+  loading: () => <Skeleton className="h-24 w-full rounded-xl" />,
+});
+const MemoryGraph = dynamic(
+  () => import("@/features/memory/MemoryGraph").then((m) => m.MemoryGraph),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-48 w-full rounded-xl" />,
+  },
+);
+const RescueDueQueue = dynamic(
+  () => import("@/features/rescue/RescueDueQueue").then((m) => m.RescueDueQueue),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-20 w-full rounded-xl" />,
+  },
+);
+const ReviewsDueQueue = dynamic(
+  () => import("@/features/review/ReviewsDueQueue").then((m) => m.ReviewsDueQueue),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-20 w-full rounded-xl" />,
+  },
+);
 
 export default function StudentDashboardPage() {
   const { allQuestions, loadQuestions } = useQuestion();

--- a/frontend/src/app/problems/[id]/page.tsx
+++ b/frontend/src/app/problems/[id]/page.tsx
@@ -9,6 +9,7 @@ import { RescueIntervention } from '@/components/rescue/RescueIntervention';
 import { QuestionDescriptionPanel } from '@/components/sidebar/QuestionDescriptionPanel';
 import { ResizablePanelGroup } from '@/components/ui/ResizablePanelGroup';
 import { useCoaching } from '@/features/coaching/coaching.hook';
+import { useWorkspace } from '@/features/workspace/use-workspace.hook';
 import { CoachingMode } from '@/features/coaching/coaching.types';
 import { questionService } from '@/features/question/question.service';
 import { useCodeRunner } from '@/features/question/use-code-runner.hook';
@@ -62,7 +63,7 @@ export default function ProblemWorkspacePage() {
     isAuthenticated,
   } = useCodeRunner({ fullQuestion, language, currentCode });
 
-  const { messages, isTyping, sendMessage } = useCoaching();
+  const { messages, isTyping, sendMessage, hydrateMessages } = useCoaching() as ReturnType<typeof useCoaching> & { hydrateMessages: (msgs: import('@/types').ChatMessage[]) => void };
   const { ref: workspaceRef, mode } = useWorkspaceMode();
   const [drawerOpen, setDrawerOpen] = useState(false);
 
@@ -84,6 +85,24 @@ export default function ProblemWorkspacePage() {
       ? fullQuestion.starter[language as keyof typeof fullQuestion.starter] || ''
       : '';
 
+  const { deleteDraft } = useWorkspace({
+    questionId: questionId || null,
+    language,
+    currentCode,
+    setCurrentCode,
+    onHydrateChat: (msgs) => {
+      // Convert persisted messages to ChatMessage
+      const hydrated = msgs.map((m) => ({
+        id: `${Date.now()}-${Math.random()}`,
+        role: m.role as 'user' | 'assistant',
+        content: m.content,
+        structured: (m as unknown as { structured?: import('@/types').StructuredCoachingResponse }).structured ?? null,
+        timestamp: new Date((m as unknown as { timestamp: string }).timestamp),
+      }));
+      if (hydrated.length) hydrateMessages(hydrated as import('@/types').ChatMessage[]);
+    },
+  });
+
   const handleEscalateToT2 = useCallback(() => {
     if (!fullQuestion) return;
     const checkpoints = buildRescueCheckpoints(
@@ -103,9 +122,10 @@ export default function ProblemWorkspacePage() {
       undefined,
       fullQuestion.difficulty,
       starterCode,
+      questionId,
     );
     if (mode !== 'wide') setDrawerOpen(true);
-  }, [fullQuestion, lastSubmitResult, currentCode, language, starterCode, sendMessage, mode]);
+  }, [fullQuestion, lastSubmitResult, currentCode, language, starterCode, sendMessage, mode, questionId]);
 
   const handleEscalateToT3 = useCallback(() => {
     if (!fullQuestion) return;
@@ -126,9 +146,10 @@ export default function ProblemWorkspacePage() {
       undefined,
       fullQuestion.difficulty,
       starterCode,
+      questionId,
     );
     if (mode !== 'wide') setDrawerOpen(true);
-  }, [fullQuestion, lastSubmitResult, currentCode, language, starterCode, sendMessage, mode]);
+  }, [fullQuestion, lastSubmitResult, currentCode, language, starterCode, sendMessage, mode, questionId]);
 
   const rescue = useRescueContract({
     questionId,
@@ -153,9 +174,10 @@ export default function ProblemWorkspacePage() {
         undefined,
         undefined,
         starterCode,
+        questionId,
       );
     },
-    [fullQuestion, currentCode, language, sendMessage, rescueActivity, starterCode],
+    [fullQuestion, currentCode, language, sendMessage, rescueActivity, starterCode, questionId],
   );
 
   const handleRunCodeRescue = useCallback(
@@ -178,6 +200,12 @@ export default function ProblemWorkspacePage() {
     },
     [rescueActivity],
   );
+
+  const handleResetCode = useCallback(() => {
+    rescueActivity();
+    setCurrentCode(starterCode);
+    void deleteDraft();
+  }, [rescueActivity, starterCode, deleteDraft]);
 
   const handleLanguageChangeRescue = useCallback(
     (lang: Language) => {
@@ -281,6 +309,7 @@ export default function ProblemWorkspacePage() {
           testResults={testResults}
           isInteractive={fullQuestion.is_interactive || false}
           onCodeChange={handleCodeChangeRescue}
+          onResetCode={handleResetCode}
           onLanguageChange={handleLanguageChangeRescue}
           onRunCode={handleRunCodeRescue}
           onSubmitCode={handleSubmitCodeRescue}

--- a/frontend/src/app/problems/page.tsx
+++ b/frontend/src/app/problems/page.tsx
@@ -23,7 +23,9 @@ import {
   XCircle,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { workspaceService } from '@/features/workspace/workspace.service';
+import { AuthContext } from '@/providers/AuthProvider';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 
 const difficultyStyles: Record<string, string> = {
@@ -45,6 +47,9 @@ export default function ProblemsPage() {
   const router = useRouter();
   const { allQuestions, loadQuestions, isLoading, error } = useQuestion();
   const [progress] = useLocalStorage<Record<string, 'attempted' | 'solved'>>('user_progress', {});
+  const auth = useContext(AuthContext);
+  const isAuthenticated = auth?.isAuthenticated ?? false;
+  const [lastVisited, setLastVisited] = useState<{ question_id: string; language: string | null } | null>(null);
 
   const [search, setSearch] = useState('');
   const [difficulty, setDifficulty] = useState<string>('all');
@@ -56,6 +61,13 @@ export default function ProblemsPage() {
   useEffect(() => {
     loadQuestions();
   }, [loadQuestions]);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    workspaceService.getLastVisited().then((data) => {
+      if (data?.question_id) setLastVisited(data);
+    }).catch(() => {});
+  }, [isAuthenticated]);
 
   const categories = useMemo(() => {
     const set = new Set<string>();
@@ -183,6 +195,12 @@ export default function ProblemsPage() {
     <div className="min-h-[100dvh] bg-background text-foreground">
       <Header />
       <main className="max-w-5xl mx-auto px-6 pt-20 pb-32">
+        {lastVisited && (
+          <div className="mb-4 flex items-center justify-between px-4 py-3 rounded-2xl bg-primary/10 ring-1 ring-primary/20">
+            <span className="text-xs text-primary/90">Continue where you left off: <span className="font-medium">{resolveQuestionTitle(lastVisited.question_id) || lastVisited.question_id}</span></span>
+            <button onClick={() => router.push(`/problems/${lastVisited.question_id}`)} className="text-xs px-3 py-1 rounded-full bg-primary text-primary-foreground hover:bg-primary/90">Resume</button>
+          </div>
+        )}
         <RecommendedQuestions />
         <RescueDueQueue resolveTitle={resolveQuestionTitle} />
         <ReviewsDueQueue resolveTitle={resolveQuestionTitle} />

--- a/frontend/src/components/editor/CodeEditor.tsx
+++ b/frontend/src/components/editor/CodeEditor.tsx
@@ -17,6 +17,7 @@ const Editor = dynamic(() => import("@monaco-editor/react"), {
 });
 
 interface CodeEditorProps {
+  onReset?: () => void;
   language: Language;
   code: string;
   initialCode: string;
@@ -40,6 +41,7 @@ export function CodeEditor({
   isRunning,
   isResizing,
   isAuthenticated = true,
+  onReset,
 }: CodeEditorProps) {
   const editorRef = useRef<any>(null);
   const monacoLanguage = language === "c" ? "cpp" : language;
@@ -53,7 +55,11 @@ export function CodeEditor({
   };
 
   const resetCode = () => {
-    onCodeChange(initialCode);
+    if (onReset) {
+      onReset();
+    } else {
+      onCodeChange(initialCode);
+    }
   };
 
   return (

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -41,7 +41,7 @@ export function Header() {
             CodeCoach AI
           </Link>
 
-          {/* Desktop Nav */}
+          {/* Desktop Nav — Dashboard moved to gear menu */}
           <nav className="hidden md:flex items-center gap-0.5 ml-2">
             <Link
               href="/problems"
@@ -56,13 +56,6 @@ export function Header() {
             >
               <GraduationCap className="h-3 w-3" />
               Learn
-            </Link>
-            <Link
-              href="/dashboard"
-              className="px-3 py-1.5 text-xs text-muted-foreground/70 hover:text-foreground hover:bg-white/5 rounded-full transition-all duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] flex items-center gap-1.5"
-            >
-              <LayoutDashboard className="h-3 w-3" />
-              Dashboard
             </Link>
             {isAdmin && (
               <Link
@@ -171,7 +164,6 @@ export function Header() {
             { href: '/', label: 'Home', delay: 'delay-100' },
             { href: '/problems', label: 'Problems', delay: 'delay-115' },
             { href: '/learn', label: 'Learn', delay: 'delay-125' },
-            { href: '/dashboard', label: 'Dashboard', delay: 'delay-130' },
             ...(isAdmin
               ? [{ href: '/admin', label: 'Admin Panel', delay: 'delay-135' as const, highlight: true as const }]
               : []),

--- a/frontend/src/components/layout/elements/CodeEditorContainer.tsx
+++ b/frontend/src/components/layout/elements/CodeEditorContainer.tsx
@@ -24,6 +24,7 @@ interface CodeEditorContainerProps {
   onRunCode: (stdin: string) => void;
   onSubmitCode: () => void;
   isAuthenticated?: boolean;
+  onResetCode?: () => void;
 }
 
 export function CodeEditorContainer({
@@ -40,6 +41,7 @@ export function CodeEditorContainer({
   onRunCode,
   onSubmitCode,
   isAuthenticated = true,
+  onResetCode,
 }: CodeEditorContainerProps) {
   const [outputHeight, setOutputHeight] = useState(200); // Default 200px
   const [outputCollapsed, setOutputCollapsed] = useState(false);
@@ -122,6 +124,7 @@ export function CodeEditorContainer({
           isRunning={isRunning}
           isResizing={isResizing}
           isAuthenticated={isAuthenticated}
+          onReset={onResetCode}
         />
 
         {/* Interactive Input Area */}

--- a/frontend/src/components/settings/SettingsModal.tsx
+++ b/frontend/src/components/settings/SettingsModal.tsx
@@ -1,126 +1,63 @@
 'use client';
-
 import { Button } from '@/components/ui/button';
-import { FileText, LogOut, Sparkles, X } from 'lucide-react';
-import { useEffect, useRef } from 'react';
-
-interface SettingsModalProps {
-  open: boolean;
-  onClose: () => void;
-  isAuthenticated?: boolean;
-  onLogout?: () => void;
-  plan?: string;
-}
-
-export function SettingsModal({
-  open,
-  onClose,
-  isAuthenticated = false,
-  onLogout,
-  plan = 'free',
-}: SettingsModalProps) {
+import { FileText, LayoutDashboard, LogOut, Sparkles, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+interface SettingsModalProps { open: boolean; onClose: () => void; isAuthenticated?: boolean; onLogout?: () => void; plan?: string; }
+type Tab = 'settings' | 'dashboard' | 'skills';
+export function SettingsModal({ open, onClose, isAuthenticated = false, onLogout, plan = 'free', }: SettingsModalProps) {
   const inputRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (open) {
-      setTimeout(() => inputRef.current?.focus(), 100);
-    }
-  }, [open]);
-
-  useEffect(() => {
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    if (open) document.addEventListener('keydown', handleEsc);
-    return () => document.removeEventListener('keydown', handleEsc);
-  }, [open, onClose]);
-
+  const [tab, setTab] = useState<Tab>('settings');
+  useEffect(() => { if (open) { setTimeout(() => inputRef.current?.focus(), 100); } else { setTab('settings'); } }, [open]);
+  useEffect(() => { const handleEsc = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); }; if (open) document.addEventListener('keydown', handleEsc); return () => document.removeEventListener('keydown', handleEsc); }, [open, onClose]);
   if (!open) return null;
-
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
       <div className="relative w-full max-w-md mx-4 p-1.5 rounded-[2rem] bg-white/[0.03] ring-1 ring-white/10">
-        <div className="rounded-[calc(2rem-0.375rem)] bg-card shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] p-6">
-          <div className="flex items-center justify-between mb-5">
+        <div className="rounded-[calc(2rem-0.375rem)] bg-card shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] p-6 max-h-[85vh] overflow-y-auto">
+          <div className="flex items-center justify-between mb-3">
             <h2 className="text-sm font-semibold tracking-wide text-foreground/80">SETTINGS</h2>
-            <button
-              aria-label="Close"
-              onClick={onClose}
-              className="p-1.5 hover:bg-white/5 rounded-full transition-all duration-500 ease-[cubic-bezier(0.32,0.72,0,1)]"
-            >
-              <X className="h-3.5 w-3.5 text-muted-foreground" />
-            </button>
+            <button aria-label="Close" onClick={onClose} className="p-1.5 hover:bg-white/5 rounded-full transition-all duration-500 ease-[cubic-bezier(0.32,0.72,0,1)]"><X className="h-3.5 w-3.5 text-muted-foreground" /></button>
           </div>
-
+          <div className="flex items-center gap-1 p-1 rounded-full bg-white/[0.04] ring-1 ring-white/5 mb-4" role="tablist">
+            {[
+              { id: 'settings' as Tab, label: 'Settings' },
+              { id: 'dashboard' as Tab, label: 'Dashboard' },
+              { id: 'skills' as Tab, label: 'Skills' },
+            ].map((t) => (
+              <button key={t.id} role="tab" aria-selected={tab === t.id} data-testid={`settings-tab-${t.id}`} onClick={() => setTab(t.id)} className={`flex-1 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${tab === t.id ? 'bg-white text-black' : 'text-muted-foreground hover:text-foreground'}`}>{t.label}</button>
+            ))}
+          </div>
           <div ref={inputRef} tabIndex={-1} className="space-y-4">
-            <div className="rounded-2xl bg-white/[0.03] ring-1 ring-white/5 p-4">
-              <div className="flex items-start gap-3">
-                <Sparkles className="h-4 w-4 text-primary mt-0.5 shrink-0" />
-                <div>
-                  <p className="text-xs font-medium text-foreground/80">
-                    AI coaching powered by Groq
-                  </p>
-                  <p className="text-[10px] text-muted-foreground/60 mt-1 leading-relaxed">
-                    Coaching runs on the platform&apos;s Groq API key — no setup required. Token
-                    usage is metered per account with daily limits.
-                  </p>
+            {tab === 'dashboard' && (
+              <div className="space-y-3" data-testid="settings-dashboard-tab">
+                <div className="rounded-2xl bg-white/[0.03] ring-1 ring-white/5 p-4">
+                  <div className="flex items-center gap-2 mb-1"><LayoutDashboard className="h-4 w-4 text-primary" /><p className="text-xs font-medium text-foreground/80">Dashboard</p></div>
+                  <p className="text-[11px] text-muted-foreground/60 leading-relaxed">Your memory graph — what to refresh before you forget. Open the full dashboard for reviews, rescue queue and skill graph.</p>
+                  <button onClick={() => { window.location.href = '/dashboard'; onClose(); }} data-testid="settings-dashboard-open" className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-white text-black px-4 py-1.5 text-xs font-medium hover:bg-white/90 transition-colors"><LayoutDashboard className="h-3.5 w-3.5" /> Open Dashboard</button>
                 </div>
-              </div>
-            </div>
-
-            <div className="rounded-2xl bg-white/[0.03] ring-1 ring-white/5 p-4">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-xs font-medium text-foreground/80">Your plan</p>
-                  <p className="text-[10px] text-muted-foreground/60 mt-1 leading-relaxed">
-                    {plan === 'premium'
-                      ? 'Premium — AI Coach and all features unlocked.'
-                      : 'Free — questions and curriculum included. AI Coach requires Premium.'}
-                  </p>
-                </div>
-                <span className="rounded-full bg-primary/10 px-3 py-1 text-[10px] font-medium uppercase tracking-wide text-primary">
-                  {plan === 'premium' ? 'Premium' : 'Free'}
-                </span>
-              </div>
-            </div>
-
-            <div className="flex justify-end gap-2 pt-2">
-              <Button variant="outline" size="sm" onClick={onClose}>
-                Cancel
-              </Button>
-              <Button size="sm" onClick={onClose}>
-                Done
-              </Button>
-            </div>
-
-            <div className="border-t border-white/5 pt-4 mt-2 space-y-1">
-              <button
-                onClick={() => {
-                  window.location.href = '/privacy';
-                  onClose();
-                }}
-                className="flex items-center gap-2 w-full px-3 py-2 text-sm text-foreground/60 hover:text-foreground hover:bg-white/5 rounded-xl transition-all duration-500 ease-[cubic-bezier(0.32,0.72,0,1)]"
-              >
-                <FileText className="h-4 w-4" />
-                Privacy Policy
-              </button>
-            </div>
-
-            {isAuthenticated && onLogout && (
-              <div className="border-t border-white/5 pt-4 mt-2">
-                <button
-                  onClick={() => {
-                    onLogout();
-                    onClose();
-                  }}
-                  className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-400/80 hover:text-red-400 hover:bg-red-500/10 rounded-xl transition-all duration-500 ease-[cubic-bezier(0.32,0.72,0,1)]"
-                >
-                  <LogOut className="h-4 w-4" />
-                  Sign out
-                </button>
               </div>
             )}
+            {tab === 'skills' && (
+              <div className="rounded-2xl bg-white/[0.03] ring-1 ring-white/5 p-4" data-testid="settings-skills-tab">
+                <p className="text-xs font-medium text-foreground/80 mb-1">Your Skill Graph</p>
+                <p className="text-[11px] text-muted-foreground/60 leading-relaxed mb-3">Mastery per skill lives in the Dashboard as a graph — open Dashboard to see the full map. This preview is the boilerplate (all 22 skills).</p>
+                <button onClick={() => { window.location.href = '/dashboard'; onClose(); }} className="inline-flex items-center gap-1.5 rounded-full bg-primary/90 text-primary-foreground px-4 py-1.5 text-xs font-medium hover:bg-primary transition-colors"><LayoutDashboard className="h-3.5 w-3.5" /> View graph in Dashboard</button>
+              </div>
+            )}
+            {tab === 'settings' && (
+              <>
+                <div className="rounded-2xl bg-white/[0.03] ring-1 ring-white/5 p-4">
+                  <div className="flex items-start gap-3"><Sparkles className="h-4 w-4 text-primary mt-0.5 shrink-0" /><div><p className="text-xs font-medium text-foreground/80">AI coaching powered by Groq</p><p className="text-[10px] text-muted-foreground/60 mt-1 leading-relaxed">Coaching runs on the platform&apos;s Groq API key — no setup required. Token usage is metered per account with daily limits.</p></div></div>
+                </div>
+                <div className="rounded-2xl bg-white/[0.03] ring-1 ring-white/5 p-4">
+                  <div className="flex items-center justify-between gap-3"><div><p className="text-xs font-medium text-foreground/80">Your plan</p><p className="text-[10px] text-muted-foreground/60 mt-1 leading-relaxed">{plan === 'premium' ? 'Premium — AI Coach and all features unlocked.' : 'Free — questions and curriculum included. AI Coach requires Premium.'}</p></div><span className="rounded-full bg-primary/10 px-3 py-1 text-[10px] font-medium uppercase tracking-wide text-primary">{plan === 'premium' ? 'Premium' : 'Free'}</span></div>
+                </div>
+              </>
+            )}
+            <div className="flex justify-end gap-2 pt-2"><Button variant="outline" size="sm" onClick={onClose}>Cancel</Button><Button size="sm" onClick={onClose}>Done</Button></div>
+            <div className="border-t border-white/5 pt-4 mt-2 space-y-1"><button onClick={() => { window.location.href = '/privacy'; onClose(); }} className="flex items-center gap-2 w-full px-3 py-2 text-sm text-foreground/60 hover:text-foreground hover:bg-white/5 rounded-xl transition-all duration-500 ease-[cubic-bezier(0.32,0.72,0,1)]"><FileText className="h-4 w-4" /> Privacy Policy</button></div>
+            {isAuthenticated && onLogout && (<div className="border-t border-white/5 pt-4 mt-2"><button onClick={() => { onLogout(); onClose(); }} className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-400/80 hover:text-red-400 hover:bg-red-500/10 rounded-xl transition-all duration-500 ease-[cubic-bezier(0.32,0.72,0,1)]"><LogOut className="h-4 w-4" /> Sign out</button></div>)}
           </div>
         </div>
       </div>

--- a/frontend/src/features/coaching/coaching.hook.ts
+++ b/frontend/src/features/coaching/coaching.hook.ts
@@ -15,7 +15,7 @@ function isRateLimited(err: unknown): boolean {
   );
 }
 
-export function useCoaching(): CoachingFeature {
+export function useCoaching(): CoachingFeature & { hydrateMessages: (msgs: ChatMessage[]) => void } {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
@@ -28,6 +28,11 @@ export function useCoaching(): CoachingFeature {
     clearLimitReached,
   } = useUsage();
 
+  const hydrateMessages = useCallback((msgs: ChatMessage[]) => {
+    setMessages(msgs);
+    messagesRef.current = msgs;
+  }, []);
+
   const sendMessage = useCallback(
     async (
       message: string,
@@ -38,6 +43,7 @@ export function useCoaching(): CoachingFeature {
       lessonContext?: string,
       difficulty?: string,
       initialCode?: string,
+      questionId?: string,
     ) => {
       const userMessage: ChatMessage = {
         id: Date.now().toString(),
@@ -69,6 +75,7 @@ export function useCoaching(): CoachingFeature {
             lessonContext,
             chatHistory,
             initialCode,
+            questionId,
           );
 
           const assistantMessage: ChatMessage = {
@@ -134,5 +141,6 @@ export function useCoaching(): CoachingFeature {
     clearError,
     limitReached,
     clearLimitReached,
+    hydrateMessages,
   };
 }

--- a/frontend/src/features/coaching/coaching.service.ts
+++ b/frontend/src/features/coaching/coaching.service.ts
@@ -12,6 +12,7 @@ export interface CoachingRequest {
   lesson_context?: string;
   chat_history?: { role: string; content: string }[];
   initial_code?: string;
+  question_id?: string;
 }
 
 export interface CoachingResponse {
@@ -32,6 +33,7 @@ export class CoachingService {
     lessonContext?: string,
     chatHistory?: { role: string; content: string }[],
     initialCode?: string,
+    questionId?: string,
   ): Promise<CoachingResponse> {
     const body: CoachingRequest = {
       problem,
@@ -49,6 +51,9 @@ export class CoachingService {
     }
     if (initialCode !== undefined) {
       body.initial_code = initialCode;
+    }
+    if (questionId) {
+      body.question_id = questionId;
     }
     const data = await this.http.post<{
       response: string;

--- a/frontend/src/features/coaching/coaching.types.ts
+++ b/frontend/src/features/coaching/coaching.types.ts
@@ -16,6 +16,7 @@ export interface CoachingRequest {
   mode: CoachingMode;
   difficulty?: string;
   initial_code?: string;
+  question_id?: string;
 }
 
 export interface CoachingResponse {
@@ -40,10 +41,12 @@ export interface CoachingActions {
     lessonContext?: string,
     difficulty?: string,
     initialCode?: string,
+    questionId?: string,
   ) => Promise<void>;
   clearMessages: () => void;
   clearError: () => void;
   clearLimitReached: () => void;
+  hydrateMessages?: (msgs: ChatMessage[]) => void;
 }
 
 export type CoachingFeature = CoachingState & CoachingActions;

--- a/frontend/src/features/skill-graph/SkillGraph.tsx
+++ b/frontend/src/features/skill-graph/SkillGraph.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { Badge } from '@/components/ui/Badge';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { useSkillGraph } from './use-skill-graph.hook';
+import { BookOpen, Sparkles, RefreshCw } from 'lucide-react';
+
+const STATUS_COLOR: Record<string, string> = {
+  new: 'bg-white/[0.04] text-muted-foreground/60 ring-white/10',
+  learning: 'bg-amber-500/10 text-amber-300 ring-amber-500/20',
+  developing: 'bg-blue-500/10 text-blue-300 ring-blue-500/20',
+  strong: 'bg-emerald-500/10 text-emerald-300 ring-emerald-500/20',
+  needs_review: 'bg-red-500/10 text-red-300 ring-red-500/20',
+};
+
+function masteryLabel(score: number) {
+  if (score >= 0.75) return 'Strong';
+  if (score >= 0.45) return 'Developing';
+  if (score >= 0.2) return 'Learning';
+  return 'New';
+}
+
+export function SkillGraph() {
+  const { graph, isLoading, error, refresh, syncFromSubmissions } = useSkillGraph(true);
+
+  if (isLoading) {
+    return (
+      <section aria-label="Skill graph" className="rounded-[2rem] bg-white/[0.03] ring-1 ring-white/5 p-5 md:p-6">
+        <div className="flex items-center gap-2.5 mb-4">
+          <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-primary/10 text-primary/80 ring-1 ring-primary/20">
+            <Sparkles className="h-4 w-4" />
+          </span>
+          <Skeleton width={140} height={14} />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3" data-testid="skill-graph-loading">
+          {[0, 1, 2, 3, 4, 5].map((i) => (
+            <div key={i} className="rounded-2xl border border-white/[0.04] bg-white/[0.01] p-4">
+              <Skeleton width={100} height={14} />
+              <Skeleton width="100%" height={8} className="mt-3" />
+              <Skeleton width={60} height={12} className="mt-3" />
+            </div>
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section aria-label="Skill graph" className="rounded-[2rem] bg-white/[0.03] ring-1 ring-white/5 p-5 md:p-6">
+        <p className="text-xs text-red-400/80">{error}</p>
+        <button
+          onClick={refresh}
+          className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-white/[0.04] ring-1 ring-white/10 px-3 py-1.5 text-xs font-medium text-muted-foreground/80 hover:bg-white/[0.08] transition-colors"
+        >
+          <RefreshCw className="h-3 w-3" /> Retry
+        </button>
+      </section>
+    );
+  }
+
+  const skills = graph?.skills ?? [];
+  const edges = graph?.edges ?? [];
+  const isBoilerplate = skills.length > 0 && skills.every((s) => s.mastery_score === 0 && s.evidence_count === 0);
+
+  return (
+    <section aria-label="Skill graph" className="rounded-[2rem] bg-white/[0.03] ring-1 ring-white/5 p-5 md:p-6">
+      <div className="flex items-center justify-between gap-3 mb-4">
+        <div className="flex items-center gap-2.5">
+          <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-primary/10 text-primary/80 ring-1 ring-primary/20">
+            <BookOpen className="h-4 w-4" />
+          </span>
+          <div>
+            <h2 className="text-sm font-semibold tracking-tight">Your Skill Graph</h2>
+            <p className="text-[11px] text-muted-foreground/60">
+              {isBoilerplate
+                ? 'Start solving — this is your starter map'
+                : `${skills.length} skills • ${edges.length} prerequisite links`}
+            </p>
+          </div>
+        </div>
+        {!isBoilerplate && (
+          <button
+            onClick={syncFromSubmissions}
+            title="Rebuild graph from completed submissions (DB query)"
+            className="inline-flex items-center gap-1.5 rounded-full bg-white/[0.04] ring-1 ring-white/10 px-3 py-1.5 text-xs font-medium text-muted-foreground/80 hover:bg-white/[0.08] transition-colors"
+          >
+            <RefreshCw className="h-3 w-3" /> Sync from history
+          </button>
+        )}
+      </div>
+
+      {skills.length === 0 ? (
+        <p className="text-xs text-muted-foreground/60">No skills yet — solve a problem to build your graph.</p>
+      ) : (
+        <>
+          {isBoilerplate && (
+            <div className="mb-4 rounded-2xl border border-dashed border-white/10 bg-white/[0.02] p-3">
+              <p className="text-xs text-muted-foreground/70">
+                This is a <span className="text-foreground/90 font-medium">boilerplate graph</span> showing every skill in the taxonomy.
+                Solve your first question and we&apos;ll sync your progress from the database — mastery, confidence and prerequisites will light up.
+              </p>
+            </div>
+          )}
+          <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {skills.map((skill) => (
+              <li
+                key={skill.skill_slug}
+                data-testid="skill-node"
+                data-skill={skill.skill_slug}
+                className="group flex flex-col rounded-2xl border border-white/[0.04] bg-white/[0.01] p-4 hover:border-white/[0.10] hover:bg-white/[0.04] transition-colors"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="text-sm font-medium text-foreground/90">{skill.name}</span>
+                  <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ring-1 ${STATUS_COLOR[skill.status] ?? STATUS_COLOR.new}`}>
+                    {masteryLabel(skill.mastery_score)}
+                  </span>
+                </div>
+                <div className="mt-2 h-1.5 w-full rounded-full bg-white/[0.06] overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-primary/80 transition-all duration-500"
+                    style={{ width: `${Math.round(skill.mastery_score * 100)}%` }}
+                    aria-label={`${skill.name} mastery ${Math.round(skill.mastery_score * 100)}%`}
+                  />
+                </div>
+                <div className="mt-2 flex items-center justify-between gap-2 text-[11px] text-muted-foreground/60">
+                  <span>mastery {(skill.mastery_score * 100).toFixed(0)}% • conf {(skill.confidence * 100).toFixed(0)}%</span>
+                  <Badge variant="outline" size="sm">{skill.skill_slug}</Badge>
+                </div>
+                {skill.evidence_count > 0 && (
+                  <p className="mt-1 text-[11px] text-muted-foreground/50">
+                    {skill.evidence_count} evidence • {skill.recent_error_count} recent errors
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+          {edges.length > 0 && (
+            <p className="mt-4 text-[11px] text-muted-foreground/40">
+              {edges.length} prerequisite edges — e.g. <span className="text-muted-foreground/60">{edges[0].source} → {edges[0].target}</span>
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/skill-graph/SkillGraph.tsx
+++ b/frontend/src/features/skill-graph/SkillGraph.tsx
@@ -1,28 +1,72 @@
 'use client';
-
-import { Badge } from '@/components/ui/Badge';
+import { useMemo } from 'react';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { useSkillGraph } from './use-skill-graph.hook';
-import { BookOpen, Sparkles, RefreshCw } from 'lucide-react';
-
+import { BookOpen, RefreshCw, Sparkles } from 'lucide-react';
+import { SkillSummary } from '@/types';
 const STATUS_COLOR: Record<string, string> = {
-  new: 'bg-white/[0.04] text-muted-foreground/60 ring-white/10',
-  learning: 'bg-amber-500/10 text-amber-300 ring-amber-500/20',
-  developing: 'bg-blue-500/10 text-blue-300 ring-blue-500/20',
-  strong: 'bg-emerald-500/10 text-emerald-300 ring-emerald-500/20',
-  needs_review: 'bg-red-500/10 text-red-300 ring-red-500/20',
+  new: '#6b7280',
+  learning: '#f59e0b',
+  developing: '#3b82f6',
+  strong: '#10b981',
+  needs_review: '#ef4444',
 };
-
-function masteryLabel(score: number) {
-  if (score >= 0.75) return 'Strong';
-  if (score >= 0.45) return 'Developing';
-  if (score >= 0.2) return 'Learning';
-  return 'New';
+const STATUS_BG: Record<string, string> = {
+  new: 'rgba(107,114,128,0.12)',
+  learning: 'rgba(245,158,11,0.14)',
+  developing: 'rgba(59,130,246,0.14)',
+  strong: 'rgba(16,185,129,0.14)',
+  needs_review: 'rgba(239,68,68,0.14)',
+};
+type Pos = { x: number; y: number; depth: number };
+function computeLayout(skills: SkillSummary[], edges: { source: string; target: string }[]): Map<string, Pos> {
+  const bySlug = new Map(skills.map((s) => [s.skill_slug, s]));
+  const prereqMap = new Map<string, string[]>();
+  edges.forEach((e) => {
+    if (!bySlug.has(e.source) || !bySlug.has(e.target)) return;
+    if (!prereqMap.has(e.target)) prereqMap.set(e.target, []);
+    prereqMap.get(e.target)!.push(e.source);
+  });
+  const depthCache = new Map<string, number>();
+  const visiting = new Set<string>();
+  const depthOf = (slug: string): number => {
+    if (depthCache.has(slug)) return depthCache.get(slug)!;
+    if (visiting.has(slug)) return 0;
+    visiting.add(slug);
+    const prereqs = prereqMap.get(slug) ?? [];
+    const d = prereqs.length === 0 ? 0 : 1 + Math.max(...prereqs.map(depthOf));
+    visiting.delete(slug);
+    depthCache.set(slug, d);
+    return d;
+  };
+  skills.forEach((s) => depthOf(s.skill_slug));
+  const levels = new Map<number, string[]>();
+  depthCache.forEach((d, slug) => {
+    if (!levels.has(d)) levels.set(d, []);
+    levels.get(d)!.push(slug);
+  });
+  const width = 900;
+  const padX = 80;
+  const usableW = width - padX * 2;
+  const layerH = 110;
+  const pos = new Map<string, Pos>();
+  levels.forEach((slugs, depth) => {
+    slugs.sort();
+    const n = slugs.length;
+    slugs.forEach((slug, idx) => {
+      const x = n === 1 ? width / 2 : padX + (idx / (n - 1)) * usableW;
+      const y = 60 + depth * layerH;
+      pos.set(slug, { x, y, depth });
+    });
+  });
+  return pos;
 }
-
 export function SkillGraph() {
   const { graph, isLoading, error, refresh, syncFromSubmissions } = useSkillGraph(true);
-
+  const skills = graph?.skills ?? [];
+  const edges = graph?.edges ?? [];
+  const isBoilerplate = skills.length > 0 && skills.every((s) => s.mastery_score === 0 && s.evidence_count === 0);
+  const layout = useMemo(() => (skills.length ? computeLayout(skills, edges) : null), [graph]);
   if (isLoading) {
     return (
       <section aria-label="Skill graph" className="rounded-[2rem] bg-white/[0.03] ring-1 ring-white/5 p-5 md:p-6">
@@ -37,34 +81,32 @@ export function SkillGraph() {
             <div key={i} className="rounded-2xl border border-white/[0.04] bg-white/[0.01] p-4">
               <Skeleton width={100} height={14} />
               <Skeleton width="100%" height={8} className="mt-3" />
-              <Skeleton width={60} height={12} className="mt-3" />
             </div>
           ))}
         </div>
       </section>
     );
   }
-
   if (error) {
     return (
       <section aria-label="Skill graph" className="rounded-[2rem] bg-white/[0.03] ring-1 ring-white/5 p-5 md:p-6">
         <p className="text-xs text-red-400/80">{error}</p>
-        <button
-          onClick={refresh}
-          className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-white/[0.04] ring-1 ring-white/10 px-3 py-1.5 text-xs font-medium text-muted-foreground/80 hover:bg-white/[0.08] transition-colors"
-        >
+        <button onClick={refresh} className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-white/[0.04] ring-1 ring-white/10 px-3 py-1.5 text-xs font-medium text-muted-foreground/80 hover:bg-white/[0.08] transition-colors">
           <RefreshCw className="h-3 w-3" /> Retry
         </button>
       </section>
     );
   }
-
-  const skills = graph?.skills ?? [];
-  const edges = graph?.edges ?? [];
-  const isBoilerplate = skills.length > 0 && skills.every((s) => s.mastery_score === 0 && s.evidence_count === 0);
-
+  if (skills.length === 0 || !layout) {
+    return (
+      <section aria-label="Skill graph" className="rounded-[2rem] bg-white/[0.03] ring-1 ring-white/5 p-5 md:p-6">
+        <p className="text-xs text-muted-foreground/60">No skills yet — solve a problem to build your graph.</p>
+      </section>
+    );
+  }
+  const height = 60 + (Math.max(...Array.from(layout.values()).map((p) => p.depth)) + 1) * 110 + 40;
   return (
-    <section aria-label="Skill graph" className="rounded-[2rem] bg-white/[0.03] ring-1 ring-white/5 p-5 md:p-6">
+    <section aria-label="Skill graph" className="rounded-[2rem] bg-white/[0.03] ring-1 ring-white/5 p-5 md:p-6" data-testid="skill-graph">
       <div className="flex items-center justify-between gap-3 mb-4">
         <div className="flex items-center gap-2.5">
           <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-primary/10 text-primary/80 ring-1 ring-primary/20">
@@ -72,76 +114,62 @@ export function SkillGraph() {
           </span>
           <div>
             <h2 className="text-sm font-semibold tracking-tight">Your Skill Graph</h2>
-            <p className="text-[11px] text-muted-foreground/60">
-              {isBoilerplate
-                ? 'Start solving — this is your starter map'
-                : `${skills.length} skills • ${edges.length} prerequisite links`}
-            </p>
+            <p className="text-[11px] text-muted-foreground/60">{isBoilerplate ? 'Start solving — this is your starter map' : `${skills.length} skills • ${edges.length} prerequisite links`}</p>
           </div>
         </div>
-        {!isBoilerplate && (
-          <button
-            onClick={syncFromSubmissions}
-            title="Rebuild graph from completed submissions (DB query)"
-            className="inline-flex items-center gap-1.5 rounded-full bg-white/[0.04] ring-1 ring-white/10 px-3 py-1.5 text-xs font-medium text-muted-foreground/80 hover:bg-white/[0.08] transition-colors"
-          >
-            <RefreshCw className="h-3 w-3" /> Sync from history
-          </button>
-        )}
-      </div>
-
-      {skills.length === 0 ? (
-        <p className="text-xs text-muted-foreground/60">No skills yet — solve a problem to build your graph.</p>
-      ) : (
-        <>
-          {isBoilerplate && (
-            <div className="mb-4 rounded-2xl border border-dashed border-white/10 bg-white/[0.02] p-3">
-              <p className="text-xs text-muted-foreground/70">
-                This is a <span className="text-foreground/90 font-medium">boilerplate graph</span> showing every skill in the taxonomy.
-                Solve your first question and we&apos;ll sync your progress from the database — mastery, confidence and prerequisites will light up.
-              </p>
-            </div>
+        <div className="flex items-center gap-2">
+          {!isBoilerplate && (
+            <button onClick={syncFromSubmissions} title="Rebuild graph from completed submissions (DB query)" className="inline-flex items-center gap-1.5 rounded-full bg-white/[0.04] ring-1 ring-white/10 px-3 py-1.5 text-xs font-medium text-muted-foreground/80 hover:bg-white/[0.08] transition-colors">
+              <RefreshCw className="h-3 w-3" /> Sync from history
+            </button>
           )}
-          <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            {skills.map((skill) => (
-              <li
-                key={skill.skill_slug}
-                data-testid="skill-node"
-                data-skill={skill.skill_slug}
-                className="group flex flex-col rounded-2xl border border-white/[0.04] bg-white/[0.01] p-4 hover:border-white/[0.10] hover:bg-white/[0.04] transition-colors"
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <span className="text-sm font-medium text-foreground/90">{skill.name}</span>
-                  <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ring-1 ${STATUS_COLOR[skill.status] ?? STATUS_COLOR.new}`}>
-                    {masteryLabel(skill.mastery_score)}
-                  </span>
-                </div>
-                <div className="mt-2 h-1.5 w-full rounded-full bg-white/[0.06] overflow-hidden">
-                  <div
-                    className="h-full rounded-full bg-primary/80 transition-all duration-500"
-                    style={{ width: `${Math.round(skill.mastery_score * 100)}%` }}
-                    aria-label={`${skill.name} mastery ${Math.round(skill.mastery_score * 100)}%`}
-                  />
-                </div>
-                <div className="mt-2 flex items-center justify-between gap-2 text-[11px] text-muted-foreground/60">
-                  <span>mastery {(skill.mastery_score * 100).toFixed(0)}% • conf {(skill.confidence * 100).toFixed(0)}%</span>
-                  <Badge variant="outline" size="sm">{skill.skill_slug}</Badge>
-                </div>
-                {skill.evidence_count > 0 && (
-                  <p className="mt-1 text-[11px] text-muted-foreground/50">
-                    {skill.evidence_count} evidence • {skill.recent_error_count} recent errors
-                  </p>
-                )}
-              </li>
+          <div className="hidden md:flex items-center gap-2 text-[10px]">
+            {Object.entries(STATUS_COLOR).map(([k, c]) => (
+              <span key={k} className="inline-flex items-center gap-1">
+                <span className="h-2 w-2 rounded-full" style={{ background: c }} />
+                {k.replace('_', ' ')}
+              </span>
             ))}
-          </ul>
-          {edges.length > 0 && (
-            <p className="mt-4 text-[11px] text-muted-foreground/40">
-              {edges.length} prerequisite edges — e.g. <span className="text-muted-foreground/60">{edges[0].source} → {edges[0].target}</span>
-            </p>
-          )}
-        </>
+          </div>
+        </div>
+      </div>
+      {isBoilerplate && (
+        <div className="mb-4 rounded-2xl border border-dashed border-white/10 bg-white/[0.02] p-3">
+          <p className="text-xs text-muted-foreground/70">This is a <span className="text-foreground/90 font-medium">boilerplate graph</span> showing every skill in the taxonomy. Solve your first question and we&apos;ll sync your progress — mastery, confidence and prerequisites will light up.</p>
+        </div>
       )}
+      <div className="overflow-x-auto">
+        <svg width={900} height={height} viewBox={`0 0 900 ${height}`} className="min-w-[700px] w-full" role="img" aria-label="Skill prerequisite graph">
+          <defs>
+            <marker id="arrow" viewBox="0 0 10 10" refX={8} refY={5} markerWidth={6} markerHeight={6} orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="rgba(255,255,255,0.25)" />
+            </marker>
+          </defs>
+          {edges.map((e, idx) => {
+            const a = layout.get(e.source);
+            const b = layout.get(e.target);
+            if (!a || !b) return null;
+            return <line key={`${e.source}-${e.target}-${idx}`} x1={a.x} y1={a.y + 22} x2={b.x} y2={b.y - 22} stroke="rgba(255,255,255,0.14)" strokeWidth={1.2} markerEnd="url(#arrow)" data-testid="skill-graph-edge" />;
+          })}
+          {skills.map((s) => {
+            const p = layout.get(s.skill_slug);
+            if (!p) return null;
+            const color = STATUS_COLOR[s.status] ?? STATUS_COLOR.new;
+            const bg = STATUS_BG[s.status] ?? STATUS_BG.new;
+            const r = 22 + Math.round(s.mastery_score * 10);
+            return (
+              <g key={s.skill_slug} data-testid="skill-graph-node" data-skill={s.skill_slug} data-status={s.status}>
+                <circle cx={p.x} cy={p.y} r={r} fill={bg} stroke={color} strokeWidth={1.6} />
+                <circle cx={p.x} cy={p.y} r={Math.max(3, Math.round(s.mastery_score * r))} fill={color} opacity={0.22} />
+                <text x={p.x} y={p.y + 4} textAnchor="middle" fontSize={8} fontWeight={700} fill="white" opacity={0.9}>{Math.round(s.mastery_score * 100)}</text>
+                <text x={p.x} y={p.y + r + 14} textAnchor="middle" fontSize={10} fontWeight={600} fill="white" opacity={0.85}>{s.name.length > 18 ? s.name.slice(0, 18) + '…' : s.name}</text>
+                <text x={p.x} y={p.y + r + 26} textAnchor="middle" fontSize={8} fill="white" opacity={0.45}>{s.status.replace('_', ' ')}</text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <p className="text-[11px] text-muted-foreground/40 mt-3">Node size = mastery · color = status · arrows = prerequisite. Initial boilerplate shows all 22 skills at 0% (gray); your solves fill it in.</p>
     </section>
   );
 }

--- a/frontend/src/features/skill-graph/skill-graph.service.ts
+++ b/frontend/src/features/skill-graph/skill-graph.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from "@/lib/http-client";
 import { FetchClient } from "@/lib/fetch-client";
-import { RecommendedQuestion } from "@/types";
+import { RecommendedQuestion, SkillGraphResponse } from "@/types";
 
 export class SkillGraphService {
   constructor(private http: HttpClient) {}
@@ -11,6 +11,20 @@ export class SkillGraphService {
       {
         cache: "no-store",
       },
+    );
+  }
+
+  async getGraph(includeBoilerplate = false): Promise<SkillGraphResponse> {
+    const qs = includeBoilerplate ? "?include_boilerplate=true" : "";
+    return this.http.get<SkillGraphResponse>(`/api/skills/me/skills${qs}`, {
+      cache: "no-store",
+    });
+  }
+
+  async syncFromSubmissions(): Promise<{ accepted: number; duplicate: number; invalid: number; skipped: number }> {
+    return this.http.post<{ accepted: number; duplicate: number; invalid: number; skipped: number }>(
+      `/api/skills/me/sync`,
+      {},
     );
   }
 }

--- a/frontend/src/features/skill-graph/use-skill-graph.hook.ts
+++ b/frontend/src/features/skill-graph/use-skill-graph.hook.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { SkillGraphResponse } from '@/types';
+import { skillGraphService } from './skill-graph.service';
+
+export function useSkillGraph(includeBoilerplate = true) {
+  const [graph, setGraph] = useState<SkillGraphResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchGraph = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await skillGraphService.getGraph(includeBoilerplate);
+      setGraph(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load skill graph');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [includeBoilerplate]);
+
+  const syncFromSubmissions = useCallback(async () => {
+    try {
+      await skillGraphService.syncFromSubmissions();
+      await fetchGraph();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Sync failed');
+    }
+  }, [fetchGraph]);
+
+  useEffect(() => {
+    fetchGraph();
+  }, [fetchGraph]);
+
+  return { graph, isLoading, error, refresh: fetchGraph, syncFromSubmissions };
+}

--- a/frontend/src/features/workspace/use-workspace.hook.ts
+++ b/frontend/src/features/workspace/use-workspace.hook.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { useCallback, useContext, useEffect, useRef } from "react";
+import { Language } from "@/types";
+import { AuthContext } from "@/providers/AuthProvider";
+import { workspaceService } from "./workspace.service";
+
+interface UseWorkspaceOptions {
+  questionId: string | null;
+  language: Language;
+  currentCode: string;
+  setCurrentCode: (code: string) => void;
+  onHydrateChat?: (messages: { role: "user" | "assistant"; content: string; structured?: unknown; timestamp: string }[]) => void;
+}
+
+/**
+ * Hydrates draft code from Redis and debounces saves.
+ * No-op when unauthenticated (per spec).
+ */
+export function useWorkspace({
+  questionId,
+  language,
+  currentCode,
+  setCurrentCode,
+  onHydrateChat,
+}: UseWorkspaceOptions) {
+  const auth = useContext(AuthContext);
+  const isAuthenticated = auth?.isAuthenticated ?? false;
+
+  const hydratedRef = useRef<string | null>(null);
+  const lastSavedRef = useRef<string>("");
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Hydrate code + chat on question/language change
+  useEffect(() => {
+    if (!questionId || !isAuthenticated) return;
+    const key = `${questionId}:${language}`;
+    if (hydratedRef.current === key) return;
+    hydratedRef.current = key;
+    let cancelled = false;
+    workspaceService
+      .getCode(questionId, language)
+      .then((res) => {
+        if (cancelled) return;
+        if (res.code) {
+          lastSavedRef.current = res.code;
+          setCurrentCode(res.code);
+        }
+      })
+      .catch(() => {});
+    if (onHydrateChat) {
+      workspaceService
+        .getChat(questionId)
+        .then((res) => {
+          if (cancelled) return;
+          if (res.messages?.length) onHydrateChat(res.messages as never);
+        })
+        .catch(() => {});
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [questionId, language, isAuthenticated, setCurrentCode, onHydrateChat]);
+
+  useEffect(() => {
+    hydratedRef.current = null;
+  }, [questionId]);
+
+  const scheduleSave = useCallback(
+    (code: string) => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+      debounceTimer.current = setTimeout(() => {
+        if (!questionId || !isAuthenticated) return;
+        if (code === lastSavedRef.current) return;
+        lastSavedRef.current = code;
+        workspaceService.saveCode(questionId, language, code).catch(() => {});
+      }, 800);
+    },
+    [questionId, language, isAuthenticated]
+  );
+
+  useEffect(() => {
+    if (!questionId || !isAuthenticated) return;
+    if (hydratedRef.current !== `${questionId}:${language}`) return;
+    scheduleSave(currentCode);
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    };
+  }, [currentCode, questionId, language, isAuthenticated, scheduleSave]);
+
+  const deleteDraft = useCallback(async () => {
+    if (!questionId || !isAuthenticated) return;
+    try {
+      await workspaceService.deleteCode(questionId, language);
+      lastSavedRef.current = "";
+    } catch {}
+  }, [questionId, language, isAuthenticated]);
+
+  const clearChat = useCallback(async () => {
+    if (!questionId || !isAuthenticated) return;
+    try {
+      await workspaceService.clearChat(questionId);
+    } catch {}
+  }, [questionId, isAuthenticated]);
+
+  return { deleteDraft, clearChat };
+}

--- a/frontend/src/features/workspace/workspace.service.ts
+++ b/frontend/src/features/workspace/workspace.service.ts
@@ -1,0 +1,57 @@
+import { HttpClient } from "@/lib/http-client";
+import { FetchClient } from "@/lib/fetch-client";
+
+export interface WorkspaceCode {
+  code: string;
+  language: string;
+  updated_at: string | null;
+  question_id: string;
+}
+
+export interface LastVisited {
+  question_id: string;
+  language: string | null;
+  visited_at: string;
+}
+
+export interface ChatMessagePersisted {
+  role: "user" | "assistant";
+  content: string;
+  structured?: unknown;
+  timestamp: string;
+}
+
+export class WorkspaceService {
+  constructor(private http: HttpClient) {}
+
+  async getCode(questionId: string, language: string): Promise<WorkspaceCode> {
+    const qs = new URLSearchParams({ language }).toString();
+    return this.http.get<WorkspaceCode>(`/api/workspace/code/${encodeURIComponent(questionId)}?${qs}`);
+  }
+
+  async saveCode(questionId: string, language: string, code: string): Promise<void> {
+    await this.http.put<void>(`/api/workspace/code/${encodeURIComponent(questionId)}`, {
+      language,
+      code,
+    });
+  }
+
+  async deleteCode(questionId: string, language: string): Promise<void> {
+    const qs = new URLSearchParams({ language }).toString();
+    await this.http.delete<void>(`/api/workspace/code/${encodeURIComponent(questionId)}?${qs}`);
+  }
+
+  async getLastVisited(): Promise<LastVisited | null> {
+    return this.http.get<LastVisited | null>(`/api/workspace/last-visited`);
+  }
+
+  async getChat(questionId: string): Promise<{ question_id: string; messages: ChatMessagePersisted[] }> {
+    return this.http.get<{ question_id: string; messages: ChatMessagePersisted[] }>(`/api/workspace/chat/${encodeURIComponent(questionId)}`);
+  }
+
+  async clearChat(questionId: string): Promise<void> {
+    await this.http.delete<void>(`/api/workspace/chat/${encodeURIComponent(questionId)}`);
+  }
+}
+
+export const workspaceService = new WorkspaceService(new FetchClient());

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -24,7 +24,7 @@ interface AuthContextType extends AuthState {
   logout: () => void;
 }
 
-const AuthContext = createContext<AuthContextType | null>(null);
+export const AuthContext = createContext<AuthContextType | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<AuthState>({

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -235,6 +235,30 @@ export interface User {
   plan?: string;
 }
 
+export interface SkillSummary {
+  skill_slug: string;
+  name: string;
+  mastery_score: number;
+  confidence: number;
+  status: "new" | "learning" | "developing" | "strong" | "needs_review";
+  trend: "improving" | "declining" | "stable";
+  evidence_count: number;
+  recent_error_count: number;
+  last_seen_at: string | null;
+  last_reviewed_at: string | null;
+}
+
+export interface SkillGraphEdge {
+  source: string;
+  target: string;
+  relation: string;
+}
+
+export interface SkillGraphResponse {
+  skills: SkillSummary[];
+  edges: SkillGraphEdge[];
+}
+
 export interface AuthState {
   user: User | null;
   token: string | null;


### PR DESCRIPTION
## Summary
Implements DB-backed skill graph + Redis workspace persistence.

### Skill Graph (prior commits)
- `SkillGraphService.get_graph(include_boilerplate)` at `backend/app/services/skill_graph_service.py:114` — boilerplate 22 skills for new users
- `sync_from_submissions()` at `backend/app/services/skill_graph_service.py:263` idempotent backfill (`sub:{id}`)
- `POST /api/skills/me/sync` at `backend/app/api/skills.py:51`, `GET /api/skills/me/skills?include_boilerplate=true`
- Live emission in `POST /api/submit` at `backend/app/api/submit.py:108`
- Frontend `SkillGraph` component + hook wired to dashboard

Perf: `frontend/src/app/dashboard/page.tsx:5` stagger loads, `next.config.js` CSP fix, trailing-slash alias.

### Redis Workspace (new)
- `WorkspaceService` at `backend/app/services/workspace_service.py:24` — draft code per `codecoach:workspace:code:{user}:{q}:{lang}`, last-visited `codecoach:workspace:last_visited:{user}`, chat `codecoach:chat:{user}:{q}` capped 20 msgs/5k chars, TTL 604800 (7d), graceful degrade
- Schemas at `backend/app/models/workspace_schemas.py:1`, config at `backend/app/core/config.py:87`
- Routes at `backend/app/api/workspace.py:9` (`PUT/GET/DELETE /api/workspace/code/{id}`, `GET /api/workspace/last-visited`, `GET/DELETE /api/workspace/chat/{id}`) auth-required
- Coaching persistence at `backend/app/api/coach.py:105` best-effort when `question_id` supplied (no streaming), `backend/app/models/schemas.py:74` optional `question_id`
- Frontend `workspace.service.ts` at `frontend/src/features/workspace/workspace.service.ts:16`, `useWorkspace` at `frontend/src/features/workspace/use-workspace.hook.ts:9` (hydrate, 800ms debounce, delete on Reset, unauth degrades), `CodeEditor` onReset at `frontend/src/components/editor/CodeEditor.tsx:58`, Resume banner at `frontend/src/app/problems/page.tsx:51`
- `AuthContext` exported at `frontend/src/providers/AuthProvider.tsx:27`
- TDD: `backend/tests/unit/test_workspace_service.py:1` 10 tests, TestClient integration verified

### Quality
- `pnpm typecheck/lint` green, `pnpm test:run` 661/661, `ruff check/format` clean
- Production-safe: Supabase-only, 7d TTL + allkeys-lru 512mb, auth-scoped keys, best-effort never 500s
- `graphify update` rebuilt