### PR TITLE
feat(coach): split questions/learn AI surfaces (graph-aware vs graph-free)

### DIFF
--- a/backend/app/adapters/coaching_prompts.py
+++ b/backend/app/adapters/coaching_prompts.py
@@ -85,6 +85,30 @@ Animation rules:
 8. Only populate the specific field(s) needed for your single step — use null or [] for everything else to avoid overwhelming the student
 9. Always end summary with a question that drives the user to think"""
 
+_LEARN_PERSONA = """You are CodeCoach Learn Companion, a patient curriculum guide.
+
+## Your Persona
+- Warm, encouraging study companion — you teach ideas, never interview
+- Expert at explaining one concept clearly with analogies and tiny examples
+- Guide the student through the current lesson step by step
+- Provide EXACTLY ONE idea at a time — never dump the whole lesson at once
+- Always link back to the lesson objective and end with a check-for-understanding question
+
+## Hard Rules
+- DO NOT write the full exercise solution or give away the complete answer
+- DO NOT introduce concepts outside the current lesson unless the student explicitly asks
+- DO NOT reveal anything beyond the lesson scope — stay within the lesson context
+- Always end your summary with a check-for-understanding question about the lesson"""
+
+_LEARN_GUIDELINES = """
+## General Guidelines
+- Be concise but thorough — teach ONE idea at a time from the lesson
+- Always end with a check-for-understanding question tied to the lesson objective
+- Never give complete exercise solutions — guide discovery through questions
+- Use **bold** sparingly for key terms only
+- Use `backticks` for code, variables, and technical terms
+- If the user expresses frustration, encourage them and offer a smaller next step within the lesson"""
+
 _GENERAL_GUIDELINES = """
 ## General Guidelines
 - Be concise but thorough — provide ONE piece of information at a time
@@ -272,6 +296,7 @@ class PromptBuilder:
         question: Optional[Dict[str, Any]] = None,
         learner_context: Optional[str] = None,
         submission_context: Optional[str] = None,
+        surface: str = "questions",
     ) -> Tuple[str, str]:
         """Return (system_prompt, user_prompt) for the given coaching request."""
         system = self._build_system(
@@ -281,6 +306,7 @@ class PromptBuilder:
             lesson_context,
             learner_context,
             submission_context,
+            surface,
         )
         user = self._build_user(
             problem,
@@ -304,8 +330,13 @@ class PromptBuilder:
         lesson_context: Optional[str],
         learner_context: Optional[str] = None,
         submission_context: Optional[str] = None,
+        surface: str = "questions",
     ) -> str:
-        persona = _STRUCTURED_PERSONA if structured else _PERSONA
+        is_learn = surface == "learn"
+        if is_learn:
+            persona = _LEARN_PERSONA
+        else:
+            persona = _STRUCTURED_PERSONA if structured else _PERSONA
         parts = [persona]
 
         section = self._mode_section(mode, structured)
@@ -323,12 +354,16 @@ class PromptBuilder:
         if ctx:
             parts.append(ctx)
 
-        if learner_context:
-            parts.append(learner_context)
-        if submission_context:
-            parts.append(submission_context)
+        # Learn surface is graph-free: skill/submission blocks are never
+        # injected, even if a caller passes them (defense in depth — the
+        # coach route also skips the LearnerContextService fetch entirely).
+        if not is_learn:
+            if learner_context:
+                parts.append(learner_context)
+            if submission_context:
+                parts.append(submission_context)
 
-        parts.append(_GENERAL_GUIDELINES)
+        parts.append(_LEARN_GUIDELINES if is_learn else _GENERAL_GUIDELINES)
 
         if structured and mode == "animate":
             parts.append(_ANIMATE_CONTRACT)
@@ -408,6 +443,8 @@ MODE_SECTIONS = _MODE_SECTIONS
 PERSONA = _PERSONA
 STRUCTURED_PERSONA = _STRUCTURED_PERSONA
 GENERAL_GUIDELINES = _GENERAL_GUIDELINES
+LEARN_PERSONA = _LEARN_PERSONA
+LEARN_GUIDELINES = _LEARN_GUIDELINES
 
 
 def build_system_prompt(

--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -133,20 +133,24 @@ async def get_coaching(
             else []
         )
 
-        # Learner context (cached skill graph + recent submissions) — always-on for authed users
+        # Learner context (cached skill graph + recent submissions) — only for
+        # the questions surface. The learn surface is graph-free by design:
+        # skipping the fetch saves Redis + DB roundtrips and prompt tokens.
+        surface = coaching_request.surface
         learner_ctx: dict = {"skill_block": "", "submission_block": ""}
-        try:
-            learner_ctx = await learner_context.get_context(user.id)
-            if learner_ctx.get("skill_block"):
-                logger.debug(
-                    "Coach learner skills: %s", learner_ctx["skill_block"][:200]
-                )
-            if learner_ctx.get("submission_block"):
-                logger.debug(
-                    "Coach submissions: %s", learner_ctx["submission_block"][:200]
-                )
-        except Exception as e:  # pragma: no cover - degrade open
-            logger.debug("Learner context fetch failed: %s", e)
+        if surface == "questions":
+            try:
+                learner_ctx = await learner_context.get_context(user.id)
+                if learner_ctx.get("skill_block"):
+                    logger.debug(
+                        "Coach learner skills: %s", learner_ctx["skill_block"][:200]
+                    )
+                if learner_ctx.get("submission_block"):
+                    logger.debug(
+                        "Coach submissions: %s", learner_ctx["submission_block"][:200]
+                    )
+            except Exception as e:  # pragma: no cover - degrade open
+                logger.debug("Learner context fetch failed: %s", e)
 
         structured_data = await provider.get_structured(
             problem=coaching_request.problem,
@@ -160,6 +164,7 @@ async def get_coaching(
             initial_code=coaching_request.initial_code,
             learner_context=learner_ctx.get("skill_block") or None,
             submission_context=learner_ctx.get("submission_block") or None,
+            surface=surface,
         )
 
         raw_response = _format_structured_as_text(structured_data)
@@ -171,6 +176,7 @@ async def get_coaching(
 
         response.headers.update(getattr(request.state, "usage_headers", {}))
         response.headers.update(getattr(request.state, "daily_limit_headers", {}))
+        response.headers["X-Surface"] = surface
 
         return CoachingResponse(
             response=raw_response,
@@ -382,6 +388,7 @@ async def get_coaching_stream(
                 lesson_context=coaching_request.lesson_context,
                 chat_history=chat_history_list,
                 initial_code=coaching_request.initial_code,
+                surface=coaching_request.surface,
             ):
                 chunk_count += 1
                 # Format as SSE

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -25,6 +25,9 @@ class CoachingMode(str, Enum):
     ANIMATE = "animate"
 
 
+CoachingSurface = Literal["questions", "learn"]
+
+
 class Language(str, Enum):
     PYTHON = "python"
     JAVASCRIPT = "javascript"
@@ -71,6 +74,19 @@ class CoachingRequest(BaseModel):
         max_length=50000,
         description="Starter code the user began with, used to detect edits for animation",
     )
+    surface: CoachingSurface = Field(
+        default="questions",
+        description=(
+            "Client surface: 'questions' is the graph-aware interview tutor, "
+            "'learn' is the graph-free curriculum companion."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def require_lesson_context_for_learn(self):
+        if self.surface == "learn" and not self.lesson_context:
+            raise ValueError("lesson_context is required when surface is 'learn'")
+        return self
 
 
 class SceneShape(BaseModel):

--- a/backend/app/ports/coaching_provider.py
+++ b/backend/app/ports/coaching_provider.py
@@ -24,6 +24,7 @@ class CoachingProvider(ABC):
         initial_code: Optional[str] = None,
         learner_context: Optional[str] = None,
         submission_context: Optional[str] = None,
+        surface: str = "questions",
     ) -> Dict[str, Any]:
         """Return a structured coaching response as a dict."""
         ...
@@ -40,6 +41,7 @@ class CoachingProvider(ABC):
         lesson_context: Optional[str] = None,
         chat_history: Optional[list] = None,
         initial_code: Optional[str] = None,
+        surface: str = "questions",
     ) -> AsyncIterator[str]:
         """Yield streaming text chunks from the coaching backend."""
         ...  # pragma: no cover

--- a/backend/app/services/groq_service.py
+++ b/backend/app/services/groq_service.py
@@ -80,6 +80,7 @@ class GroqService(CoachingProvider):
         question: Optional[Dict[str, Any]] = None,
         learner_context: Optional[str] = None,
         submission_context: Optional[str] = None,
+        surface: str = "questions",
     ) -> Dict[str, Any]:
         from app.models.schemas import StructuredCoachingResponse
 
@@ -95,7 +96,8 @@ class GroqService(CoachingProvider):
                 lesson_context or "",
                 initial_code or "",
                 _jsonable(question),
-                "v7",
+                surface,
+                "v8",
             )
             cache_key = RedisCache.key("groq", "coaching", content_hash)
             cached = await self.cache.get(cache_key)
@@ -112,10 +114,20 @@ class GroqService(CoachingProvider):
 
         # Animate embeds full user/solution code arrays plus steps, so it always
         # uses a capable dedicated model rather than the difficulty-tied tier.
+        # The Learn companion is a curriculum guide, not an interview tutor, so
+        # it always uses the cheap tier regardless of question difficulty.
         if mode == "animate":
             model = self.models["animate"]
+        elif surface == "learn":
+            model = self.models["easy"]
         else:
             model = self.models.get(difficulty, self.models["medium"])
+
+        # Defense in depth: the Learn surface is graph-free even if a caller
+        # passes graph blocks directly.
+        if surface == "learn":
+            learner_context = None
+            submission_context = None
 
         system_prompt, user_prompt = self.prompts.build(
             mode=mode,
@@ -129,6 +141,7 @@ class GroqService(CoachingProvider):
             question=question,
             learner_context=learner_context,
             submission_context=submission_context,
+            surface=surface,
         )
 
         messages = [
@@ -212,6 +225,7 @@ class GroqService(CoachingProvider):
         chat_history: Optional[list] = None,
         endpoint: str = "coach_stream",
         initial_code: Optional[str] = None,
+        surface: str = "questions",
     ) -> AsyncIterator[str]:
         model = self.models["stream"]
 
@@ -224,6 +238,7 @@ class GroqService(CoachingProvider):
             structured=structured,
             lesson_context=lesson_context,
             initial_code=initial_code,
+            surface=surface,
         )
 
         messages = [
@@ -336,6 +351,7 @@ class GroqService(CoachingProvider):
         initial_code: Optional[str] = None,
         learner_context: Optional[str] = None,
         submission_context: Optional[str] = None,
+        surface: str = "questions",
     ) -> Dict[str, Any]:
         return await self.get_structured_coaching_response(
             problem=problem,
@@ -349,6 +365,7 @@ class GroqService(CoachingProvider):
             initial_code=initial_code,
             learner_context=learner_context,
             submission_context=submission_context,
+            surface=surface,
         )
 
     async def stream(
@@ -362,6 +379,7 @@ class GroqService(CoachingProvider):
         lesson_context: Optional[str] = None,
         chat_history: Optional[list] = None,
         initial_code: Optional[str] = None,
+        surface: str = "questions",
     ) -> AsyncIterator[str]:
         async for chunk in self.get_coaching_response(
             problem=problem,
@@ -373,6 +391,7 @@ class GroqService(CoachingProvider):
             lesson_context=lesson_context,
             chat_history=chat_history,
             initial_code=initial_code,
+            surface=surface,
         ):
             yield chunk
 

--- a/backend/app/services/learner_context_service.py
+++ b/backend/app/services/learner_context_service.py
@@ -140,7 +140,9 @@ class LearnerContextService:
                 if len(priority) >= MAX_SKILLS_IN_BLOCK:
                     break
 
-        lines = ["## Learner Skill Context (server-derived, do not reveal raw scores)"]
+        lines = [
+            "## Learner Skill Context (server-derived, for internal reasoning only — never repeat mastery scores, evidence counts, or recent_errors verbatim to the student)"
+        ]
         for s in priority[:MAX_SKILLS_IN_BLOCK]:
             name = s.get("name", s.get("skill_slug", "unknown"))
             mastery = s.get("mastery_score", 0)

--- a/backend/tests/fixtures/mock_coaching_provider.py
+++ b/backend/tests/fixtures/mock_coaching_provider.py
@@ -109,6 +109,7 @@ class MockCoachingProvider(CoachingProvider):
         initial_code: Optional[str] = None,
         learner_context: Optional[str] = None,
         submission_context: Optional[str] = None,
+        surface: str = "questions",
     ) -> Dict[str, Any]:
         data: Dict[str, Any] = {
             "summary": self.RESPONSES.get(
@@ -149,5 +150,6 @@ class MockCoachingProvider(CoachingProvider):
         lesson_context: Optional[str] = None,
         chat_history: Optional[list] = None,
         initial_code: Optional[str] = None,
+        surface: str = "questions",
     ) -> AsyncIterator[str]:
         yield self.RESPONSES.get(mode, "Here's some guidance for your problem.")

--- a/backend/tests/integration/test_learner_context_flow.py
+++ b/backend/tests/integration/test_learner_context_flow.py
@@ -31,10 +31,12 @@ class CapturingProvider:
         initial_code=None,
         learner_context=None,
         submission_context=None,
+        surface="questions",
         **kwargs,
     ):
         captured["learner_context"] = learner_context
         captured["submission_context"] = submission_context
+        captured["surface"] = surface
         return {
             "summary": "captured",
             "hints": [],
@@ -135,6 +137,62 @@ class TestLearnerContextFlow:
             assert captured.get("submission_context") == "sub-ctx"
         finally:
             app.dependency_overrides.pop(get_learner_context_service_dependency, None)
+
+    @pytest.mark.asyncio
+    async def test_coach_learn_surface_skips_learner_context(self, async_client):
+        """Learn surface must not fetch the skill graph and must forward surface."""
+        from app.services.learner_context_service import LearnerContextService
+
+        mock_svc = AsyncMock(spec=LearnerContextService)
+        mock_svc.get_context = AsyncMock(
+            return_value={"skill_block": "skill-ctx", "submission_block": "sub-ctx"}
+        )
+        mock_svc.invalidate = AsyncMock()
+
+        app.dependency_overrides[get_learner_context_service_dependency] = lambda: (
+            mock_svc
+        )
+        try:
+            with mock_auth():
+                resp = await async_client.post(
+                    "/api/coach/",
+                    json={
+                        "problem": "Loops",
+                        "code": "c",
+                        "language": "python",
+                        "message": "what is a loop?",
+                        "mode": "explain",
+                        "difficulty": "easy",
+                        "lesson_context": "Loops 101",
+                        "surface": "learn",
+                    },
+                )
+            assert resp.status_code == 200
+            mock_svc.get_context.assert_not_called()
+            assert captured.get("surface") == "learn"
+            assert captured.get("learner_context") in (None, "")
+            assert captured.get("submission_context") in (None, "")
+            assert resp.headers.get("X-Surface") == "learn"
+        finally:
+            app.dependency_overrides.pop(get_learner_context_service_dependency, None)
+
+    @pytest.mark.asyncio
+    async def test_coach_learn_requires_lesson_context(self, async_client):
+        """Learn surface without lesson_context must 422, never reaching the provider."""
+        with mock_auth():
+            resp = await async_client.post(
+                "/api/coach/",
+                json={
+                    "problem": "Loops",
+                    "code": "c",
+                    "language": "python",
+                    "message": "what is a loop?",
+                    "mode": "explain",
+                    "difficulty": "easy",
+                    "surface": "learn",
+                },
+            )
+        assert resp.status_code == 422
 
     @pytest.mark.asyncio
     async def test_coach_degraded_when_learner_context_fails(self, async_client):

--- a/backend/tests/unit/test_coaching_surfaces.py
+++ b/backend/tests/unit/test_coaching_surfaces.py
@@ -1,0 +1,230 @@
+"""Unit: two AI surfaces — questions (graph-aware) vs learn (graph-free).
+
+Red phase for the dual-mode coaching split:
+- `surface` discriminator on CoachingRequest (default "questions", back-compat)
+- Learn persona is a distinct curriculum companion, never the interview tutor
+- Learn prompts never carry skill-graph blocks (defense in depth)
+- Learn uses the cheap model tier; cache keys are isolated per surface
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.adapters.coaching_prompts import PromptBuilder
+
+
+def _coaching_request(**overrides):
+    from app.models.schemas import CoachingRequest
+
+    base = {
+        "problem": "Two Sum",
+        "code": "def f(): pass",
+        "language": "python",
+        "message": "help",
+        "mode": "hint",
+    }
+    base.update(overrides)
+    return CoachingRequest(**base)
+
+
+class TestCoachingSurfaceSchema:
+    def test_surface_defaults_to_questions(self):
+        req = _coaching_request()
+        assert req.surface == "questions"
+
+    def test_surface_accepts_learn(self):
+        req = _coaching_request(surface="learn", lesson_context="Loops 101")
+        assert req.surface == "learn"
+
+    def test_surface_rejects_unknown(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            _coaching_request(surface="interview")
+
+    def test_learn_requires_lesson_context(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            _coaching_request(surface="learn")
+
+    def test_questions_does_not_require_lesson_context(self):
+        req = _coaching_request(surface="questions")
+        assert req.lesson_context is None
+
+
+class TestLearnPersona:
+    def test_learn_uses_companion_persona_not_interview_tutor(self):
+        system, _ = PromptBuilder().build(
+            mode="explain",
+            language="python",
+            problem="Loops",
+            code="for i in x: pass",
+            message="what is a loop?",
+            structured=True,
+            lesson_context="Loops 101",
+            surface="learn",
+        )
+        assert "Learn Companion" in system
+        assert "Socratic coding interview tutor" not in system
+
+    def test_learn_scopes_to_lesson_and_checks_understanding(self):
+        system, _ = PromptBuilder().build(
+            mode="explain",
+            language="python",
+            problem="Loops",
+            code="for i in x: pass",
+            message="what is a loop?",
+            structured=True,
+            lesson_context="Loops 101",
+            surface="learn",
+        )
+        assert "Loops 101" in system
+        assert "check" in system.lower()
+
+    def test_learn_never_carries_skill_graph_blocks(self):
+        system, _ = PromptBuilder().build(
+            mode="explain",
+            language="python",
+            problem="Loops",
+            code="c",
+            message="m",
+            structured=True,
+            lesson_context="Loops 101",
+            surface="learn",
+            learner_context="## Learner Skill Context\n- arrays: mastery 0.10",
+            submission_context="## Recent Attempts\n- q1 failed",
+        )
+        assert "Learner Skill Context" not in system
+        assert "Recent Attempts" not in system
+        assert "mastery 0.10" not in system
+
+    def test_questions_keeps_socratic_persona_and_graph_blocks(self):
+        system, _ = PromptBuilder().build(
+            mode="hint",
+            language="python",
+            problem="Two Sum",
+            code="c",
+            message="m",
+            structured=True,
+            surface="questions",
+            learner_context="## Learner Skill Context\n- arrays: mastery 0.10",
+            submission_context="## Recent Attempts\n- q1 failed",
+        )
+        assert "Socratic" in system
+        assert "Learner Skill Context" in system
+        assert "Recent Attempts" in system
+
+    def test_default_surface_is_questions_persona(self):
+        system, _ = PromptBuilder().build(
+            mode="hint",
+            language="python",
+            problem="P",
+            code="c",
+            message="m",
+            structured=True,
+        )
+        assert "Socratic" in system
+        assert "Learn Companion" not in system
+
+
+STRUCTURED_CONTENT = (
+    '{"summary": "Great work?", "hints": [], "code_review": null, '
+    '"complexity_analysis": null, "suggestions": [], "edge_cases": [], '
+    '"explanation": null, "debug_help": null}'
+)
+
+
+def _mock_groq_post(mock_async_client, body=None):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {}
+    mock_response.json.return_value = body or {
+        "choices": [{"message": {"content": STRUCTURED_CONTENT}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+    }
+    mock_async_client.post.return_value = mock_response
+
+
+class TestGroqSurfaceBehavior:
+    @pytest.mark.asyncio
+    async def test_learn_uses_cheap_model_tier(self):
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_cls.return_value = mock_instance
+            _mock_groq_post(mock_instance)
+
+            from app.services.groq_service import GroqService
+
+            service = GroqService(api_key="gsk_test")
+            await service.get_structured_coaching_response(
+                problem="Loops",
+                code="c",
+                language="python",
+                message="m",
+                mode="explain",
+                difficulty="hard",
+                lesson_context="Loops 101",
+                surface="learn",
+            )
+            call = mock_instance.post.call_args
+            assert call.kwargs["json"]["model"] == "openai/gpt-oss-20b"
+
+    @pytest.mark.asyncio
+    async def test_questions_keeps_difficulty_tier(self):
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_cls.return_value = mock_instance
+            _mock_groq_post(mock_instance)
+
+            from app.services.groq_service import GroqService
+
+            service = GroqService(api_key="gsk_test")
+            await service.get_structured_coaching_response(
+                problem="Two Sum",
+                code="c",
+                language="python",
+                message="m",
+                mode="hint",
+                difficulty="hard",
+                surface="questions",
+            )
+            call = mock_instance.post.call_args
+            assert call.kwargs["json"]["model"] == "openai/gpt-oss-120b"
+
+    @pytest.mark.asyncio
+    async def test_cache_keys_isolated_per_surface(self):
+        seen_keys: list[str] = []
+
+        class RecordingCache:
+            async def get(self, key):
+                seen_keys.append(key)
+                return None
+
+            async def set(self, key, value, ttl=0):
+                pass
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__.return_value = mock_instance
+            mock_cls.return_value = mock_instance
+            _mock_groq_post(mock_instance)
+
+            from app.services.groq_service import GroqService
+
+            for surface in ("questions", "learn"):
+                service = GroqService(api_key="gsk_test", cache=RecordingCache())
+                await service.get_structured_coaching_response(
+                    problem="P",
+                    code="c",
+                    language="python",
+                    message="m",
+                    mode="hint",
+                    difficulty="medium",
+                    lesson_context="Loops 101",
+                    surface=surface,
+                )
+        assert len(seen_keys) == 2
+        assert seen_keys[0] != seen_keys[1]

--- a/backend/tests/unit/test_groq_service.py
+++ b/backend/tests/unit/test_groq_service.py
@@ -375,7 +375,7 @@ class TestGroqServiceStructured:
         assert result["animation"]["steps"][0]["shapes"][0]["id"] == "cell_0"
 
     @pytest.mark.asyncio
-    async def test_animate_cache_key_includes_content_version_v7(
+    async def test_animate_cache_key_includes_content_version_v8(
         self, mock_async_client
     ):
         body = {
@@ -400,7 +400,16 @@ class TestGroqServiceStructured:
         )
 
         expected_hash = _content_hash(
-            "P", "c", "animate", "animate", "medium", "", "", _jsonable(None), "v7"
+            "P",
+            "c",
+            "animate",
+            "animate",
+            "medium",
+            "",
+            "",
+            _jsonable(None),
+            "questions",
+            "v8",
         )
         assert cache.set_calls[0][0] == RedisCache.key(
             "groq", "coaching", expected_hash

--- a/frontend/src/app/learn/lesson/[lessonId]/page.tsx
+++ b/frontend/src/app/learn/lesson/[lessonId]/page.tsx
@@ -110,6 +110,7 @@ export default function LessonPage() {
         lessonContext,
         linkedQuestion?.difficulty,
         resolvedStarterCode,
+        'learn',
       );
     },
     [lesson, currentCode, language, sendMessage, linkedQuestion?.difficulty, resolvedStarterCode],

--- a/frontend/src/app/problems/[id]/page.tsx
+++ b/frontend/src/app/problems/[id]/page.tsx
@@ -103,6 +103,7 @@ export default function ProblemWorkspacePage() {
       undefined,
       fullQuestion.difficulty,
       starterCode,
+      'questions',
     );
     if (mode !== 'wide') setDrawerOpen(true);
   }, [fullQuestion, lastSubmitResult, currentCode, language, starterCode, sendMessage, mode]);
@@ -126,6 +127,7 @@ export default function ProblemWorkspacePage() {
       undefined,
       fullQuestion.difficulty,
       starterCode,
+      'questions',
     );
     if (mode !== 'wide') setDrawerOpen(true);
   }, [fullQuestion, lastSubmitResult, currentCode, language, starterCode, sendMessage, mode]);
@@ -153,6 +155,7 @@ export default function ProblemWorkspacePage() {
         undefined,
         undefined,
         starterCode,
+        'questions',
       );
     },
     [fullQuestion, currentCode, language, sendMessage, rescueActivity, starterCode],

--- a/frontend/src/components/MainWorkspace.test.tsx
+++ b/frontend/src/components/MainWorkspace.test.tsx
@@ -365,6 +365,7 @@ describe('MainWorkspace', () => {
       undefined,
       'easy',
       '',
+      'questions',
     );
   });
 
@@ -420,6 +421,7 @@ describe('MainWorkspace', () => {
       undefined,
       'easy',
       'def two_sum(nums, target):\n    pass',
+      'questions',
     );
   });
 

--- a/frontend/src/components/MainWorkspace.tsx
+++ b/frontend/src/components/MainWorkspace.tsx
@@ -114,6 +114,7 @@ export function MainWorkspace() {
         undefined,
         (displayQuestion as any)?.difficulty || undefined,
         initialCode,
+        'questions',
       );
       // Silent Practice Next refresh is handled via learner invalidation event dispathed by backend cache; also trigger frontend refresh
       if (typeof window !== "undefined") {

--- a/frontend/src/features/coaching/coaching.hook.ts
+++ b/frontend/src/features/coaching/coaching.hook.ts
@@ -3,7 +3,7 @@
 import { useState, useCallback, useRef } from "react";
 import { ChatMessage } from "@/types";
 import { coachingService } from "./coaching.service";
-import { CoachingFeature, CoachingMode } from "./coaching.types";
+import { CoachingFeature, CoachingMode, CoachingSurface } from "./coaching.types";
 import { showToast } from "@/components/ui/Toast";
 import { useUsage } from "@/features/usage/usage.context";
 
@@ -38,6 +38,7 @@ export function useCoaching(): CoachingFeature {
       lessonContext?: string,
       difficulty?: string,
       initialCode?: string,
+      surface: CoachingSurface = "questions",
     ) => {
       const userMessage: ChatMessage = {
         id: Date.now().toString(),
@@ -69,6 +70,7 @@ export function useCoaching(): CoachingFeature {
             lessonContext,
             chatHistory,
             initialCode,
+            surface,
           );
 
           const assistantMessage: ChatMessage = {

--- a/frontend/src/features/coaching/coaching.service.test.ts
+++ b/frontend/src/features/coaching/coaching.service.test.ts
@@ -69,6 +69,7 @@ describe('CoachingService', () => {
         mode: 'hint',
         language: 'python',
         difficulty: 'medium',
+        surface: 'questions',
       });
       expect(result.response).toBe('Try using a hash map');
       expect(result.structured).toBeNull();
@@ -216,6 +217,54 @@ describe('CoachingService', () => {
           defaultArgs.mode,
         ),
       ).rejects.toThrow('Network error');
+    });
+
+    it('defaults surface to questions', async () => {
+      vi.mocked(http.post).mockResolvedValue({
+        response: 'Ok',
+        structured: null,
+      });
+
+      await service.getCoachResponse(
+        defaultArgs.problem,
+        defaultArgs.language,
+        defaultArgs.code,
+        defaultArgs.message,
+        defaultArgs.mode,
+      );
+
+      expect(http.post).toHaveBeenCalledWith(
+        '/api/coach/',
+        expect.objectContaining({ surface: 'questions' }),
+      );
+    });
+
+    it('forwards learn surface for curriculum chat', async () => {
+      vi.mocked(http.post).mockResolvedValue({
+        response: 'Ok',
+        structured: null,
+      });
+
+      await service.getCoachResponse(
+        defaultArgs.problem,
+        defaultArgs.language,
+        defaultArgs.code,
+        defaultArgs.message,
+        defaultArgs.mode,
+        defaultArgs.difficulty,
+        'Loops 101',
+        undefined,
+        undefined,
+        'learn',
+      );
+
+      expect(http.post).toHaveBeenCalledWith(
+        '/api/coach/',
+        expect.objectContaining({
+          surface: 'learn',
+          lesson_context: 'Loops 101',
+        }),
+      );
     });
 
     it('throws HttpError when server returns error', async () => {

--- a/frontend/src/features/coaching/coaching.service.ts
+++ b/frontend/src/features/coaching/coaching.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from "@/lib/http-client";
 import { FetchClient } from "@/lib/fetch-client";
 import { StructuredCoachingResponse } from "@/types";
+import { CoachingSurface } from "./coaching.types";
 
 export interface CoachingRequest {
   problem: string;
@@ -12,6 +13,7 @@ export interface CoachingRequest {
   lesson_context?: string;
   chat_history?: { role: string; content: string }[];
   initial_code?: string;
+  surface: CoachingSurface;
 }
 
 export interface CoachingResponse {
@@ -32,6 +34,7 @@ export class CoachingService {
     lessonContext?: string,
     chatHistory?: { role: string; content: string }[],
     initialCode?: string,
+    surface: CoachingSurface = "questions",
   ): Promise<CoachingResponse> {
     const body: CoachingRequest = {
       problem,
@@ -40,6 +43,7 @@ export class CoachingService {
       mode: mode.toLowerCase(),
       language: language.toLowerCase(),
       difficulty,
+      surface,
     };
     if (lessonContext) {
       body.lesson_context = lessonContext;

--- a/frontend/src/features/coaching/coaching.types.ts
+++ b/frontend/src/features/coaching/coaching.types.ts
@@ -8,6 +8,8 @@ export type CoachingMode =
   | "freeform"
   | "animate";
 
+export type CoachingSurface = "questions" | "learn";
+
 export interface CoachingRequest {
   problem: string;
   language: string;
@@ -40,6 +42,7 @@ export interface CoachingActions {
     lessonContext?: string,
     difficulty?: string,
     initialCode?: string,
+    surface?: CoachingSurface,
   ) => Promise<void>;
   clearMessages: () => void;
   clearError: () => void;


### PR DESCRIPTION
## Description

Splits the single AI coach into two isolated surfaces following AI engineering principles (retrieve-only-when-it-helps, budgeted context, persona isolation):

- **Questions** (`/problems`): graph-aware Socratic interview tutor — skill graph + recent submissions injected as before.
- **Learn** (`/learn`): graph-free curriculum companion with a new persona — no skill-graph fetch, no graph tokens, lesson-scoped, cheap model tier.

Includes the small prompt-leak hardening fix this branch was already carrying (`7170fcf`).

## Changes

- `CoachingRequest.surface: questions | learn` (default `questions`, back-compat); `learn` requires `lesson_context` (422 otherwise)
- New `Learn Companion` persona + guidelines in `PromptBuilder`; learn prompts never carry skill/submission blocks (defense in depth at route + provider + prompt layers)
- `POST /api/coach/` skips `LearnerContextService` entirely for `learn`; forwards `surface`; new `X-Surface` response header
- Learn uses cheap tier (`gpt-oss-20b`); Groq cache version `v7→v8` with surface in hash (no cross-persona poisoning)
- Frontend: `CoachingSurface` plumbed through service + hook; problems → `questions`, lesson pages → `learn`
- Harden learner skill-block header against raw score leaks (`7170fcf`)

## Related Issue

N/A (follow-up to #127 skill-context-cache work)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- [ ] Backend tests pass (`cd backend && python -m pytest`) — full suite needs local Postgres/isolated schema (unavailable in this env); ran instead: 13 new surface tests + 71 prompt/learner + 39 groq checks green via direct runners, `ruff check` + `ruff format --check` clean. CI must run the full suite incl. 2 new learn-gate integration tests.
- [x] Frontend tests pass (`cd frontend && pnpm test:run`) — 672/672 green (incl. 2 new surface tests)
- [x] TypeScript check passes (`cd frontend && pnpm typecheck`)
- [x] Lint passes (`cd frontend && pnpm lint`, backend `ruff`)

## Checklist

- [x] My code follows the project's code style
- [x] I have commented my code where necessary (only for complex logic)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (backend full suite deferred to CI — no local Postgres)
- [x] I have not added any secrets or API keys to the code