### PR TITLE
feat(coach): background warm of coach learner context on question enter

### DIFF
--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -1,4 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Request,
+    Response,
+)
 from fastapi.responses import StreamingResponse
 from pydantic import ValidationError
 from typing import AsyncIterator, Optional
@@ -8,6 +15,8 @@ import logging
 import os
 import time
 
+from app.core.cache_keys import COACH_CONTEXT_TTL, coach_context_key
+from app.core.config import get_settings
 from app.models.schemas import (
     CoachingRequest,
     CoachingResponse,
@@ -15,6 +24,8 @@ from app.models.schemas import (
     Language,
     AnimateRequest,
     AnimateResponse,
+    WarmRequest,
+    WarmResponse,
 )
 from app.ports.coaching_provider import CoachingProvider
 from app.ports.code_executor import CodeExecutor
@@ -31,7 +42,7 @@ from app.api.dependencies import (
     get_executor,
 )
 from app.models.auth_schemas import UserResponse
-from app.middleware.rate_limit import limiter, COACH_RATE_LIMIT
+from app.middleware.rate_limit import limiter, COACH_RATE_LIMIT, COACH_WARM_RATE_LIMIT
 from app.services.learner_context_service import LearnerContextService
 
 logger = logging.getLogger(__name__)
@@ -90,6 +101,84 @@ async def enforce_user_rate_limit(
     count = await cache.incr(key, ttl=60)
     if count is not None and count > limit:
         raise HTTPException(status_code=429, detail="User request rate limit exceeded")
+
+
+async def _warm_learner_context(
+    learner_context: LearnerContextService,
+    cache: RedisCache,
+    user_id: str,
+    warming_key: str,
+    question_id: Optional[str] = None,
+) -> None:
+    """Best-effort background warm: populate coach ctx, release single-flight."""
+    start = time.monotonic()
+    try:
+        await asyncio.wait_for(learner_context.get_context(user_id), timeout=4)
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        logger.debug(
+            "coach warm done user=%s question=%s ms=%d",
+            user_id,
+            question_id or "-",
+            elapsed_ms,
+        )
+    except Exception as e:  # noqa: BLE001 - warm must never raise
+        logger.debug("coach warm failed user=%s: %s", user_id, e)
+    finally:
+        try:
+            await cache.delete(warming_key)
+        except Exception:  # noqa: BLE001 - best-effort release
+            pass
+
+
+@router.post("/warm", response_model=WarmResponse, status_code=202)
+@limiter.limit(COACH_WARM_RATE_LIMIT)
+async def warm_coaching_context(
+    request: Request,
+    background: BackgroundTasks,
+    user: UserResponse = Depends(get_current_user),
+    cache: Optional[RedisCache] = Depends(get_redis_cache),
+    learner_context: LearnerContextService = Depends(
+        get_learner_context_service_dependency
+    ),
+    body: WarmRequest = WarmRequest(),
+):
+    """Warm reusable learner context when a user enters a question.
+
+    Fire-and-forget: returns 202 immediately, populates
+    ``codecoach:coach:ctx:{user}`` (+ skill/submission pieces) in the
+    background. Never returns skill data; Supabase stays source of truth.
+    """
+    _ = request
+    question_id = body.question_id if body else None
+    if not get_settings().COACH_WARM_ENABLED:
+        return WarmResponse(status="disabled", warmed=False, ttl=COACH_CONTEXT_TTL)
+    if cache is None:
+        return WarmResponse(status="disabled", warmed=False, ttl=COACH_CONTEXT_TTL)
+
+    context_key = coach_context_key(user.id)
+    try:
+        if await cache.exists(context_key):
+            return WarmResponse(
+                status="hit",
+                warmed=False,
+                ttl=await cache.ttl(context_key),
+            )
+    except Exception:  # noqa: BLE001 - degrade open
+        logger.debug("coach warm exists check failed for %s", user.id)
+
+    warming_key = RedisCache.key("warming", "coach", user.id)
+    try:
+        acquired = await cache.set_if_absent(warming_key, "1", ttl=5)
+    except Exception:  # noqa: BLE001 - degrade open
+        acquired = False
+    if not acquired:
+        return WarmResponse(status="warming", warmed=False, ttl=COACH_CONTEXT_TTL)
+
+    background.add_task(
+        _warm_learner_context, learner_context, cache, user.id, warming_key, question_id
+    )
+    logger.debug("coach warm queued user=%s question=%s", user.id, question_id or "-")
+    return WarmResponse(status="warming", warmed=True, ttl=COACH_CONTEXT_TTL)
 
 
 @router.post("/", response_model=CoachingResponse)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -37,6 +37,9 @@ class Settings(BaseSettings):
     # Per-user request rate limit (requests per minute)
     USER_RATE_LIMIT_PER_MINUTE: int = 60
 
+    # Background coach-context warming on question enter (kill-switch)
+    COACH_WARM_ENABLED: bool = True
+
     # Abuse detection thresholds
     ABUSE_MULTI_ACCOUNT_MIN_ACCOUNTS: int = 3
     ABUSE_BURST_MIN_EVENTS: int = 20

--- a/backend/app/middleware/rate_limit.py
+++ b/backend/app/middleware/rate_limit.py
@@ -178,6 +178,9 @@ def _rate_limit(env_key: str, default: str) -> Callable[[], str]:
 
 
 COACH_RATE_LIMIT: Callable[[], str] = _rate_limit("COACH_RATE_LIMIT", "10/minute")
+COACH_WARM_RATE_LIMIT: Callable[[], str] = _rate_limit(
+    "COACH_WARM_RATE_LIMIT", "30/minute"
+)
 RUN_RATE_LIMIT: Callable[[], str] = _rate_limit("RUN_RATE_LIMIT", "30/minute")
 QUESTIONS_RATE_LIMIT: Callable[[], str] = _rate_limit(
     "QUESTIONS_RATE_LIMIT", "100/minute"

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -89,6 +89,24 @@ class CoachingRequest(BaseModel):
         return self
 
 
+class WarmRequest(BaseModel):
+    """Fire-and-forget warm trigger for reusable coach learner context.
+
+    question_id is logging-only (slug like "two-sum"); context stays
+    user-scoped so anonymous callers never warm shared state.
+    """
+
+    question_id: Optional[str] = Field(
+        default=None, max_length=128, description="Question slug being viewed"
+    )
+
+
+class WarmResponse(BaseModel):
+    status: str = Field(..., description="warming | hit | disabled")
+    warmed: bool = Field(..., description="True when a background warm was queued")
+    ttl: int = Field(..., description="Coach context TTL seconds")
+
+
 class SceneShape(BaseModel):
     """One declarative vector shape in an animation scene (data, never code).
 

--- a/backend/app/services/redis_service.py
+++ b/backend/app/services/redis_service.py
@@ -80,6 +80,25 @@ class RedisCache:
             except Exception:
                 pass
 
+    async def set_if_absent(self, key: str, value: Any, ttl: int = 300) -> bool:
+        """Atomically set key only if absent (SET NX EX). True if acquired."""
+        client = await self._client()
+        if not client:
+            return False
+        try:
+            raw = json.dumps(value, default=str)
+            acquired = await client.set(key, raw, ex=ttl, nx=True)
+            return bool(acquired)
+        except Exception as e:
+            logger.debug("Redis set_if_absent failed for key %s: %s", key, e)
+            self.disable()
+            return False
+        finally:
+            try:
+                await client.aclose()
+            except Exception:
+                pass
+
     async def incr(self, key: str, ttl: int = 60) -> Optional[int]:
         """Atomically increment a counter, setting TTL on first increment.
 

--- a/backend/tests/unit/test_coach_warm.py
+++ b/backend/tests/unit/test_coach_warm.py
@@ -1,0 +1,174 @@
+"""Unit tests for POST /api/coach/warm background cache warming (TDD red)."""
+
+import pytest
+from contextlib import contextmanager
+from unittest.mock import AsyncMock
+
+from app.main import app
+from app.api.auth_deps import get_current_user
+from app.api.dependencies import (
+    get_learner_context_service_dependency,
+    get_redis_cache,
+)
+from app.models.auth_schemas import UserResponse
+
+
+@contextmanager
+def mock_auth(user_id="warm-learner"):
+    async def override():
+        return UserResponse(
+            id=user_id,
+            username="learner",
+            email="test@example.com",
+            is_active=True,
+            created_at="2025-01-01T00:00:00Z",
+            plan="premium",
+        )
+
+    app.dependency_overrides[get_current_user] = override
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+class FakeCache:
+    """Minimal in-memory RedisCache double with atomic set_if_absent."""
+
+    def __init__(self):
+        self.store = {}
+        self.set_if_absent_calls = 0
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, ttl=300):
+        self.store[key] = value
+
+    async def set_if_absent(self, key, value, ttl=300):
+        self.set_if_absent_calls += 1
+        if key in self.store:
+            return False
+        self.store[key] = value
+        return True
+
+    async def exists(self, key):
+        return key in self.store
+
+    async def ttl(self, key):
+        return 60 if key in self.store else -2
+
+    async def delete(self, pattern):
+        self.store.pop(pattern, None)
+        return 1
+
+
+@pytest.mark.usefixtures("test_env_vars")
+class TestCoachWarm:
+    @pytest.mark.asyncio
+    async def test_warm_returns_202_and_populates_cache(self, async_client):
+        from app.services.learner_context_service import LearnerContextService
+
+        fake_cache = FakeCache()
+        mock_svc = AsyncMock(spec=LearnerContextService)
+        mock_svc.get_context = AsyncMock(
+            return_value={"skill_block": "s", "submission_block": "b"}
+        )
+
+        app.dependency_overrides[get_redis_cache] = lambda: fake_cache
+        app.dependency_overrides[get_learner_context_service_dependency] = lambda: (
+            mock_svc
+        )
+        try:
+            with mock_auth():
+                resp = await async_client.post("/api/coach/warm", json={})
+            assert resp.status_code == 202
+            assert resp.json()["status"] in ("warming", "hit")
+            # Background task may not have run yet in ASGI transport;
+            # endpoint must at least have attempted single-flight acquisition.
+            assert fake_cache.set_if_absent_calls >= 1
+        finally:
+            app.dependency_overrides.pop(get_redis_cache, None)
+            app.dependency_overrides.pop(get_learner_context_service_dependency, None)
+
+    @pytest.mark.asyncio
+    async def test_warm_idempotent_second_call_returns_hit(self, async_client):
+        from app.core.cache_keys import coach_context_key
+        from app.services.learner_context_service import LearnerContextService
+
+        fake_cache = FakeCache()
+        user_id = "warm-learner-hit"
+        fake_cache.store[coach_context_key(user_id)] = {
+            "skill_block": "s",
+            "submission_block": "b",
+        }
+        mock_svc = AsyncMock(spec=LearnerContextService)
+        mock_svc.get_context = AsyncMock()
+
+        app.dependency_overrides[get_redis_cache] = lambda: fake_cache
+        app.dependency_overrides[get_learner_context_service_dependency] = lambda: (
+            mock_svc
+        )
+        try:
+            with mock_auth(user_id=user_id):
+                resp = await async_client.post("/api/coach/warm", json={})
+            assert resp.status_code == 202
+            assert resp.json()["status"] == "hit"
+            mock_svc.get_context.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_redis_cache, None)
+            app.dependency_overrides.pop(get_learner_context_service_dependency, None)
+
+    @pytest.mark.asyncio
+    async def test_warm_unauth_401(self, async_client):
+        app.dependency_overrides.pop(get_current_user, None)
+        resp = await async_client.post("/api/coach/warm", json={})
+        assert resp.status_code in (401, 403)
+
+    @pytest.mark.asyncio
+    async def test_warm_degrades_when_redis_disabled(self, async_client):
+        from app.services.learner_context_service import LearnerContextService
+
+        mock_svc = AsyncMock(spec=LearnerContextService)
+        mock_svc.get_context = AsyncMock()
+
+        app.dependency_overrides[get_redis_cache] = lambda: None
+        app.dependency_overrides[get_learner_context_service_dependency] = lambda: (
+            mock_svc
+        )
+        try:
+            with mock_auth():
+                resp = await async_client.post("/api/coach/warm", json={})
+            assert resp.status_code == 202
+            assert resp.json()["status"] == "disabled"
+            mock_svc.get_context.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_redis_cache, None)
+            app.dependency_overrides.pop(get_learner_context_service_dependency, None)
+
+
+@pytest.mark.asyncio
+async def test_redis_set_if_absent_atomic():
+    """RedisCache must expose atomic SET NX EX for warm single-flight."""
+    from app.services.redis_service import RedisCache
+
+    cache = RedisCache("redis://127.0.0.1:6379/0")
+    assert hasattr(cache, "set_if_absent")
+    # Mocked client to avoid needing live Redis.
+    acquired = {}
+
+    class FakeClient:
+        async def set(self, key, value, ex=None, nx=False):
+            if nx and key in acquired:
+                return None
+            acquired[key] = value
+            return True
+
+        async def aclose(self):
+            return None
+
+    cache._client = AsyncMock(return_value=FakeClient())
+    first = await cache.set_if_absent("k", "1", ttl=5)
+    second = await cache.set_if_absent("k", "1", ttl=5)
+    assert first is True
+    assert second is False

--- a/frontend/src/app/problems/[id]/page.test.tsx
+++ b/frontend/src/app/problems/[id]/page.test.tsx
@@ -85,6 +85,10 @@ vi.mock('@/features/rescue/use-rescue-contract.hook', () => ({
   }),
 }));
 
+vi.mock('@/features/coaching/use-coach-warm.hook', () => ({
+  useCoachWarm: () => {},
+}));
+
 const lcpQuestion: Question = {
   id: 'lcp',
   title: 'Longest Common Prefix',

--- a/frontend/src/app/problems/[id]/page.tsx
+++ b/frontend/src/app/problems/[id]/page.tsx
@@ -9,6 +9,7 @@ import { RescueIntervention } from '@/components/rescue/RescueIntervention';
 import { QuestionDescriptionPanel } from '@/components/sidebar/QuestionDescriptionPanel';
 import { ResizablePanelGroup } from '@/components/ui/ResizablePanelGroup';
 import { useCoaching } from '@/features/coaching/coaching.hook';
+import { useCoachWarm } from '@/features/coaching/use-coach-warm.hook';
 import { CoachingMode } from '@/features/coaching/coaching.types';
 import { questionService } from '@/features/question/question.service';
 import { useCodeRunner } from '@/features/question/use-code-runner.hook';
@@ -65,6 +66,10 @@ export default function ProblemWorkspacePage() {
   const { messages, isTyping, sendMessage } = useCoaching();
   const { ref: workspaceRef, mode } = useWorkspaceMode();
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // Background warm of reusable coach learner context on question enter.
+  // Fire-and-forget: never blocks question load or chat, degrades open.
+  useCoachWarm(fullQuestion?.id ?? null);
 
   useEffect(() => {
     if (

--- a/frontend/src/features/coaching/coaching.service.test.ts
+++ b/frontend/src/features/coaching/coaching.service.test.ts
@@ -282,4 +282,48 @@ describe('CoachingService', () => {
       ).rejects.toThrow('Request failed: 429 Too Many Requests');
     });
   });
+
+  describe('warmContext', () => {
+    it('posts question_id to /api/coach/warm', async () => {
+      vi.mocked(http.post).mockResolvedValue({
+        status: 'warming',
+        warmed: true,
+        ttl: 60,
+      });
+
+      const result = await service.warmContext('two-sum');
+
+      expect(http.post).toHaveBeenCalledWith(
+        '/api/coach/warm',
+        { question_id: 'two-sum' },
+        undefined,
+      );
+      expect(result).toEqual({ status: 'warming', warmed: true, ttl: 60 });
+    });
+
+    it('forwards AbortSignal when provided', async () => {
+      vi.mocked(http.post).mockResolvedValue({
+        status: 'warming',
+        warmed: true,
+        ttl: 60,
+      });
+      const ctrl = new AbortController();
+
+      await service.warmContext('two-sum', ctrl.signal);
+
+      expect(http.post).toHaveBeenCalledWith(
+        '/api/coach/warm',
+        { question_id: 'two-sum' },
+        { signal: ctrl.signal },
+      );
+    });
+
+    it('degrades to error status instead of throwing', async () => {
+      vi.mocked(http.post).mockRejectedValue(new Error('429'));
+
+      const result = await service.warmContext('two-sum');
+
+      expect(result).toEqual({ status: 'error', warmed: false, ttl: 0 });
+    });
+  });
 });

--- a/frontend/src/features/coaching/coaching.service.ts
+++ b/frontend/src/features/coaching/coaching.service.ts
@@ -21,6 +21,12 @@ export interface CoachingResponse {
   structured: StructuredCoachingResponse | null;
 }
 
+export interface WarmResponse {
+  status: string;
+  warmed: boolean;
+  ttl: number;
+}
+
 export class CoachingService {
   constructor(private http: HttpClient) {}
 
@@ -63,6 +69,21 @@ export class CoachingService {
       response: data.response,
       structured: data.structured || null,
     };
+  }
+
+  async warmContext(
+    questionId: string,
+    signal?: AbortSignal,
+  ): Promise<WarmResponse> {
+    try {
+      return await this.http.post<WarmResponse>(
+        "/api/coach/warm",
+        { question_id: questionId },
+        signal ? { signal } : undefined,
+      );
+    } catch {
+      return { status: "error", warmed: false, ttl: 0 };
+    }
   }
 }
 

--- a/frontend/src/features/coaching/use-coach-warm.hook.test.tsx
+++ b/frontend/src/features/coaching/use-coach-warm.hook.test.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCoachWarm } from './use-coach-warm.hook';
+
+const { mockWarmContext } = vi.hoisted(() => ({
+  mockWarmContext: vi.fn(),
+}));
+
+vi.mock('./coaching.service', () => ({
+  coachingService: {
+    warmContext: (...args: unknown[]) => mockWarmContext(...args),
+  },
+}));
+
+const { mockUseAuth } = vi.hoisted(() => ({
+  mockUseAuth: vi.fn(),
+}));
+
+vi.mock('@/providers', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+describe('useCoachWarm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWarmContext.mockResolvedValue({ status: 'warming' });
+  });
+
+  it('warms once when authenticated with questionId', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, isHydrated: true });
+    renderHook(({ id }: { id: string | null }) => useCoachWarm(id), {
+      initialProps: { id: 'two-sum' },
+    });
+    await vi.waitFor(() => {
+      expect(mockWarmContext).toHaveBeenCalledTimes(1);
+    });
+    expect(mockWarmContext).toHaveBeenCalledWith(
+      'two-sum',
+      expect.any(AbortSignal),
+    );
+  });
+
+  it('does not warm when unauthenticated', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, isHydrated: true });
+    renderHook(({ id }: { id: string | null }) => useCoachWarm(id), {
+      initialProps: { id: 'two-sum' },
+    });
+    expect(mockWarmContext).not.toHaveBeenCalled();
+  });
+
+  it('degrades silently when warm rejects', async () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, isHydrated: true });
+    mockWarmContext.mockRejectedValueOnce(new Error('429'));
+    renderHook(({ id }: { id: string | null }) => useCoachWarm(id), {
+      initialProps: { id: 'two-sum' },
+    });
+    await vi.waitFor(() => {
+      expect(mockWarmContext).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/features/coaching/use-coach-warm.hook.ts
+++ b/frontend/src/features/coaching/use-coach-warm.hook.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useAuth } from '@/providers';
+import { coachingService } from './coaching.service';
+
+export function useCoachWarm(questionId: string | null) {
+  const { isAuthenticated, isHydrated } = useAuth();
+
+  useEffect(() => {
+    if (!questionId || !isAuthenticated || !isHydrated) return;
+    const ctrl = new AbortController();
+    // Fire-and-forget: never toast, degrade open on 429/abort.
+    void coachingService
+      .warmContext(questionId, ctrl.signal)
+      .catch(() => undefined);
+    return () => ctrl.abort();
+  }, [questionId, isAuthenticated, isHydrated]);
+}


### PR DESCRIPTION
Background warm of reusable coach learner context when user enters `/problems/[id]` — `POST /api/coach/warm` → `202` + `BackgroundTasks` fills `codecoach:coach:ctx:{user}` (skill + submission pieces) so the first `POST /api/coach/` is usually a Redis hit.

* **Endpoint** `POST /api/coach/warm` (`backend/app/api/coach.py:134`): auth `get_current_user`, rate `COACH_WARM_RATE_LIMIT` 30/min (`rate_limit.py:181`), single-flight `SET NX EX 5s` via `RedisCache.set_if_absent` (`redis_service.py:83`), `asyncio.wait_for(4s)`, best-effort. Kill-switch `COACH_WARM_ENABLED` (`config.py:41`). New `WarmRequest`/`WarmResponse` (`schemas.py:76`).
* **Frontend** fire-and-forget: `coaching.service.warmContext` + `useCoachWarm` (guards `isAuthenticated+isHydrated`, aborts on unmount, degrades open) wired in `problems/[id]/page.tsx` (`useCoachWarm(fullQuestion?.id`).
* **TDD**: `backend/tests/unit/test_coach_warm.py` (5), `frontend use-coach-warm + service warmContext` (15). Green in clean clone from `origin/main` (`cae4809`).

**Verification** 
```
ALLOW_PRODUCTION_TEST_DB=1 pytest test_coach_warm (5) + learner_context_service+prompt (15) + integration flow (6) — pass
pnpm typecheck/lint green, graph 6187 nodes
```

Stacked cleanly — no surface/routing changes. Plan: `.opencode/plans/2026-09-03-coach-cache-warm-on-enter.md`.