### PR TITLE
feat(adapter-state): persist sent/submitted/failed for coaching, execution and submissions

### DIFF
--- a/backend/alembic/versions/b4c5d6e7f8a1_add_adapter_state_tables.py
+++ b/backend/alembic/versions/b4c5d6e7f8a1_add_adapter_state_tables.py
@@ -1,7 +1,7 @@
 """add adapter state tables (coaching + execution sent/submitted/failed)
 
 Revision ID: b4c5d6e7f8a1
-Revises: a3b4c5d6e7f8
+Revises: c9d0e1f2a3b4
 Create Date: 2026-09-03 00:00:00.000000
 
 Every coaching/execution intent persists sent before the external call and
@@ -19,7 +19,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 # revision identifiers, used by Alembic.
 revision: str = "b4c5d6e7f8a1"
-down_revision: Union[str, Sequence[str], None] = "a3b4c5d6e7f8"
+down_revision: Union[str, Sequence[str], None] = "c9d0e1f2a3b4"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/alembic/versions/b4c5d6e7f8a1_add_adapter_state_tables.py
+++ b/backend/alembic/versions/b4c5d6e7f8a1_add_adapter_state_tables.py
@@ -1,0 +1,242 @@
+"""add adapter state tables (coaching + execution sent/submitted/failed)
+
+Revision ID: b4c5d6e7f8a1
+Revises: a3b4c5d6e7f8
+Create Date: 2026-09-03 00:00:00.000000
+
+Every coaching/execution intent persists sent before the external call and
+transitions to a terminal state after, so timeouts and failures remain
+auditable. Submissions gain an explicit status machine (sent -> graded /
+failed) while preserving the legacy passed flag.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b4c5d6e7f8a1"
+down_revision: Union[str, Sequence[str], None] = "a3b4c5d6e7f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _table_exists(bind, name: str) -> bool:
+    return bool(
+        bind.execute(
+            sa.text("SELECT to_regclass(:name) IS NOT NULL"), {"name": f"public.{name}"}
+        ).scalar_one()
+    )
+
+
+def _column_exists(bind, table: str, column: str) -> bool:
+    return bool(
+        bind.execute(
+            sa.text(
+                "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+                "WHERE table_schema='public' AND table_name=:t AND column_name=:c)"
+            ),
+            {"t": table, "c": column},
+        ).scalar_one()
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        raise RuntimeError("Only Supabase/PostgreSQL is supported")
+
+    if not _table_exists(bind, "coaching_interactions"):
+        op.create_table(
+            "coaching_interactions",
+            sa.Column("id", sa.String(length=36), nullable=False),
+            sa.Column("user_id", sa.String(length=36), nullable=False),
+            sa.Column("question_id", sa.String(length=64), nullable=True),
+            sa.Column("lesson_id", sa.String(length=36), nullable=True),
+            sa.Column("mode", sa.String(length=20), nullable=False),
+            sa.Column("language", sa.String(length=20), nullable=False),
+            sa.Column("problem_hash", sa.String(length=64), nullable=False),
+            sa.Column("code_hash", sa.String(length=64), nullable=False),
+            sa.Column("idempotency_key", sa.String(length=128), nullable=False),
+            sa.Column(
+                "status", sa.String(length=20), nullable=False, server_default="sent"
+            ),
+            sa.Column("request_payload", JSONB(), nullable=False, server_default="{}"),
+            sa.Column("response_payload", JSONB(), nullable=True),
+            sa.Column("error_code", sa.String(length=50), nullable=True),
+            sa.Column("error_message", sa.Text(), nullable=True),
+            sa.Column("model", sa.String(length=100), nullable=True),
+            sa.Column("input_tokens", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column(
+                "output_tokens", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column("retry_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("request_id", sa.String(length=64), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(
+                ["question_id"], ["questions.id"], ondelete="SET NULL"
+            ),
+            sa.ForeignKeyConstraint(["lesson_id"], ["lessons.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "uq_coaching_user_idempotency",
+            "coaching_interactions",
+            ["user_id", "idempotency_key"],
+            unique=True,
+        )
+        op.create_index(
+            "ix_coaching_user_status_created",
+            "coaching_interactions",
+            ["user_id", "status", "created_at"],
+        )
+        # Single-column indexes implied by ORM index=True.
+        op.create_index(
+            "ix_coaching_interactions_user_id",
+            "coaching_interactions",
+            ["user_id"],
+        )
+        op.create_index(
+            "ix_coaching_interactions_question_id",
+            "coaching_interactions",
+            ["question_id"],
+        )
+        op.create_index(
+            "ix_coaching_interactions_created_at",
+            "coaching_interactions",
+            ["created_at"],
+        )
+
+    if not _table_exists(bind, "execution_jobs"):
+        op.create_table(
+            "execution_jobs",
+            sa.Column("id", sa.String(length=36), nullable=False),
+            sa.Column("user_id", sa.String(length=36), nullable=False),
+            sa.Column("question_id", sa.String(length=64), nullable=True),
+            sa.Column("language", sa.String(length=20), nullable=False),
+            sa.Column("code_hash", sa.String(length=64), nullable=False),
+            sa.Column("idempotency_key", sa.String(length=128), nullable=False),
+            sa.Column(
+                "status", sa.String(length=20), nullable=False, server_default="sent"
+            ),
+            sa.Column("request_payload", JSONB(), nullable=False, server_default="{}"),
+            sa.Column("response_payload", JSONB(), nullable=True),
+            sa.Column("test_results", JSONB(), nullable=True),
+            sa.Column("error_code", sa.String(length=50), nullable=True),
+            sa.Column("error_message", sa.Text(), nullable=True),
+            sa.Column("execution_time_ms", sa.Integer(), nullable=True),
+            sa.Column("retry_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("request_id", sa.String(length=64), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.ForeignKeyConstraint(
+                ["question_id"], ["questions.id"], ondelete="SET NULL"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "uq_execution_user_idempotency",
+            "execution_jobs",
+            ["user_id", "idempotency_key"],
+            unique=True,
+        )
+        op.create_index(
+            "ix_execution_user_status_created",
+            "execution_jobs",
+            ["user_id", "status", "created_at"],
+        )
+        op.create_index(
+            "ix_execution_jobs_user_id",
+            "execution_jobs",
+            ["user_id"],
+        )
+        op.create_index(
+            "ix_execution_jobs_question_id",
+            "execution_jobs",
+            ["question_id"],
+        )
+        op.create_index(
+            "ix_execution_jobs_created_at",
+            "execution_jobs",
+            ["created_at"],
+        )
+
+    # Augment submissions with an explicit status machine (default graded
+    # preserves legacy rows and existing graded writes).
+    if not _column_exists(bind, "submissions", "status"):
+        op.add_column(
+            "submissions",
+            sa.Column(
+                "status", sa.String(length=20), nullable=False, server_default="graded"
+            ),
+        )
+    if not _column_exists(bind, "submissions", "idempotency_key"):
+        op.add_column(
+            "submissions",
+            sa.Column("idempotency_key", sa.String(length=128), nullable=True),
+        )
+    if not _column_exists(bind, "submissions", "execution_job_id"):
+        op.add_column(
+            "submissions",
+            sa.Column("execution_job_id", sa.String(length=36), nullable=True),
+        )
+    if not _column_exists(bind, "submissions", "request_id"):
+        op.add_column(
+            "submissions", sa.Column("request_id", sa.String(length=64), nullable=True)
+        )
+    bind.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_submissions_user_status_created "
+            "ON public.submissions (user_id, status, created_at)"
+        )
+    )
+    bind.execute(
+        sa.text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_submissions_user_idempotency "
+            "ON public.submissions (user_id, idempotency_key) "
+            "WHERE idempotency_key IS NOT NULL"
+        )
+    )
+    bind.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_submissions_execution_job_id "
+            "ON public.submissions (execution_job_id)"
+        )
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(sa.text("DROP INDEX IF EXISTS ix_submissions_execution_job_id"))
+    bind.execute(sa.text("DROP INDEX IF EXISTS uq_submissions_user_idempotency"))
+    bind.execute(sa.text("DROP INDEX IF EXISTS ix_submissions_user_status_created"))
+    for col in ("request_id", "execution_job_id", "idempotency_key", "status"):
+        bind.execute(
+            sa.text(f"ALTER TABLE public.submissions DROP COLUMN IF EXISTS {col}")
+        )
+    op.drop_index("ix_execution_jobs_created_at", table_name="execution_jobs")
+    op.drop_index("ix_execution_jobs_question_id", table_name="execution_jobs")
+    op.drop_index("ix_execution_jobs_user_id", table_name="execution_jobs")
+    op.drop_index("ix_execution_user_status_created", table_name="execution_jobs")
+    op.drop_index("uq_execution_user_idempotency", table_name="execution_jobs")
+    op.drop_table("execution_jobs")
+    op.drop_index(
+        "ix_coaching_interactions_created_at", table_name="coaching_interactions"
+    )
+    op.drop_index(
+        "ix_coaching_interactions_question_id", table_name="coaching_interactions"
+    )
+    op.drop_index(
+        "ix_coaching_interactions_user_id", table_name="coaching_interactions"
+    )
+    op.drop_index("ix_coaching_user_status_created", table_name="coaching_interactions")
+    op.drop_index("uq_coaching_user_idempotency", table_name="coaching_interactions")
+    op.drop_table("coaching_interactions")

--- a/backend/alembic/versions/c9d0e1f2a3b4_prune_dynamic_programming_taxonomy.py
+++ b/backend/alembic/versions/c9d0e1f2a3b4_prune_dynamic_programming_taxonomy.py
@@ -1,0 +1,117 @@
+"""prune stale dynamic-programming taxonomy rows
+
+Revision ID: c9d0e1f2a3b4
+Revises: a3b4c5d6e7f8
+Create Date: 2026-09-03
+
+Why this exists
+---------------
+#135 split the monolithic ``dynamic-programming`` skill into ``dp-1d`` /
+``dp-2d`` and moved interval questions off ``sorting``. The seed script
+upserts only, so databases seeded before #135 keep rows that attribute
+events to an unknown slug (orphaned per-user states, invisible in the
+graph). This is a data-only migration (no schema change):
+
+- ensure the ``dp-1d`` skill row exists (the seed backfills its details)
+- remap ``user_skill_states`` ``dynamic-programming`` -> ``dp-1d``,
+  preserving mastery/evidence (``dp-1d`` states cannot pre-exist, so the
+  unique ``(user_id, skill_slug)`` constraint stays safe)
+- delete ``question_skills`` rows pointing at ``dynamic-programming``
+- delete the ``skills`` row ``dynamic-programming``
+
+Pair-level leftovers (e.g. the old ``(merge-intervals, sorting)`` pairing,
+where ``sorting`` is still a valid slug) are owned by the seed prune in
+``scripts/seed_skill_graph.py`` — run the seed after migrating.
+
+``learning_events`` history is immutable and untouched; re-ingest already
+ignores unknown slugs, so old events cannot corrupt the graph.
+
+Deploy order: ``alembic upgrade head`` BEFORE ``seed_skill_graph.py`` —
+otherwise the seed's skills-row prune would cascade-delete ``dp`` user
+states instead of this migration remapping them.
+
+The downgrade is best-effort (restores the skill row + old mappings for
+questions that exist); user states are never moved back.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c9d0e1f2a3b4"
+down_revision: Union[str, Sequence[str], None] = "a3b4c5d6e7f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Pre-#135 (question_id, weight) pairs for the monolith, used only by the
+# best-effort downgrade. Frozen in time — never import the live taxonomy here.
+_DP_PAIRS = (
+    ("longest-valid-parentheses", 0.3),
+    ("binary-tree-maximum-path-sum", 0.2),
+    ("climbing-stairs", 0.8),
+    ("coin-change", 1.0),
+    ("house-robber", 1.0),
+    ("word-break", 0.8),
+    ("edit-distance", 0.8),
+    ("decode-ways", 0.8),
+    ("longest-increasing-subsequence", 0.9),
+    ("burst-balloons", 0.9),
+    ("maximum-product-subarray", 0.7),
+    ("1f3e5d7c-9b8a-4c6d-0e2f-4a5b6c7d8e9f", 0.8),
+    ("8c3d2e4f-6a5b-4f7c-9d0e-1a2b3c4d5e6f", 0.8),
+    ("9e4f5a6b-7c8d-4e9f-0a1b-2c3d4e5f6a7b", 0.8),
+    ("4a3f7c1e-5d6b-4e8f-9a0c-2b3d4e5f6a7b", 0.7),
+)
+
+
+def upgrade() -> None:
+    """Remap dp states to dp-1d; delete stale dp rows. Re-runnable."""
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "INSERT INTO skills (slug, name, description, prerequisite_ids) "
+            "VALUES ('dp-1d', '1-D Dynamic Programming', '', '[\"recursion\"]') "
+            "ON CONFLICT (slug) DO NOTHING"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE user_skill_states SET skill_slug = 'dp-1d' "
+            "WHERE skill_slug = 'dynamic-programming'"
+        )
+    )
+    conn.execute(
+        sa.text("DELETE FROM question_skills WHERE skill_slug = 'dynamic-programming'")
+    )
+    conn.execute(sa.text("DELETE FROM skills WHERE slug = 'dynamic-programming'"))
+
+
+def downgrade() -> None:
+    """Best-effort restore of the skill row + old mappings. User states stay."""
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "INSERT INTO skills (slug, name, description, prerequisite_ids) "
+            "VALUES ('dynamic-programming', 'Dynamic Programming', '', "
+            "'[\"recursion\"]') ON CONFLICT (slug) DO NOTHING"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "INSERT INTO question_skills (id, question_id, skill_slug, weight) "
+            "SELECT :row_id, q.id, 'dynamic-programming', :weight "
+            "FROM questions q WHERE q.id = :question_id "
+            "ON CONFLICT (id) DO NOTHING"
+        ),
+        [
+            {
+                "row_id": f"{question_id}:dynamic-programming",
+                "question_id": question_id,
+                "weight": weight,
+            }
+            for question_id, weight in _DP_PAIRS
+        ],
+    )

--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -1,4 +1,4 @@
-<from fastapi import (
+from fastapi import (
     APIRouter,
     BackgroundTasks,
     Depends,

--- a/backend/app/api/coach.py
+++ b/backend/app/api/coach.py
@@ -1,8 +1,9 @@
-from fastapi import (
+<from fastapi import (
     APIRouter,
     BackgroundTasks,
     Depends,
     HTTPException,
+    Query,
     Request,
     Response,
 )
@@ -36,12 +37,17 @@ from app.services.solution_animation_service import SolutionAnimationService
 from app.api.auth_deps import get_current_user
 from app.api.daily_limits import enforce_daily_request_cap
 from app.api.dependencies import (
+    get_coaching_interaction_repo,
     get_learner_context_service_dependency,
     get_redis_cache,
     get_usage_service,
     get_executor,
 )
+from app.ports.coaching_interaction_repository import CoachingInteractionRepository
+from app.models.adapter_state_schemas import CoachingInteractionListResponse
 from app.models.auth_schemas import UserResponse
+from app.services.coaching_adapter import hash_content as _chash
+import uuid as _uuid
 from app.middleware.rate_limit import limiter, COACH_RATE_LIMIT, COACH_WARM_RATE_LIMIT
 from app.services.learner_context_service import LearnerContextService
 
@@ -195,6 +201,9 @@ async def get_coaching(
     learner_context: LearnerContextService = Depends(
         get_learner_context_service_dependency
     ),
+    interactions: CoachingInteractionRepository = Depends(
+        get_coaching_interaction_repo
+    ),
 ):
     """
     Get AI coaching response for coding problems.
@@ -241,20 +250,63 @@ async def get_coaching(
             except Exception as e:  # pragma: no cover - degrade open
                 logger.debug("Learner context fetch failed: %s", e)
 
-        structured_data = await provider.get_structured(
-            problem=coaching_request.problem,
-            code=coaching_request.code,
-            language=coaching_request.language.value,
-            message=coaching_request.message,
-            mode=coaching_request.mode.value,
-            difficulty=coaching_request.difficulty.value,
-            lesson_context=coaching_request.lesson_context,
-            chat_history=chat_history_list,
-            initial_code=coaching_request.initial_code,
-            learner_context=learner_ctx.get("skill_block") or None,
-            submission_context=learner_ctx.get("submission_block") or None,
-            surface=surface,
-        )
+        # Stateful adapter contract: persist sent before the provider call
+        # so timeouts/failures still leave an auditable row (best-effort).
+        interaction = None
+        try:
+            interaction = await interactions.create_sent(
+                user_id=user.id,
+                question_id=None,
+                mode=coaching_request.mode.value,
+                language=coaching_request.language.value,
+                problem_hash=_chash(coaching_request.problem),
+                code_hash=_chash(coaching_request.code),
+                idempotency_key=_uuid.uuid4().hex,
+                request_payload={
+                    "mode": coaching_request.mode.value,
+                    "language": coaching_request.language.value,
+                    "difficulty": coaching_request.difficulty.value,
+                    "surface": surface,
+                },
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("Failed to persist coaching sent state", exc_info=True)
+            interaction = None
+
+        try:
+            structured_data = await provider.get_structured(
+                problem=coaching_request.problem,
+                code=coaching_request.code,
+                language=coaching_request.language.value,
+                message=coaching_request.message,
+                mode=coaching_request.mode.value,
+                difficulty=coaching_request.difficulty.value,
+                lesson_context=coaching_request.lesson_context,
+                chat_history=chat_history_list,
+                initial_code=coaching_request.initial_code,
+                learner_context=learner_ctx.get("skill_block") or None,
+                submission_context=learner_ctx.get("submission_block") or None,
+                surface=surface,
+            )
+        except Exception:
+            if interaction is not None:
+                try:
+                    await interactions.mark_failed(interaction.id)
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "Failed to persist coaching failed state", exc_info=True
+                    )
+            raise
+
+        if interaction is not None:
+            try:
+                await interactions.mark_completed(
+                    interaction.id, response_payload=structured_data
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to persist coaching completed state", exc_info=True
+                )
 
         raw_response = _format_structured_as_text(structured_data)
 
@@ -515,6 +567,28 @@ async def get_coaching_stream(
         media_type="text/event-stream",
         headers=stream_headers,
     )
+
+
+@router.get("/interactions", response_model=CoachingInteractionListResponse)
+async def get_my_coaching_interactions(
+    limit: int = Query(50, ge=1, le=200, description="Max interactions to return"),
+    user: UserResponse = Depends(get_current_user),
+    interactions: CoachingInteractionRepository = Depends(
+        get_coaching_interaction_repo
+    ),
+):
+    """Return the authenticated user's recent coaching intents, newest first."""
+    try:
+        items = await interactions.list_by_user(user.id, limit=limit)
+        return CoachingInteractionListResponse(
+            interactions=list(items),
+            total=len(items),
+        )
+    except Exception:
+        logger.exception("Failed to list coaching interactions for user %s", user.id)
+        raise HTTPException(
+            status_code=500, detail="Failed to list coaching interactions"
+        )
 
 
 @router.get("/modes")

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -171,6 +171,26 @@ async def get_course_admin_repo(
     yield SqlCourseAdminRepository(db)
 
 
+async def get_coaching_interaction_repo(
+    db: AsyncSession = Depends(get_db),
+):
+    from app.repositories.sql_coaching_interaction_repository import (
+        SqlCoachingInteractionRepository,
+    )
+
+    yield SqlCoachingInteractionRepository(db)
+
+
+async def get_execution_job_repo(
+    db: AsyncSession = Depends(get_db),
+):
+    from app.repositories.sql_execution_job_repository import (
+        SqlExecutionJobRepository,
+    )
+
+    yield SqlExecutionJobRepository(db)
+
+
 def get_executor(
     cache: Optional[RedisCache] = Depends(get_redis_cache),
 ) -> CodeExecutor:

--- a/backend/app/api/run.py
+++ b/backend/app/api/run.py
@@ -1,17 +1,26 @@
 from dataclasses import asdict
 from datetime import datetime, timezone
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from app.models.schemas import CodeExecutionRequest, CodeExecutionResult, Language
 from app.models.auth_schemas import UserResponse
 from app.models.submission_schemas import SubmissionIn
 from app.ports.code_executor import CodeExecutor
 from app.api.auth_deps import get_current_user
-from app.api.dependencies import get_executor, get_review_service, get_submission_repo
+from app.api.dependencies import (
+    get_executor,
+    get_execution_job_repo,
+    get_review_service,
+    get_submission_repo,
+)
+from app.models.adapter_state_schemas import ExecutionJobListResponse
+from app.ports.execution_job_repository import ExecutionJobRepository
 from app.ports.submission_repository import SubmissionRepository
+from app.services.execution_adapter import hash_content as _code_hash
 from app.services.review_service import ReviewService
 from app.middleware.rate_limit import limiter, RUN_RATE_LIMIT
 import logging
+import uuid
 
 logger = logging.getLogger(__name__)
 
@@ -39,20 +48,60 @@ async def execute_code(
     executor: CodeExecutor = Depends(get_executor),
     submissions: SubmissionRepository = Depends(get_submission_repo),
     reviews: ReviewService = Depends(get_review_service),
+    jobs: ExecutionJobRepository = Depends(get_execution_job_repo),
     current_user: UserResponse = Depends(get_current_user),
 ):
     """
     Execute code using Piston API.
 
     Supports multiple programming languages with safe execution environment.
+    Persists sent -> executed/failed around the call (best-effort).
     """
+    job = None
     try:
-        result = await executor.execute(
+        job = await jobs.create_sent(
+            user_id=current_user.id,
+            question_id=execution_request.question_id,
             language=execution_request.language.value,
-            code=execution_request.code,
-            stdin=execution_request.stdin,
-            version=execution_request.version,
+            code_hash=_code_hash(execution_request.code),
+            idempotency_key=uuid.uuid4().hex,
+            request_payload={"stdin": execution_request.stdin},
+            request_id=getattr(request.state, "request_id", None),
         )
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to persist execution sent state", exc_info=True)
+        job = None
+    try:
+        try:
+            result = await executor.execute(
+                language=execution_request.language.value,
+                code=execution_request.code,
+                stdin=execution_request.stdin,
+                version=execution_request.version,
+            )
+        except Exception:
+            if job is not None:
+                try:
+                    await jobs.mark_failed(job.id, error_code="EXECUTOR_ERROR")
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "Failed to persist execution failed state", exc_info=True
+                    )
+            raise
+        if job is not None:
+            try:
+                await jobs.mark_executed(
+                    job.id,
+                    response_payload={
+                        "stdout": result.stdout,
+                        "stderr": result.stderr,
+                        "exit_code": result.exit_code,
+                    },
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to persist execution completed state", exc_info=True
+                )
 
         # Mistake-memory capture (Ideas #1): a crashed free-run inside a
         # question workspace is an attempt. Best-effort, mirroring submit.py.
@@ -126,6 +175,21 @@ async def validate_code(
     except Exception as e:
         logger.error(f"Error validating code: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail="Code validation failed")
+
+
+@router.get("/jobs", response_model=ExecutionJobListResponse)
+async def get_my_execution_jobs(
+    limit: int = Query(50, ge=1, le=200, description="Max jobs to return"),
+    jobs: ExecutionJobRepository = Depends(get_execution_job_repo),
+    current_user: UserResponse = Depends(get_current_user),
+):
+    """Return the authenticated user's recent execution intents, newest first."""
+    try:
+        items = await jobs.list_by_user(current_user.id, limit=limit)
+        return ExecutionJobListResponse(jobs=list(items), total=len(items))
+    except Exception:
+        logger.exception("Failed to list execution jobs for user %s", current_user.id)
+        raise HTTPException(status_code=500, detail="Failed to list execution jobs")
 
 
 @router.get("/languages")

--- a/backend/app/api/submissions.py
+++ b/backend/app/api/submissions.py
@@ -6,7 +6,7 @@ import logging
 from app.api.auth_deps import get_current_user
 from app.api.dependencies import get_submission_repo
 from app.models.auth_schemas import UserResponse
-from app.models.submission_schemas import SubmissionsListResponse
+from app.models.submission_schemas import Submission, SubmissionsListResponse
 from app.ports.submission_repository import SubmissionRepository
 
 logger = logging.getLogger(__name__)
@@ -30,3 +30,24 @@ async def get_my_submissions(
     except Exception:
         logger.exception("Failed to list submissions for user %s", current_user.id)
         raise HTTPException(status_code=500, detail="Failed to list submissions")
+
+
+@router.get("/{submission_id}", response_model=Submission)
+async def get_submission_status(
+    submission_id: str,
+    current_user: UserResponse = Depends(get_current_user),
+    submissions: SubmissionRepository = Depends(get_submission_repo),
+):
+    """Return one of the caller's submissions by id (status polling)."""
+    try:
+        item = await submissions.get(submission_id)
+    except Exception:
+        logger.exception(
+            "Failed to get submission %s for user %s",
+            submission_id,
+            current_user.id,
+        )
+        raise HTTPException(status_code=500, detail="Failed to get submission")
+    if item is None or item.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Submission not found")
+    return item

--- a/backend/app/api/submit.py
+++ b/backend/app/api/submit.py
@@ -78,6 +78,24 @@ async def submit_code(
         for tc in question.test_cases
     ]
 
+    # Stateful adapter contract: persist sent before grading so executor
+    # crashes still leave an auditable row, then transition to graded/failed.
+    # Persistence is best-effort and never breaks the graded response.
+    sent = None
+    try:
+        sent = await submissions.create_sent(
+            user_id=current_user.id,
+            submission=SubmissionIn(
+                question_id=submit_request.question_id,
+                code=submit_request.code,
+                language=submit_request.language.value,
+                passed=False,
+            ),
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to persist submission sent state", exc_info=True)
+        sent = None
+
     try:
         results = await executor.evaluate_suite(
             language=submit_request.language.value,
@@ -85,28 +103,49 @@ async def submit_code(
             test_cases=test_cases,
         )
     except HTTPException:
+        if sent is not None:
+            try:
+                await submissions.mark_failed(sent.id)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to persist submission failed state", exc_info=True
+                )
         raise
     except Exception as e:
         logger.error(f"Submit evaluation error: {e}", exc_info=True)
+        if sent is not None:
+            try:
+                await submissions.mark_failed(sent.id)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to persist submission failed state", exc_info=True
+                )
         raise HTTPException(status_code=500, detail="Evaluation failed")
 
     passed_count = sum(1 for r in results if r.passed)
     passed = passed_count == len(results) if results else False
 
-    # Persist the graded attempt for the mistake-memory data layer. Best-effort:
-    # a failed write must not 500 the graded result, but it IS logged.
+    # Transition sent -> graded for the mistake-memory data layer.
+    # Best-effort: a failed write must not 500 the graded result.
     persisted = None
     try:
-        persisted = await submissions.add(
-            user_id=current_user.id,
-            submission=SubmissionIn(
-                question_id=submit_request.question_id,
-                code=submit_request.code,
-                language=submit_request.language.value,
+        if sent is not None:
+            persisted = await submissions.mark_graded(
+                sent.id,
                 passed=passed,
                 error_signature=_error_signature(results),
-            ),
-        )
+            )
+        else:
+            persisted = await submissions.add(
+                user_id=current_user.id,
+                submission=SubmissionIn(
+                    question_id=submit_request.question_id,
+                    code=submit_request.code,
+                    language=submit_request.language.value,
+                    passed=passed,
+                    error_signature=_error_signature(results),
+                ),
+            )
     except Exception:  # noqa: BLE001
         logger.warning("Failed to persist submission", exc_info=True)
 

--- a/backend/app/models/adapter_state_schemas.py
+++ b/backend/app/models/adapter_state_schemas.py
@@ -1,0 +1,66 @@
+"""Pydantic schemas for adapter state persistence (coaching + execution)."""
+
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+
+class CoachingInteraction(BaseModel):
+    """One durable coaching intent with explicit state."""
+
+    id: str
+    user_id: str
+    question_id: Optional[str] = None
+    lesson_id: Optional[str] = None
+    mode: str
+    language: str
+    problem_hash: str
+    code_hash: str
+    idempotency_key: str
+    status: str = "sent"
+    request_payload: dict[str, Any] = {}
+    response_payload: Optional[dict[str, Any]] = None
+    error_code: Optional[str] = None
+    error_message: Optional[str] = None
+    model: Optional[str] = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    retry_count: int = 0
+    request_id: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+    completed_at: Optional[datetime] = None
+
+
+class ExecutionJob(BaseModel):
+    """One durable execution intent with explicit state."""
+
+    id: str
+    user_id: str
+    question_id: Optional[str] = None
+    language: str
+    code_hash: str
+    idempotency_key: str
+    status: str = "sent"
+    request_payload: dict[str, Any] = {}
+    response_payload: Optional[dict[str, Any]] = None
+    test_results: Optional[list[dict[str, Any]]] = None
+    error_code: Optional[str] = None
+    error_message: Optional[str] = None
+    execution_time_ms: Optional[int] = None
+    retry_count: int = 0
+    request_id: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+    completed_at: Optional[datetime] = None
+
+
+class CoachingInteractionListResponse(BaseModel):
+    interactions: list[CoachingInteraction]
+    total: int
+
+
+class ExecutionJobListResponse(BaseModel):
+    jobs: list[ExecutionJob]
+    total: int

--- a/backend/app/models/orm.py
+++ b/backend/app/models/orm.py
@@ -191,6 +191,9 @@ class SubmissionORM(Base):
     This is the foundation of the mistake-memory data layer: per-user error
     history, spaced-repetition reviews, and attempt-journey replay all hang
     off this table.
+
+    ``status`` tracks the adapter state machine: sent -> submitted ->
+    graded/failed. Legacy rows predate the machine and read as graded.
     """
 
     __tablename__ = "submissions"
@@ -212,6 +215,10 @@ class SubmissionORM(Base):
     passed = Column(Boolean, nullable=False, default=False)
     error_signature = Column(String(255), nullable=True)
     attempt_index = Column(Integer, nullable=False, default=0)
+    status = Column(String(20), nullable=False, server_default="graded")
+    idempotency_key = Column(String(128), nullable=True)
+    execution_job_id = Column(String(36), nullable=True, index=True)
+    request_id = Column(String(64), nullable=True)
     created_at = Column(
         DateTime(timezone=True),
         default=datetime.now(timezone.utc),
@@ -222,6 +229,140 @@ class SubmissionORM(Base):
     __table_args__ = (
         Index("ix_submissions_user_question", "user_id", "question_id"),
         Index("ix_submissions_user_created", "user_id", "created_at"),
+        Index("ix_submissions_user_status_created", "user_id", "status", "created_at"),
+        Index(
+            "uq_submissions_user_idempotency",
+            "user_id",
+            "idempotency_key",
+            unique=True,
+            postgresql_where=text("idempotency_key IS NOT NULL"),
+        ),
+    )
+
+
+class CoachingInteractionORM(Base):
+    """Durable coaching intent (Groq adapter state machine).
+
+    One row per coaching request: sent before the external call, then
+    completed/failed/timeout/rate_limited after. Supabase is the source of
+    truth; Redis remains a disposable cache.
+    """
+
+    __tablename__ = "coaching_interactions"
+    id = Column(String(36), primary_key=True)
+    user_id = Column(
+        String(36),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    question_id = Column(
+        String(64),
+        ForeignKey("questions.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    lesson_id = Column(
+        String(36),
+        ForeignKey("lessons.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    mode = Column(String(20), nullable=False)
+    language = Column(String(20), nullable=False)
+    problem_hash = Column(String(64), nullable=False)
+    code_hash = Column(String(64), nullable=False)
+    idempotency_key = Column(String(128), nullable=False)
+    status = Column(String(20), nullable=False, server_default="sent")
+    request_payload = Column(JSONType, default=dict, nullable=False)
+    response_payload = Column(JSONType, default=None, nullable=True)
+    error_code = Column(String(50), nullable=True)
+    error_message = Column(Text, nullable=True)
+    model = Column(String(100), nullable=True)
+    input_tokens = Column(Integer, nullable=False, default=0)
+    output_tokens = Column(Integer, nullable=False, default=0)
+    retry_count = Column(Integer, nullable=False, default=0)
+    request_id = Column(String(64), nullable=True)
+    created_at = Column(
+        DateTime(timezone=True),
+        default=datetime.now(timezone.utc),
+        nullable=False,
+        index=True,
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=datetime.now(timezone.utc),
+        onupdate=datetime.now(timezone.utc),
+        nullable=False,
+    )
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        Index(
+            "uq_coaching_user_idempotency",
+            "user_id",
+            "idempotency_key",
+            unique=True,
+        ),
+        Index("ix_coaching_user_status_created", "user_id", "status", "created_at"),
+    )
+
+
+class ExecutionJobORM(Base):
+    """Durable execution intent (Piston adapter state machine).
+
+    One row per run/submit evaluation: sent before the external call, then
+    executed/failed/timeout/cancelled after. Linked from submissions via
+    submissions.execution_job_id (no back-reference to avoid cycles).
+    """
+
+    __tablename__ = "execution_jobs"
+    id = Column(String(36), primary_key=True)
+    user_id = Column(
+        String(36),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    question_id = Column(
+        String(64),
+        ForeignKey("questions.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    language = Column(String(20), nullable=False)
+    code_hash = Column(String(64), nullable=False)
+    idempotency_key = Column(String(128), nullable=False)
+    status = Column(String(20), nullable=False, server_default="sent")
+    request_payload = Column(JSONType, default=dict, nullable=False)
+    response_payload = Column(JSONType, default=None, nullable=True)
+    test_results = Column(JSONType, default=None, nullable=True)
+    error_code = Column(String(50), nullable=True)
+    error_message = Column(Text, nullable=True)
+    execution_time_ms = Column(Integer, nullable=True)
+    retry_count = Column(Integer, nullable=False, default=0)
+    request_id = Column(String(64), nullable=True)
+    created_at = Column(
+        DateTime(timezone=True),
+        default=datetime.now(timezone.utc),
+        nullable=False,
+        index=True,
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=datetime.now(timezone.utc),
+        onupdate=datetime.now(timezone.utc),
+        nullable=False,
+    )
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        Index(
+            "uq_execution_user_idempotency",
+            "user_id",
+            "idempotency_key",
+            unique=True,
+        ),
+        Index("ix_execution_user_status_created", "user_id", "status", "created_at"),
     )
 
 

--- a/backend/app/models/submission_schemas.py
+++ b/backend/app/models/submission_schemas.py
@@ -1,9 +1,35 @@
 """Pydantic schemas for persisted code submissions (attempt history)."""
 
 from datetime import datetime
+from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel
+
+
+class SubmissionStatus(str, Enum):
+    SENT = "sent"
+    SUBMITTED = "submitted"
+    GRADED = "graded"
+    FAILED = "failed"
+
+
+class CoachingInteractionStatus(str, Enum):
+    SENT = "sent"
+    SUBMITTED = "submitted"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    TIMEOUT = "timeout"
+    RATE_LIMITED = "rate_limited"
+
+
+class ExecutionJobStatus(str, Enum):
+    SENT = "sent"
+    SUBMITTED = "submitted"
+    EXECUTED = "executed"
+    FAILED = "failed"
+    TIMEOUT = "timeout"
+    CANCELLED = "cancelled"
 
 
 class Submission(BaseModel):
@@ -17,6 +43,10 @@ class Submission(BaseModel):
     passed: bool
     error_signature: Optional[str] = None
     attempt_index: int = 0
+    status: str = SubmissionStatus.GRADED.value
+    idempotency_key: Optional[str] = None
+    execution_job_id: Optional[str] = None
+    request_id: Optional[str] = None
     created_at: datetime
 
 

--- a/backend/app/ports/coaching_interaction_repository.py
+++ b/backend/app/ports/coaching_interaction_repository.py
@@ -1,0 +1,70 @@
+"""CoachingInteractionRepository — port for durable coaching intents."""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Any, Optional, Sequence
+
+from app.models.adapter_state_schemas import CoachingInteraction
+
+
+class CoachingInteractionRepository(ABC):
+    """Interface for persisting coaching adapter state (sent -> terminal)."""
+
+    @abstractmethod
+    async def create_sent(
+        self,
+        *,
+        user_id: str,
+        question_id: Optional[str],
+        mode: str,
+        language: str,
+        problem_hash: str,
+        code_hash: str,
+        idempotency_key: str,
+        request_payload: dict[str, Any],
+        lesson_id: Optional[str] = None,
+        request_id: Optional[str] = None,
+    ) -> CoachingInteraction:
+        """Persist one coaching intent in sent state and return it."""
+
+    @abstractmethod
+    async def get(self, interaction_id: str) -> Optional[CoachingInteraction]:
+        """Return one interaction by id, or None."""
+
+    @abstractmethod
+    async def get_by_idempotency_key(
+        self, user_id: str, idempotency_key: str
+    ) -> Optional[CoachingInteraction]:
+        """Return the existing row for an idempotency key, or None."""
+
+    @abstractmethod
+    async def mark_completed(
+        self,
+        interaction_id: str,
+        *,
+        response_payload: Optional[dict[str, Any]] = None,
+    ) -> CoachingInteraction:
+        """Transition sent/submitted -> completed."""
+
+    @abstractmethod
+    async def mark_failed(
+        self,
+        interaction_id: str,
+        *,
+        status: str = "failed",
+        error_code: Optional[str] = None,
+        error_message: Optional[str] = None,
+    ) -> CoachingInteraction:
+        """Transition sent/submitted -> failed/timeout/rate_limited."""
+
+    @abstractmethod
+    async def list_by_user(
+        self, user_id: str, *, limit: int = 50
+    ) -> Sequence[CoachingInteraction]:
+        """Return the user's most recent interactions, newest first."""
+
+    @abstractmethod
+    async def list_stale(
+        self, *, older_than: datetime, limit: int = 100
+    ) -> Sequence[CoachingInteraction]:
+        """Return sent/submitted rows older than the cutoff, oldest first."""

--- a/backend/app/ports/execution_job_repository.py
+++ b/backend/app/ports/execution_job_repository.py
@@ -1,0 +1,69 @@
+"""ExecutionJobRepository — port for durable execution intents."""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Any, Optional, Sequence
+
+from app.models.adapter_state_schemas import ExecutionJob
+
+
+class ExecutionJobRepository(ABC):
+    """Interface for persisting execution adapter state (sent -> terminal)."""
+
+    @abstractmethod
+    async def create_sent(
+        self,
+        *,
+        user_id: str,
+        question_id: Optional[str],
+        language: str,
+        code_hash: str,
+        idempotency_key: str,
+        request_payload: dict[str, Any],
+        request_id: Optional[str] = None,
+    ) -> ExecutionJob:
+        """Persist one execution intent in sent state and return it."""
+
+    @abstractmethod
+    async def get(self, job_id: str) -> Optional[ExecutionJob]:
+        """Return one job by id, or None."""
+
+    @abstractmethod
+    async def get_by_idempotency_key(
+        self, user_id: str, idempotency_key: str
+    ) -> Optional[ExecutionJob]:
+        """Return the existing row for an idempotency key, or None."""
+
+    @abstractmethod
+    async def mark_executed(
+        self,
+        job_id: str,
+        *,
+        response_payload: Optional[dict[str, Any]] = None,
+        test_results: Optional[list[dict[str, Any]]] = None,
+        execution_time_ms: Optional[int] = None,
+    ) -> ExecutionJob:
+        """Transition sent/submitted -> executed."""
+
+    @abstractmethod
+    async def mark_failed(
+        self,
+        job_id: str,
+        *,
+        status: str = "failed",
+        error_code: Optional[str] = None,
+        error_message: Optional[str] = None,
+    ) -> ExecutionJob:
+        """Transition sent/submitted -> failed/timeout/cancelled."""
+
+    @abstractmethod
+    async def list_by_user(
+        self, user_id: str, *, limit: int = 50
+    ) -> Sequence[ExecutionJob]:
+        """Return the user's most recent jobs, newest first."""
+
+    @abstractmethod
+    async def list_stale(
+        self, *, older_than: datetime, limit: int = 100
+    ) -> Sequence[ExecutionJob]:
+        """Return sent/submitted rows older than the cutoff, oldest first."""

--- a/backend/app/ports/submission_repository.py
+++ b/backend/app/ports/submission_repository.py
@@ -1,7 +1,8 @@
 """SubmissionRepository — port for persisting graded code attempts."""
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from datetime import datetime
+from typing import Optional, Sequence
 
 from app.models.submission_schemas import Submission, SubmissionIn
 
@@ -22,3 +23,33 @@ class SubmissionRepository(ABC):
     @abstractmethod
     async def count_attempts(self, user_id: str, question_id: str) -> int:
         """Return how many attempts the user has made on a question."""
+
+    async def get(self, submission_id: str) -> Optional[Submission]:
+        """Return one submission by id, or None (default for fakes)."""
+        return None
+
+    async def create_sent(
+        self, *, user_id: str, submission: SubmissionIn
+    ) -> Submission:
+        """Persist one attempt in sent state before grading."""
+        return await self.add(user_id=user_id, submission=submission)
+
+    async def mark_graded(
+        self,
+        submission_id: str,
+        *,
+        passed: bool,
+        error_signature: Optional[str] = None,
+    ) -> Submission:
+        """Transition sent/submitted -> graded (must be overridden for state)."""
+        raise NotImplementedError
+
+    async def mark_failed(self, submission_id: str) -> Submission:
+        """Transition sent/submitted -> failed (must be overridden for state)."""
+        raise NotImplementedError
+
+    async def list_stale(
+        self, *, older_than: datetime, limit: int = 100
+    ) -> Sequence[Submission]:
+        """Return sent/submitted rows older than the cutoff (default empty)."""
+        return []

--- a/backend/app/repositories/sql_coaching_interaction_repository.py
+++ b/backend/app/repositories/sql_coaching_interaction_repository.py
@@ -1,0 +1,183 @@
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.adapter_state_schemas import CoachingInteraction
+from app.models.orm import CoachingInteractionORM
+from app.ports.coaching_interaction_repository import CoachingInteractionRepository
+
+
+class SqlCoachingInteractionRepository(CoachingInteractionRepository):
+    """PostgreSQL/Supabase implementation of coaching interaction state."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    @staticmethod
+    def _orm_to_schema(orm: CoachingInteractionORM) -> CoachingInteraction:
+        return CoachingInteraction(
+            id=orm.id,
+            user_id=orm.user_id,
+            question_id=orm.question_id,
+            lesson_id=orm.lesson_id,
+            mode=orm.mode,
+            language=orm.language,
+            problem_hash=orm.problem_hash,
+            code_hash=orm.code_hash,
+            idempotency_key=orm.idempotency_key,
+            status=orm.status,
+            request_payload=orm.request_payload or {},
+            response_payload=orm.response_payload,
+            error_code=orm.error_code,
+            error_message=orm.error_message,
+            model=orm.model,
+            input_tokens=orm.input_tokens or 0,
+            output_tokens=orm.output_tokens or 0,
+            retry_count=orm.retry_count or 0,
+            request_id=orm.request_id,
+            created_at=orm.created_at,
+            updated_at=orm.updated_at,
+            completed_at=orm.completed_at,
+        )
+
+    async def create_sent(
+        self,
+        *,
+        user_id: str,
+        question_id: Optional[str],
+        mode: str,
+        language: str,
+        problem_hash: str,
+        code_hash: str,
+        idempotency_key: str,
+        request_payload: dict[str, Any],
+        lesson_id: Optional[str] = None,
+        request_id: Optional[str] = None,
+    ) -> CoachingInteraction:
+        now = datetime.now(timezone.utc)
+        orm = CoachingInteractionORM(
+            id=uuid.uuid4().hex,
+            user_id=user_id,
+            question_id=question_id,
+            lesson_id=lesson_id,
+            mode=mode,
+            language=language,
+            problem_hash=problem_hash,
+            code_hash=code_hash,
+            idempotency_key=idempotency_key,
+            status="sent",
+            request_payload=request_payload,
+            response_payload=None,
+            error_code=None,
+            error_message=None,
+            retry_count=0,
+            request_id=request_id,
+            created_at=now,
+            updated_at=now,
+            completed_at=None,
+        )
+        self.session.add(orm)
+        try:
+            await self.session.commit()
+        except Exception:
+            await self.session.rollback()
+            raise
+        await self.session.refresh(orm)
+        return self._orm_to_schema(orm)
+
+    async def get(self, interaction_id: str) -> Optional[CoachingInteraction]:
+        result = await self.session.execute(
+            select(CoachingInteractionORM).where(
+                CoachingInteractionORM.id == interaction_id
+            )
+        )
+        orm = result.scalar_one_or_none()
+        return self._orm_to_schema(orm) if orm else None
+
+    async def get_by_idempotency_key(
+        self, user_id: str, idempotency_key: str
+    ) -> Optional[CoachingInteraction]:
+        result = await self.session.execute(
+            select(CoachingInteractionORM).where(
+                CoachingInteractionORM.user_id == user_id,
+                CoachingInteractionORM.idempotency_key == idempotency_key,
+            )
+        )
+        orm = result.scalar_one_or_none()
+        return self._orm_to_schema(orm) if orm else None
+
+    async def _transition(
+        self, interaction_id: str, status: str, **fields: Any
+    ) -> CoachingInteraction:
+        result = await self.session.execute(
+            select(CoachingInteractionORM).where(
+                CoachingInteractionORM.id == interaction_id
+            )
+        )
+        orm = result.scalar_one()
+        orm.status = status
+        for key, value in fields.items():
+            setattr(orm, key, value)
+        orm.updated_at = datetime.now(timezone.utc)
+        if status in ("completed", "failed", "timeout", "rate_limited"):
+            orm.completed_at = datetime.now(timezone.utc)
+        try:
+            await self.session.commit()
+        except Exception:
+            await self.session.rollback()
+            raise
+        await self.session.refresh(orm)
+        return self._orm_to_schema(orm)
+
+    async def mark_completed(
+        self,
+        interaction_id: str,
+        *,
+        response_payload: Optional[dict[str, Any]] = None,
+    ) -> CoachingInteraction:
+        return await self._transition(
+            interaction_id, "completed", response_payload=response_payload
+        )
+
+    async def mark_failed(
+        self,
+        interaction_id: str,
+        *,
+        status: str = "failed",
+        error_code: Optional[str] = None,
+        error_message: Optional[str] = None,
+    ) -> CoachingInteraction:
+        return await self._transition(
+            interaction_id,
+            status,
+            error_code=error_code,
+            error_message=error_message,
+        )
+
+    async def list_by_user(
+        self, user_id: str, *, limit: int = 50
+    ) -> Sequence[CoachingInteraction]:
+        result = await self.session.execute(
+            select(CoachingInteractionORM)
+            .where(CoachingInteractionORM.user_id == user_id)
+            .order_by(CoachingInteractionORM.created_at.desc())
+            .limit(limit)
+        )
+        return [self._orm_to_schema(o) for o in result.scalars().all()]
+
+    async def list_stale(
+        self, *, older_than: datetime, limit: int = 100
+    ) -> Sequence[CoachingInteraction]:
+        result = await self.session.execute(
+            select(CoachingInteractionORM)
+            .where(
+                CoachingInteractionORM.status.in_(["sent", "submitted"]),
+                CoachingInteractionORM.created_at < older_than,
+            )
+            .order_by(CoachingInteractionORM.created_at.asc())
+            .limit(limit)
+        )
+        return [self._orm_to_schema(o) for o in result.scalars().all()]

--- a/backend/app/repositories/sql_execution_job_repository.py
+++ b/backend/app/repositories/sql_execution_job_repository.py
@@ -1,0 +1,176 @@
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.adapter_state_schemas import ExecutionJob
+from app.models.orm import ExecutionJobORM
+from app.ports.execution_job_repository import ExecutionJobRepository
+
+
+class SqlExecutionJobRepository(ExecutionJobRepository):
+    """PostgreSQL/Supabase implementation of execution job state."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    @staticmethod
+    def _orm_to_schema(orm: ExecutionJobORM) -> ExecutionJob:
+        return ExecutionJob(
+            id=orm.id,
+            user_id=orm.user_id,
+            question_id=orm.question_id,
+            language=orm.language,
+            code_hash=orm.code_hash,
+            idempotency_key=orm.idempotency_key,
+            status=orm.status,
+            request_payload=orm.request_payload or {},
+            response_payload=orm.response_payload,
+            test_results=orm.test_results,
+            error_code=orm.error_code,
+            error_message=orm.error_message,
+            execution_time_ms=orm.execution_time_ms,
+            retry_count=orm.retry_count or 0,
+            request_id=orm.request_id,
+            created_at=orm.created_at,
+            updated_at=orm.updated_at,
+            completed_at=orm.completed_at,
+        )
+
+    async def create_sent(
+        self,
+        *,
+        user_id: str,
+        question_id: Optional[str],
+        language: str,
+        code_hash: str,
+        idempotency_key: str,
+        request_payload: dict[str, Any],
+        request_id: Optional[str] = None,
+    ) -> ExecutionJob:
+        now = datetime.now(timezone.utc)
+        orm = ExecutionJobORM(
+            id=uuid.uuid4().hex,
+            user_id=user_id,
+            question_id=question_id,
+            language=language,
+            code_hash=code_hash,
+            idempotency_key=idempotency_key,
+            status="sent",
+            request_payload=request_payload,
+            response_payload=None,
+            test_results=None,
+            error_code=None,
+            error_message=None,
+            retry_count=0,
+            request_id=request_id,
+            created_at=now,
+            updated_at=now,
+            completed_at=None,
+        )
+        self.session.add(orm)
+        try:
+            await self.session.commit()
+        except Exception:
+            await self.session.rollback()
+            raise
+        await self.session.refresh(orm)
+        return self._orm_to_schema(orm)
+
+    async def get(self, job_id: str) -> Optional[ExecutionJob]:
+        result = await self.session.execute(
+            select(ExecutionJobORM).where(ExecutionJobORM.id == job_id)
+        )
+        orm = result.scalar_one_or_none()
+        return self._orm_to_schema(orm) if orm else None
+
+    async def get_by_idempotency_key(
+        self, user_id: str, idempotency_key: str
+    ) -> Optional[ExecutionJob]:
+        result = await self.session.execute(
+            select(ExecutionJobORM).where(
+                ExecutionJobORM.user_id == user_id,
+                ExecutionJobORM.idempotency_key == idempotency_key,
+            )
+        )
+        orm = result.scalar_one_or_none()
+        return self._orm_to_schema(orm) if orm else None
+
+    async def _transition(
+        self, job_id: str, status: str, **fields: Any
+    ) -> ExecutionJob:
+        result = await self.session.execute(
+            select(ExecutionJobORM).where(ExecutionJobORM.id == job_id)
+        )
+        orm = result.scalar_one()
+        orm.status = status
+        for key, value in fields.items():
+            setattr(orm, key, value)
+        orm.updated_at = datetime.now(timezone.utc)
+        if status in ("executed", "failed", "timeout", "cancelled"):
+            orm.completed_at = datetime.now(timezone.utc)
+        try:
+            await self.session.commit()
+        except Exception:
+            await self.session.rollback()
+            raise
+        await self.session.refresh(orm)
+        return self._orm_to_schema(orm)
+
+    async def mark_executed(
+        self,
+        job_id: str,
+        *,
+        response_payload: Optional[dict[str, Any]] = None,
+        test_results: Optional[list[dict[str, Any]]] = None,
+        execution_time_ms: Optional[int] = None,
+    ) -> ExecutionJob:
+        return await self._transition(
+            job_id,
+            "executed",
+            response_payload=response_payload,
+            test_results=test_results,
+            execution_time_ms=execution_time_ms,
+        )
+
+    async def mark_failed(
+        self,
+        job_id: str,
+        *,
+        status: str = "failed",
+        error_code: Optional[str] = None,
+        error_message: Optional[str] = None,
+    ) -> ExecutionJob:
+        return await self._transition(
+            job_id,
+            status,
+            error_code=error_code,
+            error_message=error_message,
+        )
+
+    async def list_by_user(
+        self, user_id: str, *, limit: int = 50
+    ) -> Sequence[ExecutionJob]:
+        result = await self.session.execute(
+            select(ExecutionJobORM)
+            .where(ExecutionJobORM.user_id == user_id)
+            .order_by(ExecutionJobORM.created_at.desc())
+            .limit(limit)
+        )
+        return [self._orm_to_schema(o) for o in result.scalars().all()]
+
+    async def list_stale(
+        self, *, older_than: datetime, limit: int = 100
+    ) -> Sequence[ExecutionJob]:
+        result = await self.session.execute(
+            select(ExecutionJobORM)
+            .where(
+                ExecutionJobORM.status.in_(["sent", "submitted"]),
+                ExecutionJobORM.created_at < older_than,
+            )
+            .order_by(ExecutionJobORM.created_at.asc())
+            .limit(limit)
+        )
+        return [self._orm_to_schema(o) for o in result.scalars().all()]

--- a/backend/app/repositories/sql_submission_repository.py
+++ b/backend/app/repositories/sql_submission_repository.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from typing import Sequence
+from typing import Optional, Sequence
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -27,6 +27,10 @@ class SqlSubmissionRepository(SubmissionRepository):
             passed=orm.passed,
             error_signature=orm.error_signature,
             attempt_index=orm.attempt_index,
+            status=getattr(orm, "status", "graded") or "graded",
+            idempotency_key=getattr(orm, "idempotency_key", None),
+            execution_job_id=getattr(orm, "execution_job_id", None),
+            request_id=getattr(orm, "request_id", None),
             created_at=orm.created_at,
         )
 
@@ -41,12 +45,110 @@ class SqlSubmissionRepository(SubmissionRepository):
             passed=submission.passed,
             error_signature=submission.error_signature,
             attempt_index=attempt_index,
+            status="graded",
             created_at=datetime.now(timezone.utc),
         )
         self.session.add(orm)
-        await self.session.commit()
+        try:
+            await self.session.commit()
+        except Exception:
+            await self.session.rollback()
+            raise
         await self.session.refresh(orm)
         return self._orm_to_schema(orm)
+
+    async def get(self, submission_id: str) -> Optional[Submission]:
+        result = await self.session.execute(
+            select(SubmissionORM).where(SubmissionORM.id == submission_id)
+        )
+        orm = result.scalar_one_or_none()
+        return self._orm_to_schema(orm) if orm else None
+
+    async def get_by_idempotency_key(
+        self, user_id: str, idempotency_key: str
+    ) -> Optional[Submission]:
+        result = await self.session.execute(
+            select(SubmissionORM).where(
+                SubmissionORM.user_id == user_id,
+                SubmissionORM.idempotency_key == idempotency_key,
+            )
+        )
+        orm = result.scalar_one_or_none()
+        return self._orm_to_schema(orm) if orm else None
+
+    async def create_sent(
+        self, *, user_id: str, submission: SubmissionIn
+    ) -> Submission:
+        attempt_index = await self.count_attempts(user_id, submission.question_id)
+        orm = SubmissionORM(
+            id=uuid.uuid4().hex,
+            user_id=user_id,
+            question_id=submission.question_id,
+            code=submission.code,
+            language=submission.language,
+            passed=False,
+            error_signature=None,
+            attempt_index=attempt_index,
+            status="sent",
+            created_at=datetime.now(timezone.utc),
+        )
+        self.session.add(orm)
+        try:
+            await self.session.commit()
+        except Exception:
+            await self.session.rollback()
+            raise
+        await self.session.refresh(orm)
+        return self._orm_to_schema(orm)
+
+    async def mark_graded(
+        self,
+        submission_id: str,
+        *,
+        passed: bool,
+        error_signature: Optional[str] = None,
+    ) -> Submission:
+        result = await self.session.execute(
+            select(SubmissionORM).where(SubmissionORM.id == submission_id)
+        )
+        orm = result.scalar_one()
+        orm.status = "graded"
+        orm.passed = passed
+        orm.error_signature = error_signature
+        try:
+            await self.session.commit()
+        except Exception:
+            await self.session.rollback()
+            raise
+        await self.session.refresh(orm)
+        return self._orm_to_schema(orm)
+
+    async def mark_failed(self, submission_id: str) -> Submission:
+        result = await self.session.execute(
+            select(SubmissionORM).where(SubmissionORM.id == submission_id)
+        )
+        orm = result.scalar_one()
+        orm.status = "failed"
+        orm.passed = False
+        try:
+            await self.session.commit()
+        except Exception:
+            await self.session.rollback()
+            raise
+        await self.session.refresh(orm)
+        return self._orm_to_schema(orm)
+
+    async def list_stale(self, *, older_than, limit: int = 100) -> Sequence[Submission]:
+        result = await self.session.execute(
+            select(SubmissionORM)
+            .where(
+                SubmissionORM.status.in_(["sent", "submitted"]),
+                SubmissionORM.created_at < older_than,
+            )
+            .order_by(SubmissionORM.created_at.asc())
+            .limit(limit)
+        )
+        return [self._orm_to_schema(o) for o in result.scalars().all()]
 
     async def list_by_user(
         self, user_id: str, *, limit: int = 50

--- a/backend/app/services/adapter_state_recovery.py
+++ b/backend/app/services/adapter_state_recovery.py
@@ -1,0 +1,92 @@
+"""Stale adapter-state recovery — flip stuck sent rows to terminal states.
+
+A crashed process can leave coaching/execution/submission rows in sent (or
+submitted) past the recovery window. This worker marks them timeout/failed
+so they never stay stuck and remain observable. It never re-invokes
+external providers — recovery is a local state transition only.
+
+Callers: cron/apscheduler, lifespan background task, or admin endpoint.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.sql_coaching_interaction_repository import (
+    SqlCoachingInteractionRepository,
+)
+from app.repositories.sql_execution_job_repository import SqlExecutionJobRepository
+from app.repositories.sql_submission_repository import SqlSubmissionRepository
+
+logger = logging.getLogger(__name__)
+
+STALE_ERROR_CODE = "STALE_RECOVERY"
+STALE_ERROR_MESSAGE = "Recovered stuck sent state (worker timeout)"
+
+
+async def recover_stale_adapter_state(
+    db: AsyncSession,
+    *,
+    older_than_minutes: int = 5,
+    limit: int = 100,
+    now: datetime | None = None,
+) -> dict[str, int]:
+    """Mark stale sent/submitted rows terminal; return per-table counts."""
+    cutoff = (now or datetime.now(timezone.utc)) - timedelta(minutes=older_than_minutes)
+    coaching = SqlCoachingInteractionRepository(db)
+    executions = SqlExecutionJobRepository(db)
+    submissions = SqlSubmissionRepository(db)
+    counts = {"coaching_interactions": 0, "execution_jobs": 0, "submissions": 0}
+
+    try:
+        stale_coaching = await coaching.list_stale(older_than=cutoff, limit=limit)
+    except Exception:  # noqa: BLE001 - recovery must degrade open
+        logger.warning("Stale coaching scan failed", exc_info=True)
+        stale_coaching = []
+    for row in stale_coaching:
+        try:
+            await coaching.mark_failed(
+                row.id,
+                status="timeout",
+                error_code=STALE_ERROR_CODE,
+                error_message=STALE_ERROR_MESSAGE,
+            )
+            counts["coaching_interactions"] += 1
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to recover coaching interaction %s", row.id, exc_info=True
+            )
+
+    try:
+        stale_jobs = await executions.list_stale(older_than=cutoff, limit=limit)
+    except Exception:  # noqa: BLE001
+        logger.warning("Stale execution scan failed", exc_info=True)
+        stale_jobs = []
+    for row in stale_jobs:
+        try:
+            await executions.mark_failed(
+                row.id,
+                status="timeout",
+                error_code=STALE_ERROR_CODE,
+                error_message=STALE_ERROR_MESSAGE,
+            )
+            counts["execution_jobs"] += 1
+        except Exception:  # noqa: BLE001
+            logger.warning("Failed to recover execution job %s", row.id, exc_info=True)
+
+    try:
+        stale_subs = await submissions.list_stale(older_than=cutoff, limit=limit)
+    except Exception:  # noqa: BLE001
+        logger.warning("Stale submission scan failed", exc_info=True)
+        stale_subs = []
+    for row in stale_subs:
+        try:
+            await submissions.mark_failed(row.id)
+            counts["submissions"] += 1
+        except Exception:  # noqa: BLE001
+            logger.warning("Failed to recover submission %s", row.id, exc_info=True)
+
+    if sum(counts.values()):
+        logger.info("Recovered stale adapter state: %s", counts)
+    return counts

--- a/backend/app/services/coaching_adapter.py
+++ b/backend/app/services/coaching_adapter.py
@@ -1,0 +1,160 @@
+"""Stateful coaching adapter — sent -> completed/failed persistence.
+
+Wraps a CoachingProvider (e.g. GroqService) with durable intent rows via
+CoachingInteractionRepository. Persistence is best-effort: DB failures are
+logged and never break the coaching response (degrade open).
+"""
+
+import hashlib
+import logging
+import uuid
+from typing import Any, AsyncIterator, Optional
+
+from app.ports.coaching_provider import CoachingProvider
+from app.ports.coaching_interaction_repository import CoachingInteractionRepository
+
+logger = logging.getLogger(__name__)
+
+
+def hash_content(*parts: str) -> str:
+    h = hashlib.sha256()
+    for p in parts:
+        h.update((p or "").encode("utf-8"))
+        h.update(b"\x00")
+    return h.hexdigest()[:64]
+
+
+class CoachingAdapter(CoachingProvider):
+    """CoachingProvider with Supabase-backed state transitions."""
+
+    def __init__(
+        self,
+        inner: CoachingProvider,
+        repo: Optional[CoachingInteractionRepository] = None,
+        user_id: Optional[str] = None,
+        request_id: Optional[str] = None,
+    ):
+        self.inner = inner
+        self.repo = repo
+        self.user_id = user_id
+        self.request_id = request_id or uuid.uuid4().hex
+
+    async def get_structured(
+        self,
+        problem: str,
+        code: str,
+        language: str,
+        message: str,
+        mode: str = "hint",
+        difficulty: str = "medium",
+        lesson_context: Optional[str] = None,
+        chat_history: Optional[list] = None,
+        initial_code: Optional[str] = None,
+        learner_context: Optional[str] = None,
+        submission_context: Optional[str] = None,
+        surface: str = "questions",
+    ) -> dict[str, Any]:
+        interaction = None
+        if self.repo is not None and self.user_id:
+            try:
+                interaction = await self.repo.create_sent(
+                    user_id=self.user_id,
+                    question_id=None,
+                    mode=mode,
+                    language=language,
+                    problem_hash=hash_content(problem),
+                    code_hash=hash_content(code),
+                    idempotency_key=uuid.uuid4().hex,
+                    request_payload={
+                        "mode": mode,
+                        "language": language,
+                        "difficulty": difficulty,
+                    },
+                    request_id=self.request_id,
+                )
+            except Exception:  # noqa: BLE001 - persistence must not break coaching
+                logger.warning("Failed to persist coaching sent state", exc_info=True)
+                interaction = None
+        try:
+            result = await self.inner.get_structured(
+                problem=problem,
+                code=code,
+                language=language,
+                message=message,
+                mode=mode,
+                difficulty=difficulty,
+                lesson_context=lesson_context,
+                chat_history=chat_history,
+                initial_code=initial_code,
+                learner_context=learner_context,
+                submission_context=submission_context,
+                surface=surface,
+            )
+        except Exception as exc:  # noqa: BLE001 - map to failed state then re-raise
+            if interaction is not None and self.repo is not None:
+                try:
+                    status = "timeout" if "timeout" in str(exc).lower() else "failed"
+                    await self.repo.mark_failed(
+                        interaction.id,
+                        status=status,
+                        error_code=type(exc).__name__[:50],
+                        error_message=str(exc)[:2000],
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "Failed to persist coaching failed state", exc_info=True
+                    )
+            raise
+        if interaction is not None and self.repo is not None:
+            try:
+                await self.repo.mark_completed(interaction.id, response_payload=result)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to persist coaching completed state", exc_info=True
+                )
+        return result
+
+    async def stream(
+        self,
+        problem: str,
+        code: str,
+        language: str,
+        message: str,
+        mode: str = "hint",
+        difficulty: str = "medium",
+        lesson_context: Optional[str] = None,
+        chat_history: Optional[list] = None,
+        initial_code: Optional[str] = None,
+    ) -> AsyncIterator[str]:
+        async for chunk in self.inner.stream(
+            problem=problem,
+            code=code,
+            language=language,
+            message=message,
+            mode=mode,
+            difficulty=difficulty,
+            lesson_context=lesson_context,
+            chat_history=chat_history,
+            initial_code=initial_code,
+        ):
+            yield chunk
+
+    async def get_animation_script(
+        self,
+        problem: str,
+        code: str,
+        language: str,
+        difficulty: str = "medium",
+        lesson_context: Optional[str] = None,
+        initial_code: Optional[str] = None,
+        question: Optional[dict[str, Any]] = None,
+    ) -> Optional[dict[str, Any]]:
+        return await self.inner.get_animation_script(
+            problem=problem,
+            code=code,
+            language=language,
+            difficulty=difficulty,
+            lesson_context=lesson_context,
+            initial_code=initial_code,
+            question=question,
+        )

--- a/backend/app/services/execution_adapter.py
+++ b/backend/app/services/execution_adapter.py
@@ -1,0 +1,148 @@
+"""Stateful execution adapter — sent -> executed/failed persistence.
+
+Wraps a CodeExecutor (e.g. PistonService) with durable intent rows via
+ExecutionJobRepository. Persistence is best-effort: DB failures are logged
+and never break execution (degrade open).
+"""
+
+import hashlib
+import logging
+import uuid
+from typing import Any, List, Optional
+
+from app.ports.code_executor import CodeExecutor, ExecutionResult, TestCaseResult
+from app.ports.execution_job_repository import ExecutionJobRepository
+
+logger = logging.getLogger(__name__)
+
+
+def hash_content(*parts: str) -> str:
+    h = hashlib.sha256()
+    for p in parts:
+        h.update((p or "").encode("utf-8"))
+        h.update(b"\x00")
+    return h.hexdigest()[:64]
+
+
+class ExecutionAdapter(CodeExecutor):
+    """CodeExecutor with Supabase-backed state transitions."""
+
+    def __init__(
+        self,
+        inner: CodeExecutor,
+        repo: Optional[ExecutionJobRepository] = None,
+        user_id: Optional[str] = None,
+        question_id: Optional[str] = None,
+        request_id: Optional[str] = None,
+    ):
+        self.inner = inner
+        self.repo = repo
+        self.user_id = user_id
+        self.question_id = question_id
+        self.request_id = request_id or uuid.uuid4().hex
+
+    async def _create_job(
+        self, language: str, code: str, extra: dict[str, Any]
+    ) -> Optional[Any]:
+        if self.repo is None or not self.user_id:
+            return None
+        try:
+            return await self.repo.create_sent(
+                user_id=self.user_id,
+                question_id=self.question_id,
+                language=language,
+                code_hash=hash_content(code),
+                idempotency_key=uuid.uuid4().hex,
+                request_payload={"language": language, **extra},
+                request_id=self.request_id,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("Failed to persist execution sent state", exc_info=True)
+            return None
+
+    async def execute(
+        self, language: str, code: str, stdin: str = "", version: Optional[str] = None
+    ) -> ExecutionResult:
+        job = await self._create_job(language, code, {"stdin": stdin})
+        try:
+            result = await self.inner.execute(
+                language=language, code=code, stdin=stdin, version=version
+            )
+        except Exception as exc:  # noqa: BLE001
+            if job is not None and self.repo is not None:
+                try:
+                    await self.repo.mark_failed(
+                        job.id,
+                        error_code=type(exc).__name__[:50],
+                        error_message=str(exc)[:2000],
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "Failed to persist execution failed state", exc_info=True
+                    )
+            raise
+        if job is not None and self.repo is not None:
+            try:
+                await self.repo.mark_executed(
+                    job.id,
+                    response_payload={
+                        "stdout": result.stdout,
+                        "stderr": result.stderr,
+                        "exit_code": result.exit_code,
+                    },
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to persist execution completed state", exc_info=True
+                )
+        return result
+
+    async def evaluate_suite(
+        self, language: str, code: str, test_cases: List[dict]
+    ) -> List[TestCaseResult]:
+        job = await self._create_job(
+            language, code, {"test_cases_count": len(test_cases)}
+        )
+        try:
+            results = await self.inner.evaluate_suite(
+                language=language, code=code, test_cases=test_cases
+            )
+        except Exception as exc:  # noqa: BLE001
+            if job is not None and self.repo is not None:
+                try:
+                    await self.repo.mark_failed(
+                        job.id,
+                        error_code=type(exc).__name__[:50],
+                        error_message=str(exc)[:2000],
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "Failed to persist execution suite failed state",
+                        exc_info=True,
+                    )
+            raise
+        if job is not None and self.repo is not None:
+            try:
+                await self.repo.mark_executed(
+                    job.id,
+                    test_results=[
+                        {
+                            "index": r.index,
+                            "passed": r.passed,
+                            "hidden": r.hidden,
+                        }
+                        for r in results
+                    ],
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to persist execution suite completed state",
+                    exc_info=True,
+                )
+        return results
+
+    async def get_runtimes(self) -> List[dict]:
+        return await self.inner.get_runtimes()
+
+    def validate_code(self, language: str, code: str) -> dict:
+        return self.inner.validate_code(language=language, code=code)

--- a/backend/app/services/submit_grading_service.py
+++ b/backend/app/services/submit_grading_service.py
@@ -1,0 +1,75 @@
+"""Submit grading with durable sent/submitted/failed state.
+
+Thin orchestration over the submission repository and a code executor:
+persist sent before grading so executor crashes still leave an auditable
+row, then transition to graded/failed. Follows the layered architecture:
+API -> service -> repository ports -> SQL implementations.
+"""
+
+import logging
+from typing import Any, Optional, Sequence
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.submission_schemas import Submission, SubmissionIn
+from app.repositories.sql_submission_repository import SqlSubmissionRepository
+
+logger = logging.getLogger(__name__)
+
+
+def _error_signature(results: Sequence[Any]) -> Optional[str]:
+    for r in results:
+        passed = getattr(r, "passed", False)
+        if not passed:
+            expected = getattr(r, "expected", "")
+            actual = getattr(r, "actual", "")
+            return f"expected {expected!r}, got {actual!r}"[:255]
+    return None
+
+
+async def grade_submission_with_state(
+    *,
+    db: AsyncSession,
+    executor: Any,
+    user_id: str,
+    question_id: str,
+    code: str,
+    language: str,
+    test_cases: Optional[list[dict]] = None,
+) -> Submission:
+    """Grade one submission with sent -> graded/failed persistence.
+
+    The sent row is committed before the executor runs, so a crash still
+    leaves state. Executor exceptions transition the row to failed and are
+    swallowed into the returned row (callers decide the HTTP mapping).
+    """
+    repo = SqlSubmissionRepository(db)
+    sent = await repo.create_sent(
+        user_id=user_id,
+        submission=SubmissionIn(
+            question_id=question_id,
+            code=code,
+            language=language,
+            passed=False,
+        ),
+    )
+    try:
+        results = await executor.evaluate_suite(
+            language=language,
+            code=code,
+            test_cases=test_cases or [],
+        )
+    except Exception:  # noqa: BLE001 - executor failure is state, not raise
+        logger.warning(
+            "Grading executor failed; submission kept as failed", exc_info=True
+        )
+        return await repo.mark_failed(sent.id)
+
+    passed = bool(results) and all(getattr(r, "passed", False) for r in results)
+    # Empty suite cannot prove correctness; keep prior submit.py semantics
+    # (passed=False when no results) by treating empty as not passed.
+    if not results:
+        passed = False
+    return await repo.mark_graded(
+        sent.id, passed=passed, error_signature=_error_signature(results)
+    )

--- a/backend/tests/integration/test_adapter_state_audit.py
+++ b/backend/tests/integration/test_adapter_state_audit.py
@@ -1,0 +1,247 @@
+"""Integration tests for adapter-state audit endpoints.
+
+Covers GET /api/coach/interactions, GET /api/run/jobs and
+GET /api/submissions/{id} — the read side of sent/submitted/failed
+persistence. All routes require auth and are scoped to the caller.
+"""
+
+from contextlib import contextmanager
+
+import pytest
+
+from app.main import app
+
+
+@contextmanager
+def mock_auth(user_id="test-id"):
+    from app.api.auth_deps import get_current_user
+    from app.models.auth_schemas import UserResponse
+
+    async def override_get_current_user():
+        return UserResponse(
+            id=user_id,
+            username="testuser",
+            email="test@example.com",
+            is_active=True,
+            created_at="2025-01-01T00:00:00Z",
+            plan="free",
+        )
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+async def _seed_user_and_question(test_db, user_id="test-id"):
+    from datetime import datetime, timezone
+
+    from sqlalchemy import text
+
+    now = datetime.now(timezone.utc)
+    await test_db.execute(
+        text(
+            "INSERT INTO users "
+            "(id, username, email, hashed_password, created_at, is_active, "
+            " plan, role) "
+            "VALUES (:uid, 'testuser', 'test@example.com', 'x', :ts, 1, "
+            " 'free', 'user')"
+        ),
+        {"uid": user_id, "ts": now},
+    )
+    await test_db.execute(
+        text(
+            "INSERT INTO questions "
+            "(id, title, difficulty, category, company_tags, description, "
+            " starter_code, examples, test_cases, constraints, hints, is_interactive) "
+            "VALUES ('test-question', 'Test', 'easy', 'arrays', '[]', 'desc', "
+            " '{}', '[]', '[]', '[]', '[]', 0)"
+        )
+    )
+    await test_db.commit()
+
+
+@pytest.fixture
+def mock_provider():
+    from tests.fixtures.mock_coaching_provider import MockCoachingProvider
+
+    return MockCoachingProvider()
+
+
+@pytest.mark.asyncio
+async def test_coach_interactions_audit_lists_own_rows(
+    async_client, test_db, mock_provider
+):
+    import uuid
+
+    from app.api.coach import get_coaching_provider
+    from app.repositories.sql_coaching_interaction_repository import (
+        SqlCoachingInteractionRepository,
+    )
+
+    await _seed_user_and_question(test_db)
+    repo = SqlCoachingInteractionRepository(test_db)
+    row = await repo.create_sent(
+        user_id="test-id",
+        question_id="test-question",
+        mode="hint",
+        language="python",
+        problem_hash="ph",
+        code_hash="ch",
+        idempotency_key=f"idem-{uuid.uuid4().hex}",
+        request_payload={"mode": "hint"},
+    )
+    assert row.status == "sent"
+
+    app.dependency_overrides[get_coaching_provider] = lambda: mock_provider
+    try:
+        with mock_auth():
+            response = await async_client.get("/api/coach/interactions?limit=10")
+    finally:
+        app.dependency_overrides.pop(get_coaching_provider, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] >= 1
+    assert any(i["id"] == row.id for i in data["interactions"])
+    assert all(i["user_id"] == "test-id" for i in data["interactions"])
+
+
+@pytest.mark.asyncio
+async def test_run_jobs_audit_and_submission_status(
+    async_client, test_db, mock_provider
+):
+    import uuid
+
+    from app.api.coach import get_coaching_provider
+    from app.api.dependencies import get_question_repo
+    from app.repositories.sql_execution_job_repository import (
+        SqlExecutionJobRepository,
+    )
+
+    await _seed_user_and_question(test_db)
+
+    class MockRepo:
+        async def get_by_id(self, question_id):
+            if question_id == "test-question":
+                from app.models.schemas import (
+                    Difficulty,
+                    Example,
+                    Question,
+                    StarterCode,
+                    TestCase,
+                )
+
+                return Question(
+                    id="test-question",
+                    title="Test",
+                    difficulty=Difficulty.EASY,
+                    category="arrays",
+                    description="Test",
+                    starter=StarterCode(
+                        python="def solve():\n    pass",
+                        javascript="function solve() {}",
+                        java="class Solution { public static void solve() {} }",
+                    ),
+                    examples=[Example(input="1", output="1")],
+                    test_cases=[TestCase(input="1", expected_output="1", hidden=False)],
+                )
+            return None
+
+    class MockExec:
+        async def execute(self, language, code, stdin="", version=None):
+            from app.ports.code_executor import ExecutionResult
+
+            return ExecutionResult(stdout="ok\n", exit_code=0)
+
+        async def evaluate_suite(self, language, code, test_cases):
+            from app.ports.code_executor import TestCaseResult
+
+            return [
+                TestCaseResult(
+                    index=1,
+                    passed=True,
+                    input="1",
+                    expected="1",
+                    actual="1",
+                    hidden=False,
+                )
+            ]
+
+        async def get_runtimes(self):
+            return []
+
+    from app.api.dependencies import get_executor
+
+    app.dependency_overrides[get_question_repo] = lambda: MockRepo()
+    app.dependency_overrides[get_executor] = lambda: MockExec()
+    app.dependency_overrides[get_coaching_provider] = lambda: mock_provider
+    try:
+        with mock_auth():
+            # Generate one coaching row + one graded submission via the API.
+            coach = await async_client.post(
+                "/api/coach/",
+                json={
+                    "problem": "Add one",
+                    "code": "def solve():\n    pass",
+                    "language": "python",
+                    "message": "hint?",
+                    "mode": "hint",
+                    "difficulty": "easy",
+                },
+            )
+            assert coach.status_code == 200
+            submit = await async_client.post(
+                "/api/submit/",
+                json={
+                    "question_id": "test-question",
+                    "code": "x",
+                    "language": "python",
+                },
+            )
+            assert submit.status_code == 200
+            # Seed one execution job directly (run uses live Piston here).
+            jobs = SqlExecutionJobRepository(test_db)
+            job = await jobs.create_sent(
+                user_id="test-id",
+                question_id="test-question",
+                language="python",
+                code_hash="ch",
+                idempotency_key=f"idem-{uuid.uuid4().hex}",
+                request_payload={},
+            )
+            got_jobs = await async_client.get("/api/run/jobs?limit=10")
+            history = await async_client.get("/api/submissions/me?limit=10")
+    finally:
+        app.dependency_overrides.pop(get_question_repo, None)
+        app.dependency_overrides.pop(get_executor, None)
+        app.dependency_overrides.pop(get_coaching_provider, None)
+
+    assert got_jobs.status_code == 200
+    assert any(j["id"] == job.id for j in got_jobs.json()["jobs"])
+    assert history.status_code == 200
+    sub_id = history.json()["submissions"][0]["id"]
+    with mock_auth():
+        one = await async_client.get(f"/api/submissions/{sub_id}")
+    assert one.status_code == 200
+    assert one.json()["status"] == "graded"
+
+
+@pytest.mark.asyncio
+async def test_audit_endpoints_require_auth(async_client, test_db):
+    for path in (
+        "/api/coach/interactions",
+        "/api/run/jobs",
+        "/api/submissions/me",
+    ):
+        response = await async_client.get(path)
+        assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_submission_status_missing_returns_404(async_client, test_db):
+    await _seed_user_and_question(test_db)
+    with mock_auth():
+        response = await async_client.get("/api/submissions/does-not-exist")
+    assert response.status_code == 404

--- a/backend/tests/unit/test_adapter_state_persistence.py
+++ b/backend/tests/unit/test_adapter_state_persistence.py
@@ -1,0 +1,134 @@
+"""RED: adapter state persistence — sent/submitted/failed must be durable.
+
+Covers the system-design contract from
+Docs/plans/2026-09-03-adapter-state-persistence.md:
+- every coaching intent persists sent -> completed/failed
+- every execution intent persists sent -> executed/failed
+- every submit persists sent before grading, then graded/failed
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def _ids(test_db):
+    from app.models.auth_schemas import UserInDB
+    from app.repositories.sql_user_repository import SqlUserRepository
+    from sqlalchemy import text
+
+    uid = str(uuid.uuid4())
+    await SqlUserRepository(test_db).add(
+        UserInDB(
+            id=uid,
+            username=f"adapter{uid[:8]}",
+            email=f"adapter{uid[:8]}@example.com",
+            hashed_password="hash",
+            created_at=datetime.now(timezone.utc),
+            is_active=True,
+        )
+    )
+    await test_db.commit()
+    qid = f"q-adapter-{uid[:8]}"
+    await test_db.execute(
+        text(
+            "INSERT INTO questions "
+            "(id, title, difficulty, category, company_tags, description, "
+            " starter_code, examples, test_cases, constraints, hints, is_interactive) "
+            "VALUES (:id, 'Test Q', 'easy', 'arrays', '[]', 'desc', '{}', '[]', "
+            "'[]', '[]', '[]', 0)"
+        ),
+        {"id": qid},
+    )
+    await test_db.commit()
+    return uid, qid
+
+
+class TestAdapterStatePersistence:
+    async def test_submission_supports_sent_status(self, test_db, _ids):
+        from app.repositories.sql_submission_repository import (
+            SqlSubmissionRepository,
+        )
+        from app.models.submission_schemas import SubmissionIn
+
+        user_id, question_id = _ids
+        repo = SqlSubmissionRepository(test_db)
+        sent = await repo.create_sent(
+            user_id=user_id,
+            submission=SubmissionIn(
+                question_id=question_id,
+                code="print('hi')",
+                language="python",
+                passed=False,
+            ),
+        )
+        assert sent.status == "sent"
+
+        graded = await repo.mark_graded(sent.id, passed=True, error_signature=None)
+        assert graded.status == "graded"
+        assert graded.passed is True
+
+    async def test_submit_persists_failed_when_executor_raises(self, test_db, _ids):
+        from app.services.submit_grading_service import grade_submission_with_state
+
+        user_id, question_id = _ids
+
+        class _Boom:
+            async def evaluate_suite(self, language, code, test_cases):
+                raise RuntimeError("piston down")
+
+        result = await grade_submission_with_state(
+            db=test_db,
+            executor=_Boom(),
+            user_id=user_id,
+            question_id=question_id,
+            code="print('hi')",
+            language="python",
+        )
+        assert result.status == "failed"
+
+    async def test_coaching_interaction_sent_to_completed(self, test_db, _ids):
+        from app.repositories.sql_coaching_interaction_repository import (
+            SqlCoachingInteractionRepository,
+        )
+
+        user_id, question_id = _ids
+        repo = SqlCoachingInteractionRepository(test_db)
+        interaction = await repo.create_sent(
+            user_id=user_id,
+            question_id=question_id,
+            mode="hint",
+            language="python",
+            problem_hash="ph",
+            code_hash="ch",
+            idempotency_key=f"idem-{uuid.uuid4().hex}",
+            request_payload={"problem": "p"},
+        )
+        assert interaction.status == "sent"
+        done = await repo.mark_completed(
+            interaction.id, response_payload={"summary": "ok"}
+        )
+        assert done.status == "completed"
+
+    async def test_execution_job_sent_to_failed(self, test_db, _ids):
+        from app.repositories.sql_execution_job_repository import (
+            SqlExecutionJobRepository,
+        )
+
+        user_id, question_id = _ids
+        repo = SqlExecutionJobRepository(test_db)
+        job = await repo.create_sent(
+            user_id=user_id,
+            question_id=question_id,
+            language="python",
+            code_hash="ch",
+            idempotency_key=f"idem-{uuid.uuid4().hex}",
+            request_payload={"code": "print('hi')"},
+        )
+        assert job.status == "sent"
+        failed = await repo.mark_failed(
+            job.id, error_code="TIMEOUT", error_message="piston timeout"
+        )
+        assert failed.status == "failed"

--- a/backend/tests/unit/test_adapter_state_recovery.py
+++ b/backend/tests/unit/test_adapter_state_recovery.py
@@ -1,0 +1,150 @@
+"""RED: stale sent-state recovery must flip stuck rows to terminal states.
+
+A crashed process can leave coaching/execution/submission rows in sent
+past the recovery window. The worker marks them timeout/failed so they
+never stay stuck and remain observable.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def _ids(test_db):
+    from app.models.auth_schemas import UserInDB
+    from app.repositories.sql_user_repository import SqlUserRepository
+    from sqlalchemy import text
+
+    uid = str(uuid.uuid4())
+    await SqlUserRepository(test_db).add(
+        UserInDB(
+            id=uid,
+            username=f"rec{uid[:8]}",
+            email=f"rec{uid[:8]}@example.com",
+            hashed_password="hash",
+            created_at=datetime.now(timezone.utc),
+            is_active=True,
+        )
+    )
+    await test_db.commit()
+    qid = f"q-rec-{uid[:8]}"
+    await test_db.execute(
+        text(
+            "INSERT INTO questions "
+            "(id, title, difficulty, category, company_tags, description, "
+            " starter_code, examples, test_cases, constraints, hints, is_interactive) "
+            "VALUES (:id, 'Test Q', 'easy', 'arrays', '[]', 'desc', '{}', '[]', "
+            "'[]', '[]', '[]', 0)"
+        ),
+        {"id": qid},
+    )
+    await test_db.commit()
+    return uid, qid
+
+
+async def _backdate(test_db, table: str, row_id: str, days: int = 1):
+    from sqlalchemy import text
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    await test_db.execute(
+        text(f"UPDATE {table} SET created_at=:ts WHERE id=:id"),
+        {"ts": cutoff, "id": row_id},
+    )
+    await test_db.commit()
+
+
+class TestStaleRecovery:
+    async def test_recovers_stale_coaching_sent(self, test_db, _ids):
+        from app.repositories.sql_coaching_interaction_repository import (
+            SqlCoachingInteractionRepository,
+        )
+        from app.services.adapter_state_recovery import recover_stale_adapter_state
+
+        user_id, question_id = _ids
+        repo = SqlCoachingInteractionRepository(test_db)
+        stale = await repo.create_sent(
+            user_id=user_id,
+            question_id=question_id,
+            mode="hint",
+            language="python",
+            problem_hash="ph",
+            code_hash="ch",
+            idempotency_key=f"idem-{uuid.uuid4().hex}",
+            request_payload={},
+        )
+        fresh = await repo.create_sent(
+            user_id=user_id,
+            question_id=question_id,
+            mode="hint",
+            language="python",
+            problem_hash="ph",
+            code_hash="ch",
+            idempotency_key=f"idem-{uuid.uuid4().hex}",
+            request_payload={},
+        )
+        done = await repo.mark_completed(stale.id, response_payload={"ok": True})
+        assert done.status == "completed"
+        await _backdate(test_db, "coaching_interactions", stale.id)
+        # Re-create stale as sent (completed row must stay untouched).
+        stale2 = await repo.create_sent(
+            user_id=user_id,
+            question_id=question_id,
+            mode="hint",
+            language="python",
+            problem_hash="ph",
+            code_hash="ch",
+            idempotency_key=f"idem-{uuid.uuid4().hex}",
+            request_payload={},
+        )
+        await _backdate(test_db, "coaching_interactions", stale2.id)
+
+        counts = await recover_stale_adapter_state(
+            test_db, older_than_minutes=60, limit=100
+        )
+
+        assert counts["coaching_interactions"] >= 1
+        recovered = await repo.get(stale2.id)
+        assert recovered is not None and recovered.status == "timeout"
+        untouched = await repo.get(fresh.id)
+        assert untouched is not None and untouched.status == "sent"
+
+    async def test_recovers_stale_execution_and_submission(self, test_db, _ids):
+        from app.models.submission_schemas import SubmissionIn
+        from app.repositories.sql_execution_job_repository import (
+            SqlExecutionJobRepository,
+        )
+        from app.repositories.sql_submission_repository import (
+            SqlSubmissionRepository,
+        )
+        from app.services.adapter_state_recovery import recover_stale_adapter_state
+
+        user_id, question_id = _ids
+        jobs = SqlExecutionJobRepository(test_db)
+        subs = SqlSubmissionRepository(test_db)
+        job = await jobs.create_sent(
+            user_id=user_id,
+            question_id=question_id,
+            language="python",
+            code_hash="ch",
+            idempotency_key=f"idem-{uuid.uuid4().hex}",
+            request_payload={},
+        )
+        sent = await subs.create_sent(
+            user_id=user_id,
+            submission=SubmissionIn(
+                question_id=question_id, code="x", language="python", passed=False
+            ),
+        )
+        await _backdate(test_db, "execution_jobs", job.id)
+        await _backdate(test_db, "submissions", sent.id)
+
+        counts = await recover_stale_adapter_state(
+            test_db, older_than_minutes=60, limit=100
+        )
+
+        assert counts["execution_jobs"] >= 1
+        assert counts["submissions"] >= 1
+        assert (await jobs.get(job.id)).status == "timeout"  # type: ignore[union-attr]
+        assert (await subs.get(sent.id)).status == "failed"  # type: ignore[union-attr]


### PR DESCRIPTION
Implements Supabase-backed state machines so adapter calls survive failures.

- schema: `submissions` gains `status` (`sent/submitted/graded/failed`, default `graded` for legacy), `idempotency_key`, `execution_job_id`, `request_id`; new `coaching_interactions` and `execution_jobs` with `uq_*_user_idempotency` and `ix_*_user_status_created` (`b4c5d6e7f8a1` revises `a3b4c5d6e7f8`, PG-only, idempotent)
- ports: `CoachingInteractionRepository`, `ExecutionJobRepository`; `SubmissionRepository` gains `create_sent/mark_graded/mark_failed/get/list_stale` with typed `datetime`
- repos: `sql_*` with `rollback()` on commit failure and `list_stale(sent/submitted)`
- services: `coaching_adapter.hash_content`/`CoachingAdapter`, `execution_adapter`, `submit_grading_service.grade_submission_with_state`, `adapter_state_recovery.recover_stale_adapter_state` (local sent→timeout/failed only)
- APIs: `POST /api/submit` (sent before grading), `POST /api/run` (execution jobs), `POST /api/coach` (coaching interactions, new `Query` import) + audits `GET /api/coach/interactions`, `GET /api/run/jobs`, `GET /api/submissions/{id}` (owner-scoped 404)
- TDD: `test_adapter_state_persistence` 4/4, `test_adapter_state_recovery` 2/2, `test_adapter_state_audit` 4/4, `sql_submission_repository` 4/4, submit/submissions/coach integration + migrations 7/7 — 66 passed slice; ruff clean; warm-cache hunks kept unstaged (coach warm hunk excluded via index plumbing)

Production checks: hot paths degrade open, no secrets in rows/logs, FK-safe rollbacks, Supabase-only, no contract breaks.

Closes: n/a (adapter-state slice)