### PR TITLE
fix(monaco): restore editor rendering blocked by CSP and dynamic import

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -48,16 +48,19 @@ const nextConfig = {
           // frame-src allows the Motion Canvas animation viewer (separate Vite
           // dev server on :9000 in E2E, or NEXT_PUBLIC_ANIMATION_VIEWER_URL in
           // prod) to load in an in-app iframe (see AnimateLauncher).
+          // script-src/style-src/font-src/connect-src/worker-src include cdn.jsdelivr.net
+          // because @monaco-editor/react loads Monaco (loader.js + vs/*) from that CDN
+          // via @monaco-editor/loader@1.7.0. Without this the editor stays at "Loading…".
           {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-              "style-src 'self' 'unsafe-inline'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net",
+              "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
               "img-src 'self' data: blob: https:",
-              "font-src 'self' data:",
-              "connect-src 'self' https: wss: ws:",
-              "worker-src 'self' blob:",
+              "font-src 'self' data: https://cdn.jsdelivr.net",
+              "connect-src 'self' https: wss: ws: https://cdn.jsdelivr.net",
+              "worker-src 'self' blob: https://cdn.jsdelivr.net",
               `frame-src 'self' ${process.env.NEXT_PUBLIC_ANIMATION_VIEWER_URL || 'http://localhost:9000'}`,
               "object-src 'none'",
               "base-uri 'self'",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
+    "monaco-editor": "0.55.1",
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-icons": "^1.3.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       lucide-react:
         specifier: ^0.363.0
         version: 0.363.0(react@18.3.1)
+      monaco-editor:
+        specifier: 0.55.1
+        version: 0.55.1
       next:
         specifier: 14.2.35
         version: 14.2.35(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/frontend/src/components/editor/CodeEditor.tsx
+++ b/frontend/src/components/editor/CodeEditor.tsx
@@ -7,14 +7,17 @@ import { CheckCircle, ChevronDown, Play, RotateCcw } from "lucide-react";
 import { useRef } from "react";
 import { LANGUAGE_OPTIONS } from "./constants";
 
-const Editor = dynamic(() => import("@monaco-editor/react"), {
-  ssr: false,
-  loading: () => (
-    <div className="h-full w-full flex items-center justify-center text-xs text-muted-foreground/40">
-      Loading editor…
-    </div>
-  ),
-});
+const Editor = dynamic(
+  () => import("@monaco-editor/react").then((mod) => mod.default),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-full w-full flex items-center justify-center text-xs text-muted-foreground/40">
+        Loading editor…
+      </div>
+    ),
+  },
+);
 
 interface CodeEditorProps {
   language: Language;


### PR DESCRIPTION
### Problem
Monaco editor stayed at **Loading editor…** / blank code pane on `/problems/[id]`.

Playwright logs showed:
```
Loading the script 'https://cdn.jsdelivr.net/npm/monaco-editor@0.55.1/min/vs/loader.js' violates CSP "script-src 'self' ..."
Monaco initialization: error: Event
```
Screenshot (`/tmp/pw-screenshot.png`) showed center **Loading...** with zero `.monaco-editor` nodes.

Root causes:
- `frontend/next.config.js:54-60` CSP was `script-src 'self' 'unsafe-inline' 'unsafe-eval'` without `https://cdn.jsdelivr.net`. `@monaco-editor/loader@1.7.0` default `config.paths.vs = https://cdn.jsdelivr.net/npm/monaco-editor@0.55.1/min/vs` is fetched via injected `<script>` → blocked.
- `frontend/src/components/editor/CodeEditor.tsx:10` used `dynamic(() => import('@monaco-editor/react'))` which returns module namespace `, not component. Next dynamic should resolve `mod.default`.
- `monaco-editor` was only a transitive peer (via `@monaco-editor/react`) – pin as direct dep for version consistency with CDN URL.

### Fix
- **next.config.js:54-63**: add `https://cdn.jsdelivr.net` to `script-src`, `style-src`, `font-src`, `connect-src`, `worker-src` (covers `loader.js`, `editor.main.css`, workers).
- **CodeEditor.tsx:10**: `dynamic(() => import('@monaco-editor/react').then(m => m.default))`
- **package.json:22 / pnpm-lock.yaml:38**: add `monaco-editor@0.55.1` direct

### Verify
- `curl -s -D http://localhost:3000/problems | grep Content-Security-Policy` now includes CDN
- Playwright re-run: `monaco-editor` count 1, `view-line` 3, `window.monaco.getModels()[0].getValue()` = starter code, 0 CSP logs, screenshot `/tmp/final-check.png` shows Python code with line numbers 1–2.
- `pnpm lint` ✔, `pnpm typecheck` ✔, `pnpm test:run` 78 files 651 tests ✔
- Docker: run `docker-compose up -d --build frontend` to pick new CSP header (dev server auto-reloads).

### Follow-up
Consider bundling Monaco locally via `loader.config({ monaco })` to remove CDN dependency and latency.
