### PR TITLE
feat(redis): persist workspace code, last-visited and AI chat to Redis (7d TTL)

### DIFF
--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -40,6 +40,7 @@ from app.api.dependencies import (
     get_redis_cache,
     get_usage_service,
     get_executor,
+    get_workspace_service,
 )
 from app.models.auth_schemas import UserResponse
 from app.middleware.rate_limit import limiter, COACH_RATE_LIMIT, COACH_WARM_RATE_LIMIT
@@ -195,6 +196,7 @@ async def get_coaching(
     learner_context: LearnerContextService = Depends(
         get_learner_context_service_dependency
     ),
+    workspace_svc=Depends(get_workspace_service),
 ):
     """
     Get AI coaching response for coding problems.
@@ -266,6 +268,25 @@ async def get_coaching(
         response.headers.update(getattr(request.state, "usage_headers", {}))
         response.headers.update(getattr(request.state, "daily_limit_headers", {}))
         response.headers["X-Surface"] = surface
+
+        # Best-effort chat persistence to Redis (per-question history, 7d TTL).
+        try:
+            qid = getattr(coaching_request, "question_id", None)
+            if qid and workspace_svc:
+                await workspace_svc.append_chat(
+                    user.id,
+                    qid,
+                    [
+                        {"role": "user", "content": coaching_request.message or ""},
+                        {
+                            "role": "assistant",
+                            "content": raw_response,
+                            "structured": structured_data,
+                        },
+                    ],
+                )
+        except Exception:  # noqa: BLE001
+            logger.debug("workspace chat append failed", exc_info=True)
 
         return CoachingResponse(
             response=raw_response,

--- a/backend/app/api/courses.py
+++ b/backend/app/api/courses.py
@@ -27,6 +27,7 @@ def get_course_service(
     )
 
 
+@router.get("")
 @router.get("/")
 @limiter.limit(QUESTIONS_RATE_LIMIT)
 async def list_courses(

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -171,6 +171,14 @@ async def get_course_admin_repo(
     yield SqlCourseAdminRepository(db)
 
 
+def get_workspace_service(
+    cache: Optional[RedisCache] = Depends(get_redis_cache),
+):
+    from app.services.workspace_service import WorkspaceService
+
+    return WorkspaceService(cache=cache)
+
+
 def get_executor(
     cache: Optional[RedisCache] = Depends(get_redis_cache),
 ) -> CodeExecutor:

--- a/backend/app/api/progress.py
+++ b/backend/app/api/progress.py
@@ -17,6 +17,7 @@ def get_course_service(
     return CourseService(course_repo=course_repo, progress_repo=progress_repo)
 
 
+@router.get("")
 @router.get("/")
 async def get_all_progress(
     current_user: UserResponse = Depends(get_current_user),

--- a/backend/app/api/questions.py
+++ b/backend/app/api/questions.py
@@ -20,7 +20,7 @@ async def get_questions(
     difficulty: Optional[Difficulty] = Query(None, description="Filter by difficulty"),
     category: Optional[str] = Query(None, description="Filter by category"),
     page: int = Query(1, ge=1, description="Page number"),
-    per_page: int = Query(100, ge=1, le=100, description="Items per page"),
+    per_page: int = Query(20, ge=1, le=200, description="Items per page"),
     bank: QuestionBank = Depends(get_question_bank),
 ):
     try:
@@ -73,7 +73,7 @@ async def search_questions(
     difficulty: Optional[Difficulty] = Query(None, description="Filter by difficulty"),
     category: Optional[str] = Query(None, description="Filter by category"),
     page: int = Query(1, ge=1, description="Page number"),
-    per_page: int = Query(100, ge=1, le=100, description="Items per page"),
+    per_page: int = Query(20, ge=1, le=200, description="Items per page"),
     bank: QuestionBank = Depends(get_question_bank),
 ):
     try:
@@ -82,7 +82,7 @@ async def search_questions(
 
         result = await bank.query(
             QuestionFilters(
-                query=q, difficulty=difficulty, category=category, per_page=10000
+                query=q, difficulty=difficulty, category=category, per_page=100
             )
         )
 

--- a/backend/app/api/questions.py
+++ b/backend/app/api/questions.py
@@ -20,7 +20,7 @@ async def get_questions(
     difficulty: Optional[Difficulty] = Query(None, description="Filter by difficulty"),
     category: Optional[str] = Query(None, description="Filter by category"),
     page: int = Query(1, ge=1, description="Page number"),
-    per_page: int = Query(20, ge=1, le=200, description="Items per page"),
+    per_page: int = Query(100, ge=1, le=100, description="Items per page"),
     bank: QuestionBank = Depends(get_question_bank),
 ):
     try:
@@ -73,7 +73,7 @@ async def search_questions(
     difficulty: Optional[Difficulty] = Query(None, description="Filter by difficulty"),
     category: Optional[str] = Query(None, description="Filter by category"),
     page: int = Query(1, ge=1, description="Page number"),
-    per_page: int = Query(20, ge=1, le=200, description="Items per page"),
+    per_page: int = Query(100, ge=1, le=100, description="Items per page"),
     bank: QuestionBank = Depends(get_question_bank),
 ):
     try:
@@ -82,7 +82,7 @@ async def search_questions(
 
         result = await bank.query(
             QuestionFilters(
-                query=q, difficulty=difficulty, category=category, per_page=100
+                query=q, difficulty=difficulty, category=category, per_page=10000
             )
         )
 

--- a/backend/app/api/skills.py
+++ b/backend/app/api/skills.py
@@ -49,13 +49,37 @@ async def _invalidate_learner_cache(user_id: str, cache: RedisCache | None) -> N
         pass
 
 
+@router.get("/boilerplate", response_model=SkillGraphResponse)
+async def get_boilerplate(
+    service: SkillGraphService = Depends(get_skill_graph_service),
+):
+    """Deterministic boilerplate graph for onboarding previews.
+
+    No auth required — returns the full taxonomy with every skill in NEW
+    state. Safe for unauthenticated onboarding tour fetches.
+    """
+    try:
+        return await service.get_boilerplate_graph()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error fetching boilerplate: {e}")
+
+
 @router.get("/me/skills", response_model=SkillGraphResponse)
 async def get_my_skills(
+    include_boilerplate: bool = False,
     current_user: UserResponse = Depends(get_current_user),
     service: SkillGraphService = Depends(get_skill_graph_service),
 ):
+    """Personal skill graph.
+
+    When ``include_boilerplate`` is true, every taxonomy skill is returned
+    (unseen skills appear as NEW/0.0) — the onboarding and gear-modal view.
+    When false, only skills with evidence are returned (legacy compact view).
+    """
     try:
-        return await service.get_graph(current_user.id)
+        return await service.get_graph(
+            current_user.id, include_boilerplate=include_boilerplate
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error fetching skills: {e}")
 

--- a/backend/app/api/workspace.py
+++ b/backend/app/api/workspace.py
@@ -1,0 +1,113 @@
+"""Workspace + chat persistence endpoints (Redis cache, per-user, auth required)."""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from app.api.auth_deps import get_current_user
+from app.api.dependencies import get_workspace_service
+from app.models.auth_schemas import UserResponse
+from app.models.workspace_schemas import (
+    WorkspaceCodePut,
+    WorkspaceCodeOut,
+    LastVisitedOut,
+    ChatHistoryOut,
+)
+from app.services.workspace_service import WorkspaceService
+
+logger = logging.getLogger(__name__)
+router = APIRouter(dependencies=[Depends(get_current_user)])
+
+
+@router.put("/code/{question_id}", status_code=204)
+async def put_code(
+    question_id: str,
+    body: WorkspaceCodePut,
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    await svc.save_code(user.id, question_id, body.language, body.code)
+    return None
+
+
+@router.get("/code/{question_id}", response_model=WorkspaceCodeOut)
+async def get_code(
+    question_id: str,
+    language: str = Query(..., min_length=1, max_length=20),
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    data = await svc.get_code(user.id, question_id, language)
+    try:
+        await svc.set_last_visited(user.id, question_id, language)
+    except Exception:
+        pass
+    if data is None:
+        return WorkspaceCodeOut(
+            code="", language=language, updated_at=None, question_id=question_id
+        )
+    return WorkspaceCodeOut(
+        code=data.get("code", ""),
+        language=data.get("language", language),
+        updated_at=data.get("updated_at"),
+        question_id=question_id,
+    )
+
+
+@router.delete("/code/{question_id}", status_code=204)
+async def delete_code(
+    question_id: str,
+    language: str = Query(..., min_length=1, max_length=20),
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    await svc.delete_code(user.id, question_id, language)
+    return None
+
+
+@router.get("/last-visited", response_model=Optional[LastVisitedOut])
+async def get_last_visited(
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    data = await svc.get_last_visited(user.id)
+    if data is None:
+        return None
+    return LastVisitedOut(
+        question_id=data.get("question_id", ""),
+        language=data.get("language"),
+        visited_at=data.get("visited_at", ""),
+    )
+
+
+@router.get("/chat/{question_id}", response_model=ChatHistoryOut)
+async def get_chat(
+    question_id: str,
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    messages = await svc.get_chat(user.id, question_id)
+    return ChatHistoryOut(question_id=question_id, messages=messages)
+
+
+@router.delete("/chat/{question_id}", status_code=204)
+async def delete_chat(
+    question_id: str,
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    await svc.clear_chat(user.id, question_id)
+    return None
+
+
+@router.get("/meta/{question_id}")
+async def get_meta(
+    question_id: str,
+    user: UserResponse = Depends(get_current_user),
+    svc: WorkspaceService = Depends(get_workspace_service),
+):
+    data = await svc.get_meta(user.id, question_id)
+    if data is None:
+        return {"question_id": question_id, "language": None, "last_opened_at": None}
+    return {"question_id": question_id, **data}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,7 +4,7 @@ from pydantic import model_validator
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_file=(".env", "../.env"), extra="ignore")
 
     # Environment (fail-closed: unset = production for security gates)
     ENVIRONMENT: str = "production"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -87,7 +87,13 @@ class Settings(BaseSettings):
     REDIS_TTL_STATIC: int = 3600
     REDIS_TTL_AI: int = 86400
     REDIS_TTL_EXECUTION: int = 3600
+    REDIS_TTL_WORKSPACE: int = 604800  # 7 days — draft code + last-visited
+    REDIS_TTL_CHAT: int = 604800  # 7 days — per-question chat history
+    REDIS_TTL_LAST_EXEC: int = 604800  # 7 days — last execution / submit snapshot
     REDIS_ENABLED: bool = True
+    WORKSPACE_CODE_MAX_BYTES: int = 51200
+    CHAT_HISTORY_MAX_MESSAGES: int = 20
+    CHAT_MESSAGE_MAX_CHARS: int = 5000
 
 
 def get_settings() -> Settings:

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
 )
 from sqlalchemy.pool import NullPool
-from app.core.config import get_settings, is_production
+from app.core.config import get_settings
 from app.core.db_url import pooler_connect_args, strip_pgbouncer
 
 settings = get_settings()
@@ -37,8 +37,15 @@ if _db_url.startswith("postgresql"):
 
 engine: AsyncEngine = create_async_engine(
     _db_url,
-    poolclass=NullPool if not is_production() else None,
+    # NullPool only for isolated test schemas (DATABASE_SEARCH_PATH). In dev
+    # it forces a new TLS handshake to Supabase per-request (~5s), which is
+    # the "Request Timeouts" seen in the UI. Pooled engine reuses connections.
+    poolclass=NullPool if settings.DATABASE_SEARCH_PATH else None,
     pool_pre_ping=True,
+    pool_size=20,
+    max_overflow=10,
+    pool_timeout=30,
+    pool_recycle=300,
     **_connect_args,
 )
 async_session_maker: async_sessionmaker = async_sessionmaker(

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -35,17 +35,23 @@ if settings.DATABASE_SEARCH_PATH:
 if _db_url.startswith("postgresql"):
     _connect_args.setdefault("connect_args", {}).update(pooler_connect_args())
 
+# NullPool only for isolated test schemas (DATABASE_SEARCH_PATH). In dev
+# it forces a new TLS handshake to Supabase per-request (~5s), which is
+# the "Request Timeouts" seen in the UI. Pooled engine reuses connections.
+# Pool tuning args are only valid for pooled engines — NullPool rejects
+# pool_size / max_overflow / pool_timeout.
+_use_nullpool = bool(settings.DATABASE_SEARCH_PATH)
+_pool_kwargs: dict = {}
+if not _use_nullpool:
+    _pool_kwargs = dict(
+        pool_size=20, max_overflow=10, pool_timeout=30, pool_recycle=300
+    )
+
 engine: AsyncEngine = create_async_engine(
     _db_url,
-    # NullPool only for isolated test schemas (DATABASE_SEARCH_PATH). In dev
-    # it forces a new TLS handshake to Supabase per-request (~5s), which is
-    # the "Request Timeouts" seen in the UI. Pooled engine reuses connections.
-    poolclass=NullPool if settings.DATABASE_SEARCH_PATH else None,
+    poolclass=NullPool if _use_nullpool else None,
     pool_pre_ping=True,
-    pool_size=20,
-    max_overflow=10,
-    pool_timeout=30,
-    pool_recycle=300,
+    **_pool_kwargs,
     **_connect_args,
 )
 async_session_maker: async_sessionmaker = async_sessionmaker(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -47,6 +47,7 @@ from app.api import (  # noqa: E402
     reviews,
     memory,
     analytics,
+    workspace,
 )
 from app.core.config import get_settings, is_production  # noqa: E402
 from app.middleware.rate_limit import (  # noqa: E402
@@ -207,6 +208,7 @@ app.include_router(mistakes.router, prefix="/api/mistakes", tags=["mistakes"])
 app.include_router(reviews.router, prefix="/api/reviews", tags=["reviews"])
 app.include_router(memory.router, prefix="/api/memory", tags=["memory"])
 app.include_router(analytics.router, prefix="/api/analytics", tags=["analytics"])
+app.include_router(workspace.router, prefix="/api/workspace", tags=["workspace"])
 
 
 @app.get("/")

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -81,6 +81,11 @@ class CoachingRequest(BaseModel):
             "'learn' is the graph-free curriculum companion."
         ),
     )
+    question_id: Optional[str] = Field(
+        None,
+        max_length=100,
+        description="Question id for workspace chat persistence (optional, no breaking change)",
+    )
 
     @model_validator(mode="after")
     def require_lesson_context_for_learn(self):

--- a/backend/app/models/workspace_schemas.py
+++ b/backend/app/models/workspace_schemas.py
@@ -1,0 +1,48 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional, Any
+
+
+class WorkspaceCodePut(BaseModel):
+    language: str = Field(
+        ..., min_length=1, max_length=20, description="Programming language"
+    )
+    code: str = Field(..., max_length=51200, description="Draft code (max 50KB)")
+
+
+class WorkspaceCodeOut(BaseModel):
+    code: str
+    language: str
+    updated_at: Optional[str] = None
+    question_id: str
+
+
+class LastVisitedOut(BaseModel):
+    question_id: str
+    language: Optional[str] = None
+    visited_at: str
+
+
+class LastVisitedPut(BaseModel):
+    question_id: str = Field(..., min_length=1, max_length=100)
+    language: Optional[str] = Field(None, max_length=20)
+
+
+class ChatMessageIn(BaseModel):
+    role: str = Field(..., pattern="^(user|assistant)$")
+    content: str = Field(..., max_length=5000)
+    structured: Optional[Any] = None
+
+
+class ChatHistoryOut(BaseModel):
+    question_id: str
+    messages: List[dict]
+
+
+class ChatHistoryPut(BaseModel):
+    messages: List[ChatMessageIn] = Field(..., max_length=20)
+
+
+class WorkspaceMetaOut(BaseModel):
+    question_id: str
+    language: Optional[str] = None
+    last_opened_at: Optional[str] = None

--- a/backend/app/ports/course_repository.py
+++ b/backend/app/ports/course_repository.py
@@ -27,3 +27,12 @@ class CourseRepository(ABC):
     async def get_modules_by_course_batch(
         self, course_ids: List[str]
     ) -> List[Module]: ...
+
+    async def get_lesson_summaries_by_module_ids(
+        self, module_ids: List[str]
+    ) -> List[Lesson]:
+        """Batch fetch lesson outlines (titles only) — default falls back to per-module fetch for test doubles."""
+        results: List[Lesson] = []
+        for mid in module_ids:
+            results.extend(await self.get_lessons_by_module(mid))
+        return results

--- a/backend/app/repositories/sql_course_repository.py
+++ b/backend/app/repositories/sql_course_repository.py
@@ -71,9 +71,28 @@ class SqlCourseRepository(CourseRepository):
 
     async def get_all_courses(self) -> List[Course]:
         result = await self.session.execute(select(CourseORM).order_by(CourseORM.order))
-        courses = []
-        for orm in result.scalars().all():
-            courses.append(await self._hydrate_course(orm))
+        orms = result.scalars().all()
+        if not orms:
+            return []
+        # Batch fetch module ids for all courses in one query — avoids N+1 (14 roundtrips → 2)
+        course_ids = [o.id for o in orms]
+        mod_rows = await self.session.execute(
+            select(ModuleORM.id, ModuleORM.course_id, ModuleORM.order)
+            .where(ModuleORM.course_id.in_(course_ids))
+            .order_by(ModuleORM.course_id, ModuleORM.order)
+        )
+        # Order rows already sorted; group preserving order
+        from collections import defaultdict
+
+        mod_map: dict[str, list[str]] = defaultdict(list)
+        # Need to preserve order within course; query orders by course_id, order so within each course it's sorted
+        for mid, cid, _ in mod_rows.all():
+            mod_map[cid].append(mid)
+        courses: List[Course] = []
+        for orm in orms:
+            c = self._course_to_model(orm)
+            c.modules = mod_map.get(orm.id, [])
+            courses.append(c)
         return courses
 
     async def get_course_by_id(self, course_id: str) -> Optional[Course]:
@@ -105,15 +124,88 @@ class SqlCourseRepository(CourseRepository):
         )
         return [self._lesson_to_model(row) for row in result.scalars().all()]
 
+    async def get_lesson_summaries_by_module_ids(
+        self, module_ids: List[str]
+    ) -> List[Lesson]:
+        """Batch fetch lessons for course outline — only titles/metadata, no heavy content.
+
+        Single query for all modules (vs N per-module queries) and omits
+        `content`/`starter_code`/`test_cases` which bloat payload & latency.
+        `Lesson.content` is set to empty string for outline use; full fetch
+        via get_lesson_by_id when user opens a lesson.
+        """
+        if not module_ids:
+            return []
+        result = await self.session.execute(
+            select(
+                LessonORM.id,
+                LessonORM.course_id,
+                LessonORM.module_id,
+                LessonORM.title,
+                LessonORM.type,
+                LessonORM.order,
+                LessonORM.question_id,
+                LessonORM.language,
+            )
+            .where(LessonORM.module_id.in_(module_ids))
+            .order_by(LessonORM.module_id, LessonORM.order)
+        )
+        lessons: List[Lesson] = []
+        for (
+            lid,
+            course_id,
+            module_id,
+            title,
+            type_val,
+            order,
+            question_id,
+            language,
+        ) in result.all():
+            from app.models.course_schemas import LessonType
+
+            lessons.append(
+                Lesson(
+                    id=lid,
+                    course_id=course_id,
+                    module_id=module_id,
+                    title=title,
+                    type=LessonType(type_val) if type_val else LessonType.THEORY,
+                    content="",  # outline: fetch full via /lessons/{id}
+                    order=order,
+                    starter_code=None,
+                    test_cases=None,
+                    question_id=question_id,
+                    language=language,
+                )
+            )
+        return lessons
+
     async def get_modules_by_course(self, course_id: str) -> List[Module]:
         result = await self.session.execute(
             select(ModuleORM)
             .where(ModuleORM.course_id == course_id)
             .order_by(ModuleORM.order)
         )
-        modules = []
-        for orm in result.scalars().all():
-            modules.append(await self._hydrate_module(orm))
+        orms = result.scalars().all()
+        if not orms:
+            return []
+        # Batch lesson ids in one query instead of N per-module
+        module_ids = [m.id for m in orms]
+        lesson_rows = await self.session.execute(
+            select(LessonORM.id, LessonORM.module_id, LessonORM.order)
+            .where(LessonORM.module_id.in_(module_ids))
+            .order_by(LessonORM.module_id, LessonORM.order)
+        )
+        from collections import defaultdict
+
+        lesson_map: dict[str, list[str]] = defaultdict(list)
+        for lid, mid, _ in lesson_rows.all():
+            lesson_map[mid].append(lid)
+        modules: List[Module] = []
+        for orm in orms:
+            m = self._module_to_model(orm)
+            m.lessons = lesson_map.get(orm.id, [])
+            modules.append(m)
         return modules
 
     async def get_modules_by_course_batch(self, course_ids: List[str]) -> List[Module]:

--- a/backend/app/repositories/sql_question_repository.py
+++ b/backend/app/repositories/sql_question_repository.py
@@ -95,6 +95,76 @@ class SqlQuestionRepository(QuestionRepository):
         result = await self.session.execute(stmt)
         return [self._orm_to_model(q) for q in result.scalars().all()]
 
+    async def get_summaries(
+        self, difficulty: Optional[Difficulty] = None, category: Optional[str] = None
+    ):
+        """Optimized: fetch only summary columns (no starter/test_cases). Heavy fields would bloat payload & roundtrip."""
+        from app.models.schemas import QuestionSummary
+
+        stmt = select(
+            QuestionORM.id,
+            QuestionORM.title,
+            QuestionORM.difficulty,
+            QuestionORM.category,
+            QuestionORM.company_tags,
+        )
+        if difficulty:
+            stmt = stmt.where(QuestionORM.difficulty == difficulty.value)
+        if category:
+            stmt = stmt.where(QuestionORM.category.ilike(category))
+        stmt = stmt.order_by(QuestionORM.title)
+        result = await self.session.execute(stmt)
+        return [
+            QuestionSummary(
+                id=row[0],
+                title=row[1],
+                difficulty=Difficulty(row[2]),
+                category=row[3],
+                company_tags=row[4] or [],
+                solved=False,
+            )
+            for row in result.all()
+        ]
+
+    async def search_summaries(
+        self,
+        query: str,
+        difficulty: Optional[Difficulty] = None,
+        category: Optional[str] = None,
+    ):
+        from app.models.schemas import QuestionSummary
+
+        query_param = f"%{query}%"
+        stmt = select(
+            QuestionORM.id,
+            QuestionORM.title,
+            QuestionORM.difficulty,
+            QuestionORM.category,
+            QuestionORM.company_tags,
+        ).where(
+            or_(
+                QuestionORM.title.ilike(query_param),
+                QuestionORM.description.ilike(query_param),
+            )
+        )
+        if difficulty:
+            stmt = stmt.where(QuestionORM.difficulty == difficulty.value)
+        if category:
+            stmt = stmt.where(QuestionORM.category.ilike(category))
+        stmt = stmt.order_by(QuestionORM.title)
+        result = await self.session.execute(stmt)
+        return [
+            QuestionSummary(
+                id=row[0],
+                title=row[1],
+                difficulty=Difficulty(row[2]),
+                category=row[3],
+                company_tags=row[4] or [],
+                solved=False,
+            )
+            for row in result.all()
+        ]
+
     async def get_categories(self) -> List[str]:
         result = await self.session.execute(
             select(QuestionORM.category).distinct().order_by(QuestionORM.category)

--- a/backend/app/services/course_service.py
+++ b/backend/app/services/course_service.py
@@ -1,10 +1,16 @@
+import time
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from app.models.course_schemas import Course, CourseProgress, CourseSummary, Lesson
 from app.ports.course_repository import CourseRepository
 from app.ports.progress_repository import ProgressRepository
 from app.services.redis_service import RedisCache
+
+# In-memory TTL cache for anonymous course list (Supabase pooler ~1.5s per query; intermittent timeout on cold pool)
+# Keyed by None (anonymous) — user-specific progress bypasses cache
+_course_list_cache: Dict[str, Tuple[float, List[CourseSummary]]] = {}
+_COURSE_LIST_TTL = 30.0
 
 
 class CourseService:
@@ -19,6 +25,12 @@ class CourseService:
         self.cache = cache
 
     async def list_courses(self, user_id: Optional[str] = None) -> List[CourseSummary]:
+        # Anonymous list is same for everyone — cache to avoid repeated Supabase roundtrips and intermittent 408 on cold pool
+        if not user_id:
+            cached = _course_list_cache.get("anonymous")
+            if cached and (time.time() - cached[0] < _COURSE_LIST_TTL):
+                return cached[1]
+
         courses = await self.course_repo.get_all_courses()
         courses.sort(key=lambda c: c.order)
 
@@ -60,6 +72,8 @@ class CourseService:
                     progress=progress,
                 )
             )
+        if not user_id:
+            _course_list_cache["anonymous"] = (time.time(), summaries)
         return summaries
 
     async def get_course(self, course_id: str) -> Optional[Course]:
@@ -79,9 +93,24 @@ class CourseService:
         modules.sort(key=lambda m: m.order)
         result = course.model_dump()
         result["modules"] = []
+        # Batch fetch lesson outlines (titles only) in single query — avoids N+1 roundtrips to Supabase pooler (~1-2s each)
+        module_ids = [m.id for m in modules]
+        all_lessons = []
+        if hasattr(self.course_repo, "get_lesson_summaries_by_module_ids"):
+            all_lessons = await self.course_repo.get_lesson_summaries_by_module_ids(
+                module_ids
+            )  # type: ignore
+        else:
+            # Fallback for in-memory test repos
+            for mid in module_ids:
+                all_lessons.extend(await self.course_repo.get_lessons_by_module(mid))
+        # Group by module_id preserving order
+        lessons_by_module: dict[str, list] = {mid: [] for mid in module_ids}
+        for le in all_lessons:
+            lessons_by_module.setdefault(le.module_id, []).append(le)
         for mod in modules:
             mod_dict = mod.model_dump()
-            lessons = await self.course_repo.get_lessons_by_module(mod.id)
+            lessons = lessons_by_module.get(mod.id, [])
             lessons.sort(key=lambda le: le.order)
             mod_dict["lessons"] = [le.model_dump() for le in lessons]
             result["modules"].append(mod_dict)

--- a/backend/app/services/skill_graph_service.py
+++ b/backend/app/services/skill_graph_service.py
@@ -17,6 +17,8 @@ from app.models.skill_graph_schemas import (
     UserSkillState,
 )
 from app.ports.skill_graph_repository import SkillGraphRepository
+from app.models.skill_graph_schemas import SkillStatus, Trend
+
 from app.services.skill_graph_rules import (
     apply_event,
     decay_state,
@@ -111,7 +113,10 @@ class SkillGraphService:
         return result
 
     async def get_graph(
-        self, user_id: str, now: Optional[datetime] = None
+        self,
+        user_id: str,
+        now: Optional[datetime] = None,
+        include_boilerplate: bool = False,
     ) -> SkillGraphResponse:
         now = now or datetime.now(timezone.utc)
         skills_by_slug, _ = await self._load_taxonomy()
@@ -121,6 +126,22 @@ class SkillGraphService:
         for slug, skill in skills_by_slug.items():
             state = states.get(slug)
             if state is None:
+                if not include_boilerplate:
+                    continue
+                summaries.append(
+                    SkillSummary(
+                        skill_slug=slug,
+                        name=skill.name,
+                        mastery_score=0.0,
+                        confidence=0.0,
+                        status=SkillStatus.NEW,
+                        trend=Trend.STABLE,
+                        evidence_count=0,
+                        recent_error_count=0,
+                        last_seen_at=None,
+                        last_reviewed_at=None,
+                    )
+                )
                 continue
             decayed = decay_state(state, now)
             summaries.append(
@@ -140,8 +161,44 @@ class SkillGraphService:
                     last_reviewed_at=decayed.last_reviewed_at,
                 )
             )
-        summaries.sort(key=lambda s: s.mastery_score, reverse=True)
+        # Boilerplate-first: stable learners see full taxonomy sorted by mastery;
+        # new users (all 0.0) keep taxonomy insertion order.
+        if include_boilerplate:
+            summaries.sort(key=lambda s: (-s.mastery_score, s.skill_slug))
+        else:
+            summaries.sort(key=lambda s: s.mastery_score, reverse=True)
 
+        edges = [
+            SkillGraphEdge(source=prereq, target=slug, relation="prerequisite")
+            for slug, skill in skills_by_slug.items()
+            for prereq in skill.prerequisite_ids
+            if prereq in skills_by_slug
+        ]
+        return SkillGraphResponse(skills=summaries, edges=edges)
+
+    async def get_boilerplate_graph(self) -> SkillGraphResponse:
+        """Deterministic boilerplate graph — no user state, all skills NEW.
+
+        Used for onboarding previews and unauthenticated tour. Pure taxonomy,
+        no DB state reads beyond the skill list.
+        """
+        skills_by_slug, _ = await self._load_taxonomy()
+        summaries = [
+            SkillSummary(
+                skill_slug=slug,
+                name=skill.name,
+                mastery_score=0.0,
+                confidence=0.0,
+                status=SkillStatus.NEW,
+                trend=Trend.STABLE,
+                evidence_count=0,
+                recent_error_count=0,
+                last_seen_at=None,
+                last_reviewed_at=None,
+            )
+            for slug, skill in skills_by_slug.items()
+        ]
+        summaries.sort(key=lambda s: s.skill_slug)
         edges = [
             SkillGraphEdge(source=prereq, target=slug, relation="prerequisite")
             for slug, skill in skills_by_slug.items()

--- a/backend/app/services/workspace_service.py
+++ b/backend/app/services/workspace_service.py
@@ -1,0 +1,290 @@
+"""Workspace + chat persistence backed by Redis.
+
+Gracefully degrades when Redis is unavailable (cache is None or disabled):
+all methods become no-ops / return None or empty lists, never raise.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from app.core.config import get_settings
+from app.services.redis_service import RedisCache
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class WorkspaceService:
+    """Per-user workspace (draft code, last-visited, chat) stored in Redis."""
+
+    def __init__(self, cache: Optional[RedisCache]):
+        self.cache = cache
+        settings = get_settings()
+        self.ttl_workspace = settings.REDIS_TTL_WORKSPACE
+        self.ttl_chat = settings.REDIS_TTL_CHAT
+        self.ttl_last_exec = settings.REDIS_TTL_LAST_EXEC
+        self.max_code_bytes = settings.WORKSPACE_CODE_MAX_BYTES
+        self.max_chat_messages = settings.CHAT_HISTORY_MAX_MESSAGES
+        self.max_chat_chars = settings.CHAT_MESSAGE_MAX_CHARS
+
+    @staticmethod
+    def _code_key(user_id: str, question_id: str, language: str) -> str:
+        return RedisCache.key("workspace", "code", user_id, question_id, language)
+
+    @staticmethod
+    def _meta_key(user_id: str, question_id: str) -> str:
+        return RedisCache.key("workspace", "meta", user_id, question_id)
+
+    @staticmethod
+    def _chat_key(user_id: str, question_id: str) -> str:
+        return RedisCache.key("chat", user_id, question_id)
+
+    @staticmethod
+    def _last_visited_key(user_id: str) -> str:
+        return RedisCache.key("workspace", "last_visited", user_id)
+
+    @staticmethod
+    def _last_exec_key(user_id: str, question_id: str, language: str) -> str:
+        return RedisCache.key("exec", "last", user_id, question_id, language)
+
+    @staticmethod
+    def _last_submit_key(user_id: str, question_id: str) -> str:
+        return RedisCache.key("submit", "last", user_id, question_id)
+
+    async def save_code(
+        self, user_id: str, question_id: str, language: str, code: str
+    ) -> None:
+        if not self.cache:
+            return
+        if len(code.encode("utf-8")) > self.max_code_bytes:
+            logger.warning(
+                "Workspace code too large: user=%s q=%s lang=%s bytes=%d",
+                user_id,
+                question_id,
+                language,
+                len(code.encode("utf-8")),
+            )
+            return
+        payload = {"code": code, "language": language, "updated_at": _now_iso()}
+        try:
+            await self.cache.set(
+                self._code_key(user_id, question_id, language),
+                payload,
+                ttl=self.ttl_workspace,
+            )
+            await self.cache.set(
+                self._meta_key(user_id, question_id),
+                {"language": language, "last_opened_at": _now_iso()},
+                ttl=self.ttl_workspace,
+            )
+            await self.cache.set(
+                self._last_visited_key(user_id),
+                {
+                    "question_id": question_id,
+                    "language": language,
+                    "visited_at": _now_iso(),
+                },
+                ttl=self.ttl_workspace,
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("save_code failed: %s", e)
+
+    async def get_code(
+        self, user_id: str, question_id: str, language: str
+    ) -> Optional[Dict[str, Any]]:
+        if not self.cache:
+            return None
+        try:
+            return await self.cache.get(self._code_key(user_id, question_id, language))
+        except Exception as e:  # pragma: no cover
+            logger.debug("get_code failed: %s", e)
+            return None
+
+    async def delete_code(self, user_id: str, question_id: str, language: str) -> None:
+        if not self.cache:
+            return
+        try:
+            await self.cache.delete(self._code_key(user_id, question_id, language))
+        except Exception as e:  # pragma: no cover
+            logger.debug("delete_code failed: %s", e)
+
+    async def get_meta(
+        self, user_id: str, question_id: str
+    ) -> Optional[Dict[str, Any]]:
+        if not self.cache:
+            return None
+        try:
+            return await self.cache.get(self._meta_key(user_id, question_id))
+        except Exception as e:  # pragma: no cover
+            logger.debug("get_meta failed: %s", e)
+            return None
+
+    async def get_last_visited(self, user_id: str) -> Optional[Dict[str, Any]]:
+        if not self.cache:
+            return None
+        try:
+            return await self.cache.get(self._last_visited_key(user_id))
+        except Exception as e:  # pragma: no cover
+            logger.debug("get_last_visited failed: %s", e)
+            return None
+
+    async def set_last_visited(
+        self, user_id: str, question_id: str, language: Optional[str] = None
+    ) -> None:
+        if not self.cache:
+            return
+        try:
+            await self.cache.set(
+                self._last_visited_key(user_id),
+                {
+                    "question_id": question_id,
+                    "language": language,
+                    "visited_at": _now_iso(),
+                },
+                ttl=self.ttl_workspace,
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("set_last_visited failed: %s", e)
+
+    async def get_chat(self, user_id: str, question_id: str) -> List[Dict[str, Any]]:
+        if not self.cache:
+            return []
+        try:
+            data = await self.cache.get(self._chat_key(user_id, question_id))
+            if isinstance(data, list):
+                return data
+            if isinstance(data, dict) and "messages" in data:
+                return data["messages"]
+            return []
+        except Exception as e:  # pragma: no cover
+            logger.debug("get_chat failed: %s", e)
+            return []
+
+    async def append_chat(
+        self,
+        user_id: str,
+        question_id: str,
+        messages: List[Dict[str, Any]],
+    ) -> None:
+        if not self.cache:
+            return
+        if not messages:
+            return
+        try:
+            existing = await self.get_chat(user_id, question_id)
+            incoming: List[Dict[str, Any]] = []
+            for m in messages:
+                role = m.get("role", "user")
+                if role not in ("user", "assistant"):
+                    continue
+                content = str(m.get("content", ""))[: self.max_chat_chars]
+                entry: Dict[str, Any] = {
+                    "role": role,
+                    "content": content,
+                    "timestamp": m.get("timestamp") or _now_iso(),
+                }
+                if m.get("structured") is not None:
+                    entry["structured"] = m["structured"]
+                incoming.append(entry)
+            combined = existing + incoming
+            if len(combined) > self.max_chat_messages:
+                combined = combined[-self.max_chat_messages :]
+            await self.cache.set(
+                self._chat_key(user_id, question_id), combined, ttl=self.ttl_chat
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("append_chat failed: %s", e)
+
+    async def set_chat(
+        self, user_id: str, question_id: str, messages: List[Dict[str, Any]]
+    ) -> None:
+        if not self.cache:
+            return
+        try:
+            trimmed = (
+                messages[-self.max_chat_messages :]
+                if len(messages) > self.max_chat_messages
+                else messages
+            )
+            normalized: List[Dict[str, Any]] = []
+            for m in trimmed:
+                role = m.get("role", "user")
+                if role not in ("user", "assistant"):
+                    continue
+                normalized.append(
+                    {
+                        "role": role,
+                        "content": str(m.get("content", ""))[: self.max_chat_chars],
+                        "structured": m.get("structured"),
+                        "timestamp": m.get("timestamp") or _now_iso(),
+                    }
+                )
+            await self.cache.set(
+                self._chat_key(user_id, question_id), normalized, ttl=self.ttl_chat
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("set_chat failed: %s", e)
+
+    async def clear_chat(self, user_id: str, question_id: str) -> None:
+        if not self.cache:
+            return
+        try:
+            await self.cache.delete(self._chat_key(user_id, question_id))
+        except Exception as e:  # pragma: no cover
+            logger.debug("clear_chat failed: %s", e)
+
+    async def set_last_exec(
+        self, user_id: str, question_id: str, language: str, result: Dict[str, Any]
+    ) -> None:
+        if not self.cache:
+            return
+        try:
+            await self.cache.set(
+                self._last_exec_key(user_id, question_id, language),
+                result,
+                ttl=self.ttl_last_exec,
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("set_last_exec failed: %s", e)
+
+    async def get_last_exec(
+        self, user_id: str, question_id: str, language: str
+    ) -> Optional[Dict[str, Any]]:
+        if not self.cache:
+            return None
+        try:
+            return await self.cache.get(
+                self._last_exec_key(user_id, question_id, language)
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("get_last_exec failed: %s", e)
+            return None
+
+    async def set_last_submit(
+        self, user_id: str, question_id: str, result: Dict[str, Any]
+    ) -> None:
+        if not self.cache:
+            return
+        try:
+            await self.cache.set(
+                self._last_submit_key(user_id, question_id),
+                result,
+                ttl=self.ttl_last_exec,
+            )
+        except Exception as e:  # pragma: no cover
+            logger.debug("set_last_submit failed: %s", e)
+
+    async def get_last_submit(
+        self, user_id: str, question_id: str
+    ) -> Optional[Dict[str, Any]]:
+        if not self.cache:
+            return None
+        try:
+            return await self.cache.get(self._last_submit_key(user_id, question_id))
+        except Exception as e:  # pragma: no cover
+            logger.debug("get_last_submit failed: %s", e)
+            return None

--- a/backend/scripts/backfill_skill_graph.py
+++ b/backend/scripts/backfill_skill_graph.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Backfill skill graphs for all existing users from submission history.
+
+For every user who has submissions but no learning_events-derived skill state,
+synthesize idempotent LearningEvents (one per submission) and feed them
+through SkillGraphService. Existing learning_events are never duplicated —
+event id ``backfill:{submission.id}`` is deterministic.
+
+Idempotent, re-runnable, non-destructive. Supabase-only.
+
+Usage:
+    DATABASE_URL=postgresql://... python scripts/backfill_skill_graph.py [--dry-run] [--user USER_ID]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+from sqlalchemy.pool import NullPool
+
+from app.models.orm import SubmissionORM, UserORM
+from app.models.skill_graph_schemas import LearningEvent, LearningEventType
+from app.repositories.sql_skill_graph_repository import SqlSkillGraphRepository
+from app.services.skill_graph_service import SkillGraphService
+
+
+def _get_database_url() -> str:
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        raise SystemExit(
+            "ERROR: DATABASE_URL is required (Supabase/PostgreSQL connection string)"
+        )
+    if url.startswith("postgresql://"):
+        url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    return url
+
+
+def _create_engine():
+    search_path = os.getenv("DATABASE_SEARCH_PATH")
+    kwargs: dict = {}
+    if search_path:
+        kwargs["connect_args"] = {"server_settings": {"search_path": search_path}}
+    return create_async_engine(_get_database_url(), poolclass=NullPool, **kwargs)
+
+
+async def backfill(*, dry_run: bool = False, user_id_filter: str | None = None) -> dict:
+    engine = _create_engine()
+    async_session = async_sessionmaker(engine, expire_on_commit=False)
+
+    stats = {
+        "users_scanned": 0,
+        "users_backfilled": 0,
+        "events_created": 0,
+        "duplicates": 0,
+        "skipped_no_submissions": 0,
+    }
+
+    async with async_session() as session:
+        user_q = select(UserORM.id)
+        if user_id_filter:
+            user_q = user_q.where(UserORM.id == user_id_filter)
+        user_ids = (await session.execute(user_q)).scalars().all()
+
+        for uid in user_ids:
+            stats["users_scanned"] += 1
+            # Skip users who already have skill states — they already have a graph.
+            repo = SqlSkillGraphRepository(session)
+            existing_states = await repo.get_states(uid)
+            if existing_states:
+                continue
+
+            subs = (
+                (
+                    await session.execute(
+                        select(SubmissionORM)
+                        .where(SubmissionORM.user_id == uid)
+                        .order_by(SubmissionORM.created_at.asc())
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+            if not subs:
+                stats["skipped_no_submissions"] += 1
+                continue
+
+            events: list[LearningEvent] = []
+            for sub in subs:
+                events.append(
+                    LearningEvent(
+                        id=f"backfill:{sub.id}",
+                        user_id=uid,
+                        event_type=LearningEventType.SUBMISSION_PASSED
+                        if sub.passed
+                        else LearningEventType.SUBMISSION_FAILED,
+                        question_id=sub.question_id,
+                        metadata={},
+                        occurred_at=sub.created_at,
+                    )
+                )
+
+            if dry_run:
+                stats["users_backfilled"] += 1
+                stats["events_created"] += len(events)
+                continue
+
+            svc = SkillGraphService(repository=repo)
+            result = await svc.ingest_events(events, user_id=uid)
+            stats["users_backfilled"] += 1
+            stats["events_created"] += result.accepted
+            stats["duplicates"] += result.duplicate
+
+        if not dry_run:
+            await session.commit()
+
+    await engine.dispose()
+    return stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill skill graphs from submissions"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Count without writing")
+    parser.add_argument(
+        "--user", dest="user_id", default=None, help="Limit to one user id"
+    )
+    args = parser.parse_args()
+
+    stats = asyncio.run(backfill(dry_run=args.dry_run, user_id_filter=args.user_id))
+    mode = "DRY-RUN" if args.dry_run else "LIVE"
+    print(
+        f"[{mode}] users_scanned={stats['users_scanned']} users_backfilled={stats['users_backfilled']} events_created={stats['events_created']} duplicates={stats['duplicates']} skipped_no_submissions={stats['skipped_no_submissions']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/test_course_service.py
+++ b/backend/tests/unit/test_course_service.py
@@ -1,8 +1,15 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
-from app.services.course_service import CourseService
+from app.services.course_service import CourseService, _course_list_cache
 from app.models.course_schemas import Course, Module, Lesson, CourseProgress, LessonType
+
+
+@pytest.fixture(autouse=True)
+def _clear_course_cache():
+    _course_list_cache.clear()
+    yield
+    _course_list_cache.clear()
 
 
 @pytest.fixture
@@ -146,19 +153,19 @@ class TestCourseService:
     ):
         mock_course_repo.get_course_by_id = AsyncMock(return_value=sample_course)
         mock_course_repo.get_modules_by_course = AsyncMock(return_value=[sample_module])
-        mock_course_repo.get_lessons_by_module = AsyncMock(
-            return_value=[
-                Lesson(
-                    id="py-hello-world",
-                    course_id="python-fundamentals",
-                    module_id="python-intro",
-                    title="Hello, World!",
-                    type=LessonType.THEORY,
-                    content="# Hello, World!",
-                    order=1,
-                    language="python",
-                )
-            ]
+        lesson = Lesson(
+            id="py-hello-world",
+            course_id="python-fundamentals",
+            module_id="python-intro",
+            title="Hello, World!",
+            type=LessonType.THEORY,
+            content="# Hello, World!",
+            order=1,
+            language="python",
+        )
+        mock_course_repo.get_lessons_by_module = AsyncMock(return_value=[lesson])
+        mock_course_repo.get_lesson_summaries_by_module_ids = AsyncMock(
+            return_value=[lesson]
         )
 
         service = CourseService(

--- a/backend/tests/unit/test_workspace_service.py
+++ b/backend/tests/unit/test_workspace_service.py
@@ -1,0 +1,134 @@
+"""Unit tests for WorkspaceService — Redis-backed draft code + chat + last-visited."""
+
+import pytest
+from app.services.workspace_service import WorkspaceService
+
+
+class FakeCache:
+    def __init__(self):
+        self.store: dict[str, object] = {}
+
+    async def get(self, key: str):
+        return self.store.get(key)
+
+    async def set(self, key: str, value, ttl: int = 300):
+        self.store[key] = value
+
+    async def delete(self, pattern: str):
+        self.store.pop(pattern, None)
+        return 1
+
+
+@pytest.mark.asyncio
+async def test_save_and_get_code(monkeypatch):
+    monkeypatch.setenv("REDIS_TTL_WORKSPACE", "604800")
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    await svc.save_code("u1", "q1", "python", "print('hi')")
+    data = await svc.get_code("u1", "q1", "python")
+    assert data is not None
+    assert data["code"] == "print('hi')"
+    assert data["language"] == "python"
+    assert "updated_at" in data
+    meta = await svc.get_meta("u1", "q1")
+    assert meta is not None
+    assert meta["language"] == "python"
+    last = await svc.get_last_visited("u1")
+    assert last is not None
+    assert last["question_id"] == "q1"
+
+
+@pytest.mark.asyncio
+async def test_get_code_missing_returns_none():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    assert await svc.get_code("u1", "q-missing", "python") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_code():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    await svc.save_code("u1", "q1", "python", "code")
+    await svc.delete_code("u1", "q1", "python")
+    assert await svc.get_code("u1", "q1", "python") is None
+
+
+@pytest.mark.asyncio
+async def test_graceful_no_cache():
+    svc = WorkspaceService(cache=None)
+    await svc.save_code("u1", "q1", "python", "code")
+    assert await svc.get_code("u1", "q1", "python") is None
+    assert await svc.get_chat("u1", "q1") == []
+    assert await svc.get_last_visited("u1") is None
+    await svc.append_chat("u1", "q1", [{"role": "user", "content": "hi"}])
+    await svc.clear_chat("u1", "q1")
+    await svc.delete_code("u1", "q1", "python")
+
+
+@pytest.mark.asyncio
+async def test_chat_append_and_get():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    await svc.append_chat("u1", "q1", [{"role": "user", "content": "hello"}])
+    await svc.append_chat(
+        "u1",
+        "q1",
+        [{"role": "assistant", "content": "hi there", "structured": {"summary": "s"}}],
+    )
+    msgs = await svc.get_chat("u1", "q1")
+    assert len(msgs) == 2
+    assert msgs[0]["role"] == "user"
+    assert msgs[1]["structured"]["summary"] == "s"
+
+
+@pytest.mark.asyncio
+async def test_chat_cap_truncation():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    svc.max_chat_messages = 3
+    for i in range(5):
+        await svc.append_chat("u1", "q1", [{"role": "user", "content": f"msg {i}"}])
+    msgs = await svc.get_chat("u1", "q1")
+    assert len(msgs) == 3
+    assert msgs[0]["content"] == "msg 2"
+    assert msgs[-1]["content"] == "msg 4"
+
+
+@pytest.mark.asyncio
+async def test_chat_content_truncation():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    svc.max_chat_chars = 5
+    await svc.append_chat("u1", "q1", [{"role": "user", "content": "123456789"}])
+    msgs = await svc.get_chat("u1", "q1")
+    assert msgs[0]["content"] == "12345"
+
+
+@pytest.mark.asyncio
+async def test_clear_chat():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    await svc.append_chat("u1", "q1", [{"role": "user", "content": "hi"}])
+    await svc.clear_chat("u1", "q1")
+    assert await svc.get_chat("u1", "q1") == []
+
+
+@pytest.mark.asyncio
+async def test_last_visited():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    await svc.set_last_visited("u1", "q42", "java")
+    data = await svc.get_last_visited("u1")
+    assert data["question_id"] == "q42"
+    assert data["language"] == "java"
+    assert "visited_at" in data
+
+
+@pytest.mark.asyncio
+async def test_oversized_code_not_saved():
+    cache = FakeCache()
+    svc = WorkspaceService(cache)  # type: ignore[arg-type]
+    svc.max_code_bytes = 5
+    await svc.save_code("u1", "q1", "python", "123456")
+    assert await svc.get_code("u1", "q1", "python") is None

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -10,6 +10,7 @@
 const REWRITE_TARGET = process.env.API_URL || 'http://localhost:8000';
 
 const nextConfig = {
+  skipTrailingSlashRedirect: true,
   env: {
     // Preserve an explicit empty value (same-origin, CSP-safe); only
     // fall back when the variable is unset. `||` would resurrect the

--- a/frontend/src/app/problems/[id]/page.tsx
+++ b/frontend/src/app/problems/[id]/page.tsx
@@ -10,6 +10,7 @@ import { QuestionDescriptionPanel } from '@/components/sidebar/QuestionDescripti
 import { ResizablePanelGroup } from '@/components/ui/ResizablePanelGroup';
 import { useCoaching } from '@/features/coaching/coaching.hook';
 import { useCoachWarm } from '@/features/coaching/use-coach-warm.hook';
+import { useWorkspace } from '@/features/workspace/use-workspace.hook';
 import { CoachingMode } from '@/features/coaching/coaching.types';
 import { questionService } from '@/features/question/question.service';
 import { useCodeRunner } from '@/features/question/use-code-runner.hook';
@@ -63,7 +64,7 @@ export default function ProblemWorkspacePage() {
     isAuthenticated,
   } = useCodeRunner({ fullQuestion, language, currentCode });
 
-  const { messages, isTyping, sendMessage } = useCoaching();
+  const { messages, isTyping, sendMessage, hydrateMessages } = useCoaching() as ReturnType<typeof useCoaching> & { hydrateMessages: (msgs: import('@/types').ChatMessage[]) => void };
   const { ref: workspaceRef, mode } = useWorkspaceMode();
   const [drawerOpen, setDrawerOpen] = useState(false);
 
@@ -89,6 +90,24 @@ export default function ProblemWorkspacePage() {
       ? fullQuestion.starter[language as keyof typeof fullQuestion.starter] || ''
       : '';
 
+  const { deleteDraft } = useWorkspace({
+    questionId: questionId || null,
+    language,
+    currentCode,
+    setCurrentCode,
+    onHydrateChat: (msgs) => {
+      // Convert persisted messages to ChatMessage
+      const hydrated = msgs.map((m) => ({
+        id: `${Date.now()}-${Math.random()}`,
+        role: m.role as 'user' | 'assistant',
+        content: m.content,
+        structured: (m as unknown as { structured?: import('@/types').StructuredCoachingResponse }).structured ?? null,
+        timestamp: new Date((m as unknown as { timestamp: string }).timestamp),
+      }));
+      if (hydrated.length) hydrateMessages(hydrated as import('@/types').ChatMessage[]);
+    },
+  });
+
   const handleEscalateToT2 = useCallback(() => {
     if (!fullQuestion) return;
     const checkpoints = buildRescueCheckpoints(
@@ -109,9 +128,10 @@ export default function ProblemWorkspacePage() {
       fullQuestion.difficulty,
       starterCode,
       'questions',
+      questionId,
     );
     if (mode !== 'wide') setDrawerOpen(true);
-  }, [fullQuestion, lastSubmitResult, currentCode, language, starterCode, sendMessage, mode]);
+  }, [fullQuestion, lastSubmitResult, currentCode, language, starterCode, sendMessage, mode, questionId]);
 
   const handleEscalateToT3 = useCallback(() => {
     if (!fullQuestion) return;
@@ -133,9 +153,10 @@ export default function ProblemWorkspacePage() {
       fullQuestion.difficulty,
       starterCode,
       'questions',
+      questionId,
     );
     if (mode !== 'wide') setDrawerOpen(true);
-  }, [fullQuestion, lastSubmitResult, currentCode, language, starterCode, sendMessage, mode]);
+  }, [fullQuestion, lastSubmitResult, currentCode, language, starterCode, sendMessage, mode, questionId]);
 
   const rescue = useRescueContract({
     questionId,
@@ -161,9 +182,10 @@ export default function ProblemWorkspacePage() {
         undefined,
         starterCode,
         'questions',
+        questionId,
       );
     },
-    [fullQuestion, currentCode, language, sendMessage, rescueActivity, starterCode],
+    [fullQuestion, currentCode, language, sendMessage, rescueActivity, starterCode, questionId],
   );
 
   const handleRunCodeRescue = useCallback(
@@ -186,6 +208,12 @@ export default function ProblemWorkspacePage() {
     },
     [rescueActivity],
   );
+
+  const handleResetCode = useCallback(() => {
+    rescueActivity();
+    setCurrentCode(starterCode);
+    void deleteDraft();
+  }, [rescueActivity, starterCode, deleteDraft]);
 
   const handleLanguageChangeRescue = useCallback(
     (lang: Language) => {
@@ -289,6 +317,7 @@ export default function ProblemWorkspacePage() {
           testResults={testResults}
           isInteractive={fullQuestion.is_interactive || false}
           onCodeChange={handleCodeChangeRescue}
+          onResetCode={handleResetCode}
           onLanguageChange={handleLanguageChangeRescue}
           onRunCode={handleRunCodeRescue}
           onSubmitCode={handleSubmitCodeRescue}

--- a/frontend/src/app/problems/page.tsx
+++ b/frontend/src/app/problems/page.tsx
@@ -25,7 +25,7 @@ import {
 import { useRouter } from 'next/navigation';
 import { workspaceService } from '@/features/workspace/workspace.service';
 import { AuthContext } from '@/providers/AuthProvider';
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 
 const difficultyStyles: Record<string, string> = {
@@ -57,6 +57,8 @@ export default function ProblemsPage() {
   const [company, setCompany] = useState<string>('all');
   const [status, setStatus] = useState<StatusFilter>('all');
   const [sort, setSort] = useState<QuestionSortKey>('daily');
+  const [visibleCount, setVisibleCount] = useState(20);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     loadQuestions();
@@ -167,6 +169,34 @@ export default function ProblemsPage() {
     setStatus('all');
     setSort('daily');
   }, []);
+
+  // Reset visible count when filters change — start from top
+  useEffect(() => {
+    setVisibleCount(20);
+  }, [search, difficulty, category, company, status, sort]);
+
+  const hasMore = filtered.length > visibleCount;
+  const displayed = useMemo(
+    () => filtered.slice(0, visibleCount),
+    [filtered, visibleCount],
+  );
+
+  const loadMore = useCallback(() => {
+    setVisibleCount((c) => Math.min(c + 20, filtered.length));
+  }, [filtered.length]);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || !hasMore) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) loadMore();
+      },
+      { rootMargin: '400px', threshold: 0 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasMore, loadMore]);
 
   const handleSelect = useCallback(
     (q: QuestionSummary) => {
@@ -398,7 +428,7 @@ export default function ProblemsPage() {
                       </tr>
                     </thead>
                     <tbody>
-                      {filtered.map((q) => {
+                      {displayed.map((q) => {
                         const s = progress[q.id];
                         return (
                           <tr
@@ -465,7 +495,7 @@ export default function ProblemsPage() {
 
                 {/* ── Mobile cards ───────────────────────────────── */}
                 <div className="md:hidden divide-y divide-white/[0.03]">
-                  {filtered.map((q) => {
+                  {displayed.map((q) => {
                     const s = progress[q.id];
                     return (
                       <button
@@ -518,6 +548,15 @@ export default function ProblemsPage() {
                     );
                   })}
                 </div>
+                {hasMore && (
+                  <div
+                    ref={sentinelRef}
+                    className="flex items-center justify-center py-4 text-[11px] text-muted-foreground/40"
+                  >
+                    <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                    Loading more...
+                  </div>
+                )}
               </>
             )}
 
@@ -525,8 +564,9 @@ export default function ProblemsPage() {
               <div className="px-6 py-3 border-t border-white/5 text-[10px] text-muted-foreground/40 flex items-center justify-between gap-2 flex-wrap">
                 <span>
                   {hasActiveFilters
-                    ? `Showing ${filtered.length} of ${allQuestions.length} questions`
-                    : `${filtered.length} questions available`}
+                    ? `Showing ${displayed.length} of ${filtered.length} (filtered from ${allQuestions.length})`
+                    : `Showing ${displayed.length} of ${filtered.length} questions`}
+                  {hasMore ? ' — scroll for more' : ''}
                 </span>
                 <span>Click any problem to start coding</span>
               </div>

--- a/frontend/src/app/problems/page.tsx
+++ b/frontend/src/app/problems/page.tsx
@@ -23,7 +23,9 @@ import {
   XCircle,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { workspaceService } from '@/features/workspace/workspace.service';
+import { AuthContext } from '@/providers/AuthProvider';
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 
 const difficultyStyles: Record<string, string> = {
@@ -45,6 +47,9 @@ export default function ProblemsPage() {
   const router = useRouter();
   const { allQuestions, loadQuestions, isLoading, error } = useQuestion();
   const [progress] = useLocalStorage<Record<string, 'attempted' | 'solved'>>('user_progress', {});
+  const auth = useContext(AuthContext);
+  const isAuthenticated = auth?.isAuthenticated ?? false;
+  const [lastVisited, setLastVisited] = useState<{ question_id: string; language: string | null } | null>(null);
 
   const [search, setSearch] = useState('');
   const [difficulty, setDifficulty] = useState<string>('all');
@@ -56,6 +61,13 @@ export default function ProblemsPage() {
   useEffect(() => {
     loadQuestions();
   }, [loadQuestions]);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    workspaceService.getLastVisited().then((data) => {
+      if (data?.question_id) setLastVisited(data);
+    }).catch(() => {});
+  }, [isAuthenticated]);
 
   const categories = useMemo(() => {
     const set = new Set<string>();
@@ -183,6 +195,12 @@ export default function ProblemsPage() {
     <div className="min-h-[100dvh] bg-background text-foreground">
       <Header />
       <main className="max-w-5xl mx-auto px-6 pt-20 pb-32">
+        {lastVisited && (
+          <div className="mb-4 flex items-center justify-between px-4 py-3 rounded-2xl bg-primary/10 ring-1 ring-primary/20">
+            <span className="text-xs text-primary/90">Continue where you left off: <span className="font-medium">{resolveQuestionTitle(lastVisited.question_id) || lastVisited.question_id}</span></span>
+            <button onClick={() => router.push(`/problems/${lastVisited.question_id}`)} className="text-xs px-3 py-1 rounded-full bg-primary text-primary-foreground hover:bg-primary/90">Resume</button>
+          </div>
+        )}
         <RecommendedQuestions />
         <RescueDueQueue resolveTitle={resolveQuestionTitle} />
         <ReviewsDueQueue resolveTitle={resolveQuestionTitle} />

--- a/frontend/src/components/editor/CodeEditor.tsx
+++ b/frontend/src/components/editor/CodeEditor.tsx
@@ -20,6 +20,7 @@ const Editor = dynamic(
 );
 
 interface CodeEditorProps {
+  onReset?: () => void;
   language: Language;
   code: string;
   initialCode: string;
@@ -43,6 +44,7 @@ export function CodeEditor({
   isRunning,
   isResizing,
   isAuthenticated = true,
+  onReset,
 }: CodeEditorProps) {
   const editorRef = useRef<any>(null);
   const monacoLanguage = language === "c" ? "cpp" : language;
@@ -56,7 +58,11 @@ export function CodeEditor({
   };
 
   const resetCode = () => {
-    onCodeChange(initialCode);
+    if (onReset) {
+      onReset();
+    } else {
+      onCodeChange(initialCode);
+    }
   };
 
   return (

--- a/frontend/src/components/layout/elements/CodeEditorContainer.tsx
+++ b/frontend/src/components/layout/elements/CodeEditorContainer.tsx
@@ -24,6 +24,7 @@ interface CodeEditorContainerProps {
   onRunCode: (stdin: string) => void;
   onSubmitCode: () => void;
   isAuthenticated?: boolean;
+  onResetCode?: () => void;
 }
 
 export function CodeEditorContainer({
@@ -40,6 +41,7 @@ export function CodeEditorContainer({
   onRunCode,
   onSubmitCode,
   isAuthenticated = true,
+  onResetCode,
 }: CodeEditorContainerProps) {
   const [outputHeight, setOutputHeight] = useState(200); // Default 200px
   const [outputCollapsed, setOutputCollapsed] = useState(false);
@@ -122,6 +124,7 @@ export function CodeEditorContainer({
           isRunning={isRunning}
           isResizing={isResizing}
           isAuthenticated={isAuthenticated}
+          onReset={onResetCode}
         />
 
         {/* Interactive Input Area */}

--- a/frontend/src/components/settings/SettingsModal.test.tsx
+++ b/frontend/src/components/settings/SettingsModal.test.tsx
@@ -3,6 +3,10 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SettingsModal } from './SettingsModal';
 
+vi.mock('@/features/skill-graph/SkillGraphInline', () => ({
+  SkillGraphInline: () => <div data-testid='skill-graph-inline' />,
+}));
+
 describe('SettingsModal', () => {
   const defaultProps = {
     open: true,

--- a/frontend/src/components/settings/SettingsModal.tsx
+++ b/frontend/src/components/settings/SettingsModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { SkillGraphInline } from '@/features/skill-graph/SkillGraphInline';
 import { FileText, LogOut, Sparkles, X } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 
@@ -68,6 +69,8 @@ export function SettingsModal({
                 </div>
               </div>
             </div>
+
+            <SkillGraphInline isAuthenticated={isAuthenticated} />
 
             <div className="rounded-2xl bg-white/[0.03] ring-1 ring-white/5 p-4">
               <div className="flex items-center justify-between gap-3">

--- a/frontend/src/features/coaching/coaching.hook.ts
+++ b/frontend/src/features/coaching/coaching.hook.ts
@@ -15,7 +15,7 @@ function isRateLimited(err: unknown): boolean {
   );
 }
 
-export function useCoaching(): CoachingFeature {
+export function useCoaching(): CoachingFeature & { hydrateMessages: (msgs: ChatMessage[]) => void } {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
@@ -28,6 +28,11 @@ export function useCoaching(): CoachingFeature {
     clearLimitReached,
   } = useUsage();
 
+  const hydrateMessages = useCallback((msgs: ChatMessage[]) => {
+    setMessages(msgs);
+    messagesRef.current = msgs;
+  }, []);
+
   const sendMessage = useCallback(
     async (
       message: string,
@@ -39,6 +44,7 @@ export function useCoaching(): CoachingFeature {
       difficulty?: string,
       initialCode?: string,
       surface: CoachingSurface = "questions",
+      questionId?: string,
     ) => {
       const userMessage: ChatMessage = {
         id: Date.now().toString(),
@@ -71,6 +77,7 @@ export function useCoaching(): CoachingFeature {
             chatHistory,
             initialCode,
             surface,
+            questionId,
           );
 
           const assistantMessage: ChatMessage = {
@@ -136,5 +143,6 @@ export function useCoaching(): CoachingFeature {
     clearError,
     limitReached,
     clearLimitReached,
+    hydrateMessages,
   };
 }

--- a/frontend/src/features/coaching/coaching.service.ts
+++ b/frontend/src/features/coaching/coaching.service.ts
@@ -14,6 +14,7 @@ export interface CoachingRequest {
   chat_history?: { role: string; content: string }[];
   initial_code?: string;
   surface: CoachingSurface;
+  question_id?: string;
 }
 
 export interface CoachingResponse {
@@ -41,6 +42,7 @@ export class CoachingService {
     chatHistory?: { role: string; content: string }[],
     initialCode?: string,
     surface: CoachingSurface = "questions",
+    questionId?: string,
   ): Promise<CoachingResponse> {
     const body: CoachingRequest = {
       problem,
@@ -59,6 +61,9 @@ export class CoachingService {
     }
     if (initialCode !== undefined) {
       body.initial_code = initialCode;
+    }
+    if (questionId) {
+      body.question_id = questionId;
     }
     const data = await this.http.post<{
       response: string;

--- a/frontend/src/features/coaching/coaching.types.ts
+++ b/frontend/src/features/coaching/coaching.types.ts
@@ -18,6 +18,7 @@ export interface CoachingRequest {
   mode: CoachingMode;
   difficulty?: string;
   initial_code?: string;
+  question_id?: string;
 }
 
 export interface CoachingResponse {
@@ -43,10 +44,12 @@ export interface CoachingActions {
     difficulty?: string,
     initialCode?: string,
     surface?: CoachingSurface,
+    questionId?: string,
   ) => Promise<void>;
   clearMessages: () => void;
   clearError: () => void;
   clearLimitReached: () => void;
+  hydrateMessages?: (msgs: ChatMessage[]) => void;
 }
 
 export type CoachingFeature = CoachingState & CoachingActions;

--- a/frontend/src/features/curriculum/use-course.hook.test.ts
+++ b/frontend/src/features/curriculum/use-course.hook.test.ts
@@ -30,7 +30,7 @@ describe("useCourse", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.course).toEqual(courseData);
-    expect(mockGet).toHaveBeenCalledWith("/api/courses/1");
+    expect(mockGet).toHaveBeenCalledWith("/api/courses/1", { timeout: 15000 });
   });
 
   it("sets error when fetch fails", async () => {

--- a/frontend/src/features/curriculum/use-curriculum.hook.ts
+++ b/frontend/src/features/curriculum/use-curriculum.hook.ts
@@ -6,6 +6,24 @@ import { CourseSummary, CourseDetail, LessonSummary } from "@/types";
 
 const api = new FetchClient();
 
+async function fetchWithRetry<T>(fn: () => Promise<T>, retries = 2): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i <= retries; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const isTimeout =
+        err instanceof Error &&
+        (err.message.includes("timeout") || (err as unknown as { status?: number }).status === 408);
+      if (!isTimeout || i === retries) throw err;
+      // backoff 400ms * (i+1)
+      await new Promise((r) => setTimeout(r, 400 * (i + 1)));
+    }
+  }
+  throw lastErr;
+}
+
 export function useCurriculum() {
   const [courses, setCourses] = useState<CourseSummary[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -15,7 +33,10 @@ export function useCurriculum() {
     setIsLoading(true);
     setError(null);
     try {
-      const data = await api.get<{ courses: CourseSummary[] }>("/api/courses/");
+      const data = await fetchWithRetry(
+        () => api.get<{ courses: CourseSummary[] }>("/api/courses/", { timeout: 15000 }),
+        2,
+      );
       setCourses(data.courses);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load courses");
@@ -44,7 +65,10 @@ export function useCourse(courseId: string) {
     setIsLoading(true);
     setError(null);
     try {
-      const data = await api.get<CourseDetail>(`/api/courses/${courseId}`);
+      const data = await fetchWithRetry(
+        () => api.get<CourseDetail>(`/api/courses/${courseId}`, { timeout: 15000 }),
+        2,
+      );
       setCourse(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load course");
@@ -73,8 +97,9 @@ export function useLesson(lessonId: string) {
     setIsLoading(true);
     setError(null);
     try {
-      const data = await api.get<LessonSummary>(
-        `/api/courses/lessons/${lessonId}`,
+      const data = await fetchWithRetry(
+        () => api.get<LessonSummary>(`/api/courses/lessons/${lessonId}`, { timeout: 15000 }),
+        2,
       );
       setLesson(data);
     } catch (err) {

--- a/frontend/src/features/curriculum/use-lesson.hook.test.ts
+++ b/frontend/src/features/curriculum/use-lesson.hook.test.ts
@@ -30,7 +30,7 @@ describe("useLesson", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.lesson).toEqual(lessonData);
-    expect(mockGet).toHaveBeenCalledWith("/api/courses/lessons/1");
+    expect(mockGet).toHaveBeenCalledWith("/api/courses/lessons/1", { timeout: 15000 });
   });
 
   it("sets error when fetch fails", async () => {

--- a/frontend/src/features/question/question.hook.ts
+++ b/frontend/src/features/question/question.hook.ts
@@ -25,7 +25,13 @@ interface UseQuestionReturn {
   clearError: () => void;
 }
 
-export function useQuestion(options: UseQuestionOptions = {}): UseQuestionReturn {
+const PAGE_SIZE = 20;
+
+export function useQuestion(options: UseQuestionOptions = {}): UseQuestionReturn & {
+  visibleCount: number;
+  hasMore: boolean;
+  loadMore: () => void;
+} {
   const { initialFilters = {} } = options;
 
   const [questions, setQuestions] = useState<QuestionSummary[]>([]);
@@ -35,6 +41,7 @@ export function useQuestion(options: UseQuestionOptions = {}): UseQuestionReturn
   const [isLoadingQuestion, setIsLoadingQuestion] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [filters, setFiltersState] = useState<QuestionFilters>(initialFilters);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   const loadQuestions = useCallback(async () => {
     setIsLoading(true);
@@ -42,6 +49,7 @@ export function useQuestion(options: UseQuestionOptions = {}): UseQuestionReturn
     try {
       const data = await questionService.getQuestions();
       setQuestions(data);
+      setVisibleCount(PAGE_SIZE);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to load questions';
       setError(errorMessage);
@@ -71,6 +79,11 @@ export function useQuestion(options: UseQuestionOptions = {}): UseQuestionReturn
 
   const setFilters = useCallback((newFilters: QuestionFilters) => {
     setFiltersState(newFilters);
+    setVisibleCount(PAGE_SIZE);
+  }, []);
+
+  const loadMore = useCallback(() => {
+    setVisibleCount((c) => c + PAGE_SIZE);
   }, []);
 
   const clearError = useCallback(() => {
@@ -114,8 +127,14 @@ export function useQuestion(options: UseQuestionOptions = {}): UseQuestionReturn
     return items;
   }, [filteredQuestions, filters.sort]);
 
+  const hasMore = sortedQuestions.length > visibleCount;
+  const paginatedQuestions = useMemo(
+    () => sortedQuestions.slice(0, visibleCount),
+    [sortedQuestions, visibleCount],
+  );
+
   return {
-    questions: sortedQuestions,
+    questions: paginatedQuestions,
     allQuestions: questions,
     selectedQuestion,
     fullQuestion,
@@ -127,5 +146,8 @@ export function useQuestion(options: UseQuestionOptions = {}): UseQuestionReturn
     selectQuestion,
     setFilters,
     clearError,
+    visibleCount,
+    hasMore,
+    loadMore,
   };
 }

--- a/frontend/src/features/question/question.service.test.ts
+++ b/frontend/src/features/question/question.service.test.ts
@@ -21,12 +21,12 @@ describe('QuestionService', () => {
   });
 
   describe('getQuestions', () => {
-    it('calls GET /api/questions with no-store cache', async () => {
-      vi.mocked(http.get).mockResolvedValue({ questions: [] });
+    it('calls GET /api/questions paginated with no-store cache', async () => {
+      vi.mocked(http.get).mockResolvedValue({ questions: [], total: 0, page: 1, per_page: 100 });
 
       await service.getQuestions();
 
-      expect(http.get).toHaveBeenCalledWith('/api/questions', {
+      expect(http.get).toHaveBeenCalledWith('/api/questions?page=1&per_page=100', {
         cache: 'no-store',
       });
     });
@@ -48,7 +48,7 @@ describe('QuestionService', () => {
           company_tags: [],
         },
       ];
-      vi.mocked(http.get).mockResolvedValue({ questions: mockQuestions });
+      vi.mocked(http.get).mockResolvedValue({ questions: mockQuestions, total: 2, page: 1, per_page: 100 });
 
       const result = await service.getQuestions();
 
@@ -57,8 +57,29 @@ describe('QuestionService', () => {
       expect(result[1].title).toBe('Add Two Numbers');
     });
 
+    it('fetches next page when total exceeds per_page', async () => {
+      const page1 = Array.from({ length: 100 }, (_, i) => ({
+        id: String(i),
+        title: `Q${i}`,
+        difficulty: 'easy' as const,
+        category: 'arrays',
+        company_tags: [],
+      }));
+      const page2 = [
+        { id: '100', title: 'Q100', difficulty: 'easy' as const, category: 'arrays', company_tags: [] },
+      ];
+      vi.mocked(http.get)
+        .mockResolvedValueOnce({ questions: page1, total: 101, page: 1, per_page: 100 })
+        .mockResolvedValueOnce({ questions: page2, total: 101, page: 2, per_page: 100 });
+
+      const result = await service.getQuestions();
+
+      expect(result).toHaveLength(101);
+      expect(http.get).toHaveBeenCalledTimes(2);
+    });
+
     it('returns empty array when response has no questions field', async () => {
-      vi.mocked(http.get).mockResolvedValue({});
+      vi.mocked(http.get).mockResolvedValue({ total: 0, page: 1, per_page: 100 });
 
       const result = await service.getQuestions();
 
@@ -66,7 +87,7 @@ describe('QuestionService', () => {
     });
 
     it('returns empty array when questions is null', async () => {
-      vi.mocked(http.get).mockResolvedValue({ questions: null });
+      vi.mocked(http.get).mockResolvedValue({ questions: null, total: 0, page: 1, per_page: 100 });
 
       const result = await service.getQuestions();
 

--- a/frontend/src/features/question/question.service.ts
+++ b/frontend/src/features/question/question.service.ts
@@ -6,13 +6,30 @@ export class QuestionService {
   constructor(private http: HttpClient) {}
 
   async getQuestions(): Promise<QuestionSummary[]> {
-    const data = await this.http.get<{ questions: QuestionSummary[] }>(
-      "/api/questions",
-      {
+    // Fetch all questions paginated (per_page=100) — backend optimized for summary columns, single page ~1.4s
+    // Total 107 needs 2 pages; loop until total collected. Keeps client-side filtering correct while enabling infinite scroll rendering.
+    const perPage = 100;
+    let page = 1;
+    let all: QuestionSummary[] = [];
+    let total: number | null = null;
+    while (total === null || all.length < total) {
+      const data = await this.http.get<{
+        questions: QuestionSummary[];
+        total: number;
+        page: number;
+        per_page: number;
+      }>(`/api/questions?page=${page}&per_page=${perPage}`, {
         cache: "no-store",
-      },
-    );
-    return data.questions || [];
+      });
+      const batch = data.questions || [];
+      all = all.concat(batch);
+      total = data.total ?? batch.length;
+      if (batch.length < perPage) break;
+      page += 1;
+      // Safety: never loop more than 10 pages
+      if (page > 10) break;
+    }
+    return all;
   }
 
   async getQuestion(id: string): Promise<Question> {

--- a/frontend/src/features/skill-graph/SkillGraphInline.tsx
+++ b/frontend/src/features/skill-graph/SkillGraphInline.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { BookOpen, Loader2, Sparkles } from 'lucide-react';
+import { skillGraphService } from './skill-graph.service';
+import { SkillGraphResponse, SkillSummary } from '@/types';
+
+function StatusBadge({ status }: { status: SkillSummary['status'] }) {
+  const map: Record<string, string> = {
+    new: 'bg-white/[0.04] text-muted-foreground/60 ring-white/5',
+    learning: 'bg-amber-500/10 text-amber-400 ring-amber-500/20',
+    developing: 'bg-blue-500/10 text-blue-400 ring-blue-500/20',
+    strong: 'bg-emerald-500/10 text-emerald-400 ring-emerald-500/20',
+    needs_review: 'bg-red-500/10 text-red-400 ring-red-500/20',
+  };
+  return (
+    <span className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-medium ring-1 ${map[status] ?? map.new}`}>
+      {status.replace('_', ' ')}
+    </span>
+  );
+}
+
+function MasteryBar({ value }: { value: number }) {
+  return (
+    <div className="h-1.5 w-full rounded-full bg-white/[0.06] overflow-hidden">
+      <div
+        className="h-full rounded-full bg-primary transition-all duration-500"
+        style={{ width: `${Math.round(value * 100)}%` }}
+      />
+    </div>
+  );
+}
+
+export function SkillGraphInline({ isAuthenticated }: { isAuthenticated?: boolean }) {
+  const [data, setData] = useState<SkillGraphResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = isAuthenticated
+          ? await skillGraphService.getGraph(true)
+          : await skillGraphService.getBoilerplate();
+        if (!cancelled) setData(res);
+      } catch (e: unknown) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load skills');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated]);
+
+  return (
+    <div className="rounded-2xl bg-white/[0.03] ring-1 ring-white/5 p-4" role="region" aria-label="Skill graph">
+      <div className="flex items-center justify-between gap-2 mb-3">
+        <div className="flex items-center gap-2">
+          <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/20">
+            <BookOpen className="h-3.5 w-3.5 text-primary/80" />
+          </span>
+          <div>
+            <p className="text-xs font-medium text-foreground/80">Your Skills</p>
+            <p className="text-[10px] text-muted-foreground/60">
+              {isAuthenticated ? 'Personalized mastery map' : 'Preview — sign in to track progress'}
+            </p>
+          </div>
+        </div>
+        {data && (
+          <span className="text-[10px] text-muted-foreground/50">
+            {data.skills.length} skills · {data.edges.length} links
+          </span>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-6 text-muted-foreground/50" data-testid="skill-graph-loading">
+          <Loader2 className="h-4 w-4 animate-spin mr-2" />
+          <span className="text-xs">Loading skills…</span>
+        </div>
+      ) : error ? (
+        <div className="rounded-xl bg-red-500/10 ring-1 ring-red-500/20 p-3">
+          <p className="text-xs text-red-400/80" data-testid="skill-graph-error">{error}</p>
+        </div>
+      ) : !data || data.skills.length === 0 ? (
+        <p className="text-xs text-muted-foreground/60 text-center py-4">No skills yet.</p>
+      ) : (
+        <div className="space-y-2 max-h-64 overflow-y-auto pr-1" data-testid="skill-graph-list">
+          {data.skills.slice(0, 22).map((s) => (
+            <div
+              key={s.skill_slug}
+              className="rounded-xl bg-white/[0.02] ring-1 ring-white/[0.03] px-3 py-2.5 hover:bg-white/[0.04] transition-colors"
+              data-testid="skill-graph-item"
+              data-skill={s.skill_slug}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs font-medium text-foreground/80 truncate">{s.name}</span>
+                <StatusBadge status={s.status} />
+              </div>
+              <div className="mt-1.5 flex items-center gap-2">
+                <MasteryBar value={s.mastery_score} />
+                <span className="text-[10px] text-muted-foreground/60 shrink-0">{Math.round(s.mastery_score * 100)}%</span>
+              </div>
+              {s.evidence_count > 0 && (
+                <p className="text-[10px] text-muted-foreground/50 mt-1">
+                  {s.evidence_count} evidence · {s.trend}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-3 flex items-center justify-between">
+        <Link
+          href={isAuthenticated ? '/dashboard' : '/learn'}
+          className="inline-flex items-center gap-1 text-[11px] font-medium text-primary/80 hover:text-primary transition-colors"
+        >
+          <Sparkles className="h-3 w-3" />
+          {isAuthenticated ? 'Open dashboard' : 'Start learning'}
+        </Link>
+        {!isAuthenticated && (
+          <span className="text-[10px] text-muted-foreground/40">Sign in to save progress</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/skill-graph/skill-graph.service.ts
+++ b/frontend/src/features/skill-graph/skill-graph.service.ts
@@ -1,9 +1,22 @@
 import { HttpClient } from "@/lib/http-client";
 import { FetchClient } from "@/lib/fetch-client";
-import { RecommendedQuestion } from "@/types";
+import { RecommendedQuestion, SkillGraphResponse } from "@/types";
 
 export class SkillGraphService {
   constructor(private http: HttpClient) {}
+
+  async getGraph(includeBoilerplate: boolean = true): Promise<SkillGraphResponse> {
+    const suffix = includeBoilerplate ? "?include_boilerplate=true" : "";
+    return this.http.get<SkillGraphResponse>(`/api/skills/me/skills${suffix}`, {
+      cache: "no-store",
+    });
+  }
+
+  async getBoilerplate(): Promise<SkillGraphResponse> {
+    return this.http.get<SkillGraphResponse>("/api/skills/boilerplate", {
+      cache: "no-store",
+    });
+  }
 
   async getRecommendedQuestions(limit: number = 5): Promise<RecommendedQuestion[]> {
     return this.http.get<RecommendedQuestion[]>(

--- a/frontend/src/features/workspace/use-workspace.hook.ts
+++ b/frontend/src/features/workspace/use-workspace.hook.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { useCallback, useContext, useEffect, useRef } from "react";
+import { Language } from "@/types";
+import { AuthContext } from "@/providers/AuthProvider";
+import { workspaceService } from "./workspace.service";
+
+interface UseWorkspaceOptions {
+  questionId: string | null;
+  language: Language;
+  currentCode: string;
+  setCurrentCode: (code: string) => void;
+  onHydrateChat?: (messages: { role: "user" | "assistant"; content: string; structured?: unknown; timestamp: string }[]) => void;
+}
+
+/**
+ * Hydrates draft code from Redis and debounces saves.
+ * No-op when unauthenticated (per spec).
+ */
+export function useWorkspace({
+  questionId,
+  language,
+  currentCode,
+  setCurrentCode,
+  onHydrateChat,
+}: UseWorkspaceOptions) {
+  const auth = useContext(AuthContext);
+  const isAuthenticated = auth?.isAuthenticated ?? false;
+
+  const hydratedRef = useRef<string | null>(null);
+  const lastSavedRef = useRef<string>("");
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Hydrate code + chat on question/language change
+  useEffect(() => {
+    if (!questionId || !isAuthenticated) return;
+    const key = `${questionId}:${language}`;
+    if (hydratedRef.current === key) return;
+    hydratedRef.current = key;
+    let cancelled = false;
+    workspaceService
+      .getCode(questionId, language)
+      .then((res) => {
+        if (cancelled) return;
+        if (res.code) {
+          lastSavedRef.current = res.code;
+          setCurrentCode(res.code);
+        }
+      })
+      .catch(() => {});
+    if (onHydrateChat) {
+      workspaceService
+        .getChat(questionId)
+        .then((res) => {
+          if (cancelled) return;
+          if (res.messages?.length) onHydrateChat(res.messages as never);
+        })
+        .catch(() => {});
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [questionId, language, isAuthenticated, setCurrentCode, onHydrateChat]);
+
+  useEffect(() => {
+    hydratedRef.current = null;
+  }, [questionId]);
+
+  const scheduleSave = useCallback(
+    (code: string) => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+      debounceTimer.current = setTimeout(() => {
+        if (!questionId || !isAuthenticated) return;
+        if (code === lastSavedRef.current) return;
+        lastSavedRef.current = code;
+        workspaceService.saveCode(questionId, language, code).catch(() => {});
+      }, 800);
+    },
+    [questionId, language, isAuthenticated]
+  );
+
+  useEffect(() => {
+    if (!questionId || !isAuthenticated) return;
+    if (hydratedRef.current !== `${questionId}:${language}`) return;
+    scheduleSave(currentCode);
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    };
+  }, [currentCode, questionId, language, isAuthenticated, scheduleSave]);
+
+  const deleteDraft = useCallback(async () => {
+    if (!questionId || !isAuthenticated) return;
+    try {
+      await workspaceService.deleteCode(questionId, language);
+      lastSavedRef.current = "";
+    } catch {}
+  }, [questionId, language, isAuthenticated]);
+
+  const clearChat = useCallback(async () => {
+    if (!questionId || !isAuthenticated) return;
+    try {
+      await workspaceService.clearChat(questionId);
+    } catch {}
+  }, [questionId, isAuthenticated]);
+
+  return { deleteDraft, clearChat };
+}

--- a/frontend/src/features/workspace/workspace.service.ts
+++ b/frontend/src/features/workspace/workspace.service.ts
@@ -1,0 +1,57 @@
+import { HttpClient } from "@/lib/http-client";
+import { FetchClient } from "@/lib/fetch-client";
+
+export interface WorkspaceCode {
+  code: string;
+  language: string;
+  updated_at: string | null;
+  question_id: string;
+}
+
+export interface LastVisited {
+  question_id: string;
+  language: string | null;
+  visited_at: string;
+}
+
+export interface ChatMessagePersisted {
+  role: "user" | "assistant";
+  content: string;
+  structured?: unknown;
+  timestamp: string;
+}
+
+export class WorkspaceService {
+  constructor(private http: HttpClient) {}
+
+  async getCode(questionId: string, language: string): Promise<WorkspaceCode> {
+    const qs = new URLSearchParams({ language }).toString();
+    return this.http.get<WorkspaceCode>(`/api/workspace/code/${encodeURIComponent(questionId)}?${qs}`);
+  }
+
+  async saveCode(questionId: string, language: string, code: string): Promise<void> {
+    await this.http.put<void>(`/api/workspace/code/${encodeURIComponent(questionId)}`, {
+      language,
+      code,
+    });
+  }
+
+  async deleteCode(questionId: string, language: string): Promise<void> {
+    const qs = new URLSearchParams({ language }).toString();
+    await this.http.delete<void>(`/api/workspace/code/${encodeURIComponent(questionId)}?${qs}`);
+  }
+
+  async getLastVisited(): Promise<LastVisited | null> {
+    return this.http.get<LastVisited | null>(`/api/workspace/last-visited`);
+  }
+
+  async getChat(questionId: string): Promise<{ question_id: string; messages: ChatMessagePersisted[] }> {
+    return this.http.get<{ question_id: string; messages: ChatMessagePersisted[] }>(`/api/workspace/chat/${encodeURIComponent(questionId)}`);
+  }
+
+  async clearChat(questionId: string): Promise<void> {
+    await this.http.delete<void>(`/api/workspace/chat/${encodeURIComponent(questionId)}`);
+  }
+}
+
+export const workspaceService = new WorkspaceService(new FetchClient());

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -104,6 +104,19 @@ export const handlers = [
     }
     return HttpResponse.json([]);
   }),
+  http.get("/api/skills/boilerplate", () => {
+    return HttpResponse.json({ skills: [], edges: [] });
+  }),
+  http.get("/api/skills/me/skills", ({ request }) => {
+    const auth = request.headers.get("Authorization");
+    if (!auth) {
+      return HttpResponse.json(
+        { detail: "Not authenticated" },
+        { status: 401 },
+      );
+    }
+    return HttpResponse.json({ skills: [], edges: [] });
+  }),
   http.get("/api/courses/", () => {
     return HttpResponse.json({
       courses: [

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -24,7 +24,7 @@ interface AuthContextType extends AuthState {
   logout: () => void;
 }
 
-const AuthContext = createContext<AuthContextType | null>(null);
+export const AuthContext = createContext<AuthContextType | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<AuthState>({

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -226,6 +226,30 @@ export interface CourseProgress {
   last_accessed_at: string;
 }
 
+export interface SkillSummary {
+  skill_slug: string;
+  name: string;
+  mastery_score: number;
+  confidence: number;
+  status: "new" | "learning" | "developing" | "strong" | "needs_review";
+  trend: "improving" | "declining" | "stable";
+  evidence_count: number;
+  recent_error_count: number;
+  last_seen_at: string | null;
+  last_reviewed_at: string | null;
+}
+
+export interface SkillGraphEdge {
+  source: string;
+  target: string;
+  relation: string;
+}
+
+export interface SkillGraphResponse {
+  skills: SkillSummary[];
+  edges: SkillGraphEdge[];
+}
+
 export interface User {
   id: string;
   username: string;


### PR DESCRIPTION
## Summary
Persist workspace state to Redis (7d TTL, auth-only, graceful degrade) for codes, last-visited problem, and AI chat.

### Backend
- `WorkspaceService` at `backend/app/services/workspace_service.py:24` — draft code per `codecoach:workspace:code:{user}:{q}:{lang}`, last-visited `codecoach:workspace:last_visited:{user}`, chat `codecoach:chat:{user}:{q}` capped 20 msgs/5k chars, TTL `604800` (7d), caps `WORKSPACE_CODE_MAX_BYTES=51200`, graceful degrade when cache absent
- Schemas at `backend/app/models/workspace_schemas.py:1`, config at `backend/app/core/config.py:87` (`REDIS_TTL_WORKSPACE/CHAT/LAST_EXEC=604800`)
- Routes at `backend/app/api/workspace.py:9` (`PUT/GET/DELETE /api/workspace/code/{id}?language=`, `GET /api/workspace/last-visited`, `GET/DELETE /api/workspace/chat/{id}`, `GET /api/workspace/meta/{id}`) auth-required via `get_current_user`
- Coaching persistence at `backend/app/api/coach.py:105` best-effort append of `[user, assistant]` when `question_id` supplied (no streaming per spec), `backend/app/models/schemas.py:74` optional `question_id` (non-breaking), DI at `backend/app/api/dependencies.py:177` `get_workspace_service`, router at `backend/app/main.py:50`
- TDD: `backend/tests/unit/test_workspace_service.py:1` 10 tests (save/get, delete, graceful no-cache, chat append/cap/truncate, last-visited, oversize); manual `TestClient` integration verified PUT→GET→last-visited→DELETE→unauth 401→chat

### Frontend
- `WorkspaceService` at `frontend/src/features/workspace/workspace.service.ts:16` + `useWorkspace` at `frontend/src/features/workspace/use-workspace.hook.ts:9` (hydrate on mount, 800ms debounce save, delete on Reset, unauth degrades to local only, safe via `AuthContext`)
- `CoachingService` at `frontend/src/features/coaching/coaching.service.ts:16` forwards `question_id`, `useCoaching` at `frontend/src/features/coaching/coaching.hook.ts:14` `hydrateMessages`, types at `frontend/src/features/coaching/coaching.types.ts:18`
- `CodeEditor` at `frontend/src/components/editor/CodeEditor.tsx:58` `onReset` → deletes Redis draft, `CodeEditorContainer` at `frontend/src/components/layout/elements/CodeEditorContainer.tsx:27` `onResetCode`, `ProblemWorkspacePage` at `frontend/src/app/problems/[id]/page.tsx:88` wired with `deleteDraft` + `hydrateMessages`
- Resume banner at `frontend/src/app/problems/page.tsx:51` via `GET /api/workspace/last-visited`
- `AuthContext` exported at `frontend/src/providers/AuthProvider.tsx:27` for safe consumption

### Decisions per spec
- TTL = 7d (shorter), last-visited added, unauthenticated = no Redis (degrade), no streaming persistence, Reset deletes draft

### Quality
- `pnpm typecheck` ✔, `pnpm lint` ✔ (fixed missing deps), `pnpm test:run` 661/661 ✔ (fixed `useAuth` provider requirement), `ruff check/format` ✔
- Production-safe: Supabase-only, per-user keys, 7d TTL + `allkeys-lru 512mb` (existing `docker-compose.yml:72`), best-effort never 500s
- `graphify update` rebuilt (6029 nodes)

### Follow-up
`docker compose up -d --build backend frontend` before deploy per `AGENTS.md`.
