### PR TITLE
feat(skill-graph): reclassify supporting skills out of roadmap track

### DIFF
--- a/backend/app/models/skill_graph_schemas.py
+++ b/backend/app/models/skill_graph_schemas.py
@@ -36,6 +36,11 @@ class Trend(str, Enum):
     STABLE = "stable"
 
 
+class SkillKind(str, Enum):
+    ROADMAP = "roadmap"
+    SUPPORTING = "supporting"
+
+
 class Skill(BaseModel):
     slug: str = Field(..., description="Unique skill slug")
     name: str = Field(..., description="Human-readable skill name")
@@ -43,6 +48,10 @@ class Skill(BaseModel):
     parent_id: Optional[str] = Field(None, description="Parent skill slug (hierarchy)")
     prerequisite_ids: List[str] = Field(
         default_factory=list, description="Skills that must be mastered first"
+    )
+    kind: SkillKind = Field(
+        default=SkillKind.ROADMAP,
+        description="Roadmap (interview-pattern) vs supporting (cross-cutting)",
     )
 
 

--- a/backend/app/services/skill_graph_service.py
+++ b/backend/app/services/skill_graph_service.py
@@ -23,6 +23,7 @@ from app.services.skill_graph_rules import (
     mastery_for_status,
     recommend,
 )
+from app.services.skill_taxonomy import SUPPORTING_SKILL_SLUGS
 
 
 class SkillGraphService:
@@ -150,11 +151,38 @@ class SkillGraphService:
         ]
         return SkillGraphResponse(skills=summaries, edges=edges)
 
+    async def get_roadmap(
+        self, user_id: str, now: Optional[datetime] = None
+    ) -> SkillGraphResponse:
+        """Roadmap-track graph: supporting skills excluded from progress totals.
+
+        Full per-skill state stays available via ``get_graph`` (analytics /
+        coaching context); this view is what the NeetCode-style roadmap renders.
+        """
+        full = await self.get_graph(user_id, now=now)
+        supporting = set(SUPPORTING_SKILL_SLUGS)
+        roadmap_skills = [s for s in full.skills if s.skill_slug not in supporting]
+        roadmap_edges = [
+            e
+            for e in full.edges
+            if e.source not in supporting and e.target not in supporting
+        ]
+        return SkillGraphResponse(skills=roadmap_skills, edges=roadmap_edges)
+
     async def get_recommendations(
-        self, user_id: str, now: Optional[datetime] = None, limit: int = 5
+        self,
+        user_id: str,
+        now: Optional[datetime] = None,
+        limit: int = 5,
+        include_supporting: bool = False,
     ) -> List[Recommendation]:
         now = now or datetime.now(timezone.utc)
         skills_by_slug, question_skills_by_q = await self._load_taxonomy()
+        if not include_supporting:
+            supporting = set(SUPPORTING_SKILL_SLUGS)
+            skills_by_slug = {
+                slug: s for slug, s in skills_by_slug.items() if slug not in supporting
+            }
         states = await self.repository.get_states(user_id)
 
         skill_names = {slug: s.name for slug, s in skills_by_slug.items()}

--- a/backend/app/services/skill_taxonomy.py
+++ b/backend/app/services/skill_taxonomy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Tuple
 
-from app.models.skill_graph_schemas import QuestionSkill, Skill, SkillStatus
+from app.models.skill_graph_schemas import QuestionSkill, Skill, SkillKind, SkillStatus
 
 # Curated, deterministic skill taxonomy. Parent/child gives hierarchy;
 # prerequisite_ids define ordering that recommendations must respect.
@@ -12,6 +12,7 @@ SKILLS: List[Skill] = [
         slug="programming-fundamentals",
         name="Programming Fundamentals",
         description="Basic syntax, variables, control flow, functions.",
+        kind=SkillKind.SUPPORTING,
     ),
     Skill(
         slug="arrays",
@@ -120,24 +121,28 @@ SKILLS: List[Skill] = [
         name="Debugging",
         description="Reading error output, isolating failure, reproducing bugs.",
         prerequisite_ids=["programming-fundamentals"],
+        kind=SkillKind.SUPPORTING,
     ),
     Skill(
         slug="testing",
         name="Testing",
         description="Edge cases, unit assertions, input/output validation.",
         prerequisite_ids=["programming-fundamentals"],
+        kind=SkillKind.SUPPORTING,
     ),
     Skill(
         slug="time-complexity",
         name="Time Complexity",
         description="Big-O analysis, identifying dominant operations.",
         prerequisite_ids=["programming-fundamentals"],
+        kind=SkillKind.SUPPORTING,
     ),
     Skill(
         slug="space-complexity",
         name="Space Complexity",
         description="Auxiliary memory analysis, in-place vs. extra space.",
         prerequisite_ids=["programming-fundamentals"],
+        kind=SkillKind.SUPPORTING,
     ),
 ]
 
@@ -317,6 +322,28 @@ def _build_question_skills() -> Dict[str, List[QuestionSkill]]:
 
 
 QUESTION_SKILLS: Dict[str, List[QuestionSkill]] = _build_question_skills()
+
+# Roadmap vs supporting track (Issue #134, NeetCode conventions). Supporting
+# skills stay in the DB + event system for analytics/coaching context but are
+# excluded from roadmap ordering, progress totals, and primary recommendations.
+# Derived from Skill.kind so there is a single source of truth; no DB migration
+# needed (seed script upserts taxonomy fields, ORM rows remain kind-agnostic).
+SUPPORTING_SKILL_SLUGS: Tuple[str, ...] = tuple(
+    s.slug for s in SKILLS if s.kind == SkillKind.SUPPORTING
+)
+ROADMAP_SKILL_SLUGS: Tuple[str, ...] = tuple(
+    s.slug for s in SKILLS if s.kind == SkillKind.ROADMAP
+)
+_SUPPORTING_SLUGS: frozenset = frozenset(SUPPORTING_SKILL_SLUGS)
+
+
+def is_roadmap_skill(slug: str) -> bool:
+    return slug not in _SUPPORTING_SLUGS
+
+
+def roadmap_skills() -> List[Skill]:
+    return [s for s in SKILLS if s.kind == SkillKind.ROADMAP]
+
 
 # Alias for analytics plateau rule (plan expects QUESTION_SKILL_MAP) — keeps 109/109 contract.
 QUESTION_SKILL_MAP: Dict[str, List[Tuple[str, float]]] = _QUESTION_SKILL_WEIGHTS

--- a/backend/tests/unit/test_skill_roadmap_tracks.py
+++ b/backend/tests/unit/test_skill_roadmap_tracks.py
@@ -1,0 +1,74 @@
+"""Roadmap vs supporting skill separation (Issue #134).
+
+NeetCode-style roadmap must contain only interview-pattern skills. Supporting
+/ cross-cutting skills stay in the DB + event system for analytics/coaching
+but are excluded from roadmap ordering, progress totals, and primary
+recommendations.
+"""
+
+from app.models.skill_graph_schemas import SkillKind
+from app.services import skill_taxonomy
+
+
+class TestRoadmapSeparation:
+    def test_supporting_slugs_are_exactly_the_five(self):
+        assert set(skill_taxonomy.SUPPORTING_SKILL_SLUGS) == {
+            "programming-fundamentals",
+            "debugging",
+            "testing",
+            "time-complexity",
+            "space-complexity",
+        }
+
+    def test_supporting_skills_carry_supporting_kind(self):
+        by_slug = {s.slug: s for s in skill_taxonomy.SKILLS}
+        for slug in skill_taxonomy.SUPPORTING_SKILL_SLUGS:
+            assert by_slug[slug].kind == SkillKind.SUPPORTING
+
+    def test_roadmap_skills_exclude_supporting(self):
+        roadmap_slugs = {s.slug for s in skill_taxonomy.roadmap_skills()}
+        assert not (roadmap_slugs & set(skill_taxonomy.SUPPORTING_SKILL_SLUGS))
+        # Core interview patterns stay on the roadmap.
+        for slug in ("arrays", "hash-maps", "two-pointers", "graphs"):
+            assert slug in roadmap_slugs
+
+    def test_is_roadmap_skill_helper(self):
+        assert skill_taxonomy.is_roadmap_skill("arrays") is True
+        assert skill_taxonomy.is_roadmap_skill("debugging") is False
+
+
+class TestRoadmapRecommendations:
+    def _repo(self):
+        from tests.simulation.in_memory_repo import InMemorySkillGraphRepository
+
+        from app.services.skill_taxonomy import QUESTION_SKILLS, SKILLS
+
+        repo = InMemorySkillGraphRepository()
+        repo.seed_skills(list(SKILLS))
+        repo.seed_question_skills(
+            [m for mappings in QUESTION_SKILLS.values() for m in mappings]
+        )
+        return repo
+
+    async def _recs(self, include_supporting: bool):
+        from app.services.skill_graph_service import SkillGraphService
+
+        service = SkillGraphService(repository=self._repo())
+        return await service.get_recommendations(
+            "u1", include_supporting=include_supporting
+        )
+
+    def test_default_recommendations_exclude_supporting(self):
+        import asyncio
+
+        recs = asyncio.run(self._recs(include_supporting=False))
+        slugs = {r.skill_slug for r in recs}
+        assert not (slugs & set(skill_taxonomy.SUPPORTING_SKILL_SLUGS))
+
+    def test_opt_in_recommendations_can_include_supporting(self):
+        import asyncio
+
+        recs = asyncio.run(self._recs(include_supporting=True))
+        # Full graph still knows supporting skills; at least the pipeline runs
+        # without error and returns roadmap-first results.
+        assert recs


### PR DESCRIPTION
Reclassifies the 5 cross-cutting skills out of the NeetCode-style DSA roadmap. Additive only, no migration.

Closes #134