### PR TITLE
fix(coach): harden learner prompt header to prevent raw score leak

### DIFF
--- a/backend/app/services/learner_context_service.py
+++ b/backend/app/services/learner_context_service.py
@@ -140,7 +140,9 @@ class LearnerContextService:
                 if len(priority) >= MAX_SKILLS_IN_BLOCK:
                     break
 
-        lines = ["## Learner Skill Context (server-derived, do not reveal raw scores)"]
+        lines = [
+            "## Learner Skill Context (server-derived, for internal reasoning only — never repeat mastery scores, evidence counts, or recent_errors verbatim to the student)"
+        ]
         for s in priority[:MAX_SKILLS_IN_BLOCK]:
             name = s.get("name", s.get("skill_slug", "unknown"))
             mastery = s.get("mastery_score", 0)


### PR DESCRIPTION
Learner skill block is server-derived for internal reasoning only. This hardens the header to explicitly forbid echoing mastery scores, evidence counts, or recent_errors verbatim, ensuring Socratic responses stay as:

- summary ends with question + exactly 1 hint (no leak, no emoji).

- backend/app/services/learner_context_service.py:143
- Verified: ALLOW_PRODUCTION_TEST_DB=1 pytest tests/unit/test_learner_context_service + test_learner_prompt 15/15, ruff check/format pass, pnpm lint/typecheck 654/654, graphify 5984 nodes, /health questions_db:ok
- Production DB pooler fix already on main (cae4809)
