### PR TITLE
feat(skill-graph): align taxonomy with NeetCode buckets

### DIFF
--- a/backend/app/models/skill_graph_schemas.py
+++ b/backend/app/models/skill_graph_schemas.py
@@ -36,6 +36,11 @@ class Trend(str, Enum):
     STABLE = "stable"
 
 
+class SkillKind(str, Enum):
+    ROADMAP = "roadmap"
+    SUPPORTING = "supporting"
+
+
 class Skill(BaseModel):
     slug: str = Field(..., description="Unique skill slug")
     name: str = Field(..., description="Human-readable skill name")
@@ -43,6 +48,10 @@ class Skill(BaseModel):
     parent_id: Optional[str] = Field(None, description="Parent skill slug (hierarchy)")
     prerequisite_ids: List[str] = Field(
         default_factory=list, description="Skills that must be mastered first"
+    )
+    kind: SkillKind = Field(
+        default=SkillKind.ROADMAP,
+        description="Roadmap (interview-pattern) vs supporting (cross-cutting)",
     )
 
 

--- a/backend/app/services/skill_graph_service.py
+++ b/backend/app/services/skill_graph_service.py
@@ -23,6 +23,7 @@ from app.services.skill_graph_rules import (
     mastery_for_status,
     recommend,
 )
+from app.services.skill_taxonomy import SUPPORTING_SKILL_SLUGS
 
 
 class SkillGraphService:
@@ -150,11 +151,38 @@ class SkillGraphService:
         ]
         return SkillGraphResponse(skills=summaries, edges=edges)
 
+    async def get_roadmap(
+        self, user_id: str, now: Optional[datetime] = None
+    ) -> SkillGraphResponse:
+        """Roadmap-track graph: supporting skills excluded from progress totals.
+
+        Full per-skill state stays available via ``get_graph`` (analytics /
+        coaching context); this view is what the NeetCode-style roadmap renders.
+        """
+        full = await self.get_graph(user_id, now=now)
+        supporting = set(SUPPORTING_SKILL_SLUGS)
+        roadmap_skills = [s for s in full.skills if s.skill_slug not in supporting]
+        roadmap_edges = [
+            e
+            for e in full.edges
+            if e.source not in supporting and e.target not in supporting
+        ]
+        return SkillGraphResponse(skills=roadmap_skills, edges=roadmap_edges)
+
     async def get_recommendations(
-        self, user_id: str, now: Optional[datetime] = None, limit: int = 5
+        self,
+        user_id: str,
+        now: Optional[datetime] = None,
+        limit: int = 5,
+        include_supporting: bool = False,
     ) -> List[Recommendation]:
         now = now or datetime.now(timezone.utc)
         skills_by_slug, question_skills_by_q = await self._load_taxonomy()
+        if not include_supporting:
+            supporting = set(SUPPORTING_SKILL_SLUGS)
+            skills_by_slug = {
+                slug: s for slug, s in skills_by_slug.items() if slug not in supporting
+            }
         states = await self.repository.get_states(user_id)
 
         skill_names = {slug: s.name for slug, s in skills_by_slug.items()}

--- a/backend/app/services/skill_taxonomy.py
+++ b/backend/app/services/skill_taxonomy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Tuple
 
-from app.models.skill_graph_schemas import QuestionSkill, Skill, SkillStatus
+from app.models.skill_graph_schemas import QuestionSkill, Skill, SkillKind, SkillStatus
 
 # Curated, deterministic skill taxonomy. Parent/child gives hierarchy;
 # prerequisite_ids define ordering that recommendations must respect.
@@ -12,6 +12,7 @@ SKILLS: List[Skill] = [
         slug="programming-fundamentals",
         name="Programming Fundamentals",
         description="Basic syntax, variables, control flow, functions.",
+        kind=SkillKind.SUPPORTING,
     ),
     Skill(
         slug="arrays",
@@ -120,24 +121,28 @@ SKILLS: List[Skill] = [
         name="Debugging",
         description="Reading error output, isolating failure, reproducing bugs.",
         prerequisite_ids=["programming-fundamentals"],
+        kind=SkillKind.SUPPORTING,
     ),
     Skill(
         slug="testing",
         name="Testing",
         description="Edge cases, unit assertions, input/output validation.",
         prerequisite_ids=["programming-fundamentals"],
+        kind=SkillKind.SUPPORTING,
     ),
     Skill(
         slug="time-complexity",
         name="Time Complexity",
         description="Big-O analysis, identifying dominant operations.",
         prerequisite_ids=["programming-fundamentals"],
+        kind=SkillKind.SUPPORTING,
     ),
     Skill(
         slug="space-complexity",
         name="Space Complexity",
         description="Auxiliary memory analysis, in-place vs. extra space.",
         prerequisite_ids=["programming-fundamentals"],
+        kind=SkillKind.SUPPORTING,
     ),
 ]
 
@@ -317,6 +322,28 @@ def _build_question_skills() -> Dict[str, List[QuestionSkill]]:
 
 
 QUESTION_SKILLS: Dict[str, List[QuestionSkill]] = _build_question_skills()
+
+# Roadmap vs supporting track (Issue #134, NeetCode conventions). Supporting
+# skills stay in the DB + event system for analytics/coaching context but are
+# excluded from roadmap ordering, progress totals, and primary recommendations.
+# Derived from Skill.kind so there is a single source of truth; no DB migration
+# needed (seed script upserts taxonomy fields, ORM rows remain kind-agnostic).
+SUPPORTING_SKILL_SLUGS: Tuple[str, ...] = tuple(
+    s.slug for s in SKILLS if s.kind == SkillKind.SUPPORTING
+)
+ROADMAP_SKILL_SLUGS: Tuple[str, ...] = tuple(
+    s.slug for s in SKILLS if s.kind == SkillKind.ROADMAP
+)
+_SUPPORTING_SLUGS: frozenset = frozenset(SUPPORTING_SKILL_SLUGS)
+
+
+def is_roadmap_skill(slug: str) -> bool:
+    return slug not in _SUPPORTING_SLUGS
+
+
+def roadmap_skills() -> List[Skill]:
+    return [s for s in SKILLS if s.kind == SkillKind.ROADMAP]
+
 
 # Alias for analytics plateau rule (plan expects QUESTION_SKILL_MAP) — keeps 109/109 contract.
 QUESTION_SKILL_MAP: Dict[str, List[Tuple[str, float]]] = _QUESTION_SKILL_WEIGHTS

--- a/backend/app/services/skill_taxonomy.py
+++ b/backend/app/services/skill_taxonomy.py
@@ -99,10 +99,22 @@ SKILLS: List[Skill] = [
         prerequisite_ids=["trees"],
     ),
     Skill(
-        slug="dynamic-programming",
-        name="Dynamic Programming",
-        description="Overlapping subproblems, memoization, tabulation.",
+        slug="tries",
+        name="Tries",
+        description="Prefix trees, word search, autocomplete.",
+        prerequisite_ids=["trees"],
+    ),
+    Skill(
+        slug="dp-1d",
+        name="1-D Dynamic Programming",
+        description="Linear subproblems, memoization over indices.",
         prerequisite_ids=["recursion"],
+    ),
+    Skill(
+        slug="dp-2d",
+        name="2-D Dynamic Programming",
+        description="Grid and string-table subproblems, two-dimensional tables.",
+        prerequisite_ids=["dp-1d"],
     ),
     Skill(
         slug="greedy",
@@ -111,9 +123,21 @@ SKILLS: List[Skill] = [
         prerequisite_ids=["arrays"],
     ),
     Skill(
+        slug="intervals",
+        name="Intervals",
+        description="Merging and scheduling overlapping ranges.",
+        prerequisite_ids=["sorting"],
+    ),
+    Skill(
         slug="bit-manipulation",
         name="Bit Manipulation",
         description="XOR tricks, masks, two's-complement arithmetic.",
+        prerequisite_ids=["programming-fundamentals"],
+    ),
+    Skill(
+        slug="math-geometry",
+        name="Math & Geometry",
+        description="Arithmetic tricks, combinatorics, coordinate geometry.",
         prerequisite_ids=["programming-fundamentals"],
     ),
     Skill(
@@ -168,8 +192,8 @@ _QUESTION_SKILL_WEIGHTS: Dict[str, List[Tuple[str, float]]] = {
     "first-missing-positive": [("arrays", 0.7), ("hash-maps", 0.3)],
     "product-of-array-except-self": [("arrays", 0.8), ("time-complexity", 0.2)],
     "missing-number": [("arrays", 0.6), ("bit-manipulation", 0.4)],
-    "merge-intervals": [("sorting", 0.5), ("arrays", 0.5)],
-    "non-overlapping-intervals": [("greedy", 0.7), ("sorting", 0.3)],
+    "merge-intervals": [("intervals", 0.5), ("arrays", 0.5)],
+    "non-overlapping-intervals": [("greedy", 0.7), ("intervals", 0.3)],
     # --- Two Pointers -----------------------------------------------------
     "reverse-string": [("strings", 0.5), ("two-pointers", 0.5)],
     "valid-palindrome": [("two-pointers", 0.7), ("strings", 0.3)],
@@ -203,9 +227,9 @@ _QUESTION_SKILL_WEIGHTS: Dict[str, List[Tuple[str, float]]] = {
     ],
     "min-stack": [("stacks-queues", 0.8), ("arrays", 0.2)],
     "daily-temperatures": [("stacks-queues", 0.8), ("arrays", 0.2)],
-    "car-fleet": [("stacks-queues", 0.6), ("sorting", 0.4)],
+    "car-fleet": [("stacks-queues", 0.6), ("intervals", 0.4)],
     "largest-rectangle-in-histogram": [("stacks-queues", 0.8), ("two-pointers", 0.2)],
-    "longest-valid-parentheses": [("stacks-queues", 0.7), ("dynamic-programming", 0.3)],
+    "longest-valid-parentheses": [("stacks-queues", 0.7), ("dp-1d", 0.3)],
     # --- Heaps & Priority Queues -------------------------------------------
     "top-k-frequent-elements": [("heaps", 0.7), ("hash-maps", 0.3)],
     "k-closest-points-to-origin": [("heaps", 0.7), ("sorting", 0.3)],
@@ -240,7 +264,7 @@ _QUESTION_SKILL_WEIGHTS: Dict[str, List[Tuple[str, float]]] = {
     "validate-binary-search-tree": [("trees", 0.8), ("recursion", 0.2)],
     "kth-smallest-element-in-a-bst": [("trees", 0.8), ("searching", 0.2)],
     "lowest-common-ancestor-of-a-binary-tree": [("trees", 0.8), ("recursion", 0.2)],
-    "binary-tree-maximum-path-sum": [("trees", 0.8), ("dynamic-programming", 0.2)],
+    "binary-tree-maximum-path-sum": [("trees", 0.8), ("dp-1d", 0.2)],
     # --- Graphs ----------------------------------------------------------------
     "number-of-islands": [("graphs", 1.0)],
     "clone-graph": [("graphs", 0.8), ("hash-maps", 0.2)],
@@ -249,16 +273,17 @@ _QUESTION_SKILL_WEIGHTS: Dict[str, List[Tuple[str, float]]] = {
     "word-ladder": [("graphs", 0.7), ("searching", 0.3)],
     "word-search": [("backtracking", 0.8), ("graphs", 0.2)],
     "e42b2609-8b2c-49a0-9fa3-b7145df07bc3": [("graphs", 0.6), ("heaps", 0.4)],
-    # --- Dynamic Programming -----------------------------------------------------
-    "climbing-stairs": [("dynamic-programming", 0.8), ("recursion", 0.2)],
-    "coin-change": [("dynamic-programming", 1.0)],
-    "house-robber": [("dynamic-programming", 1.0)],
-    "word-break": [("dynamic-programming", 0.8), ("strings", 0.2)],
-    "edit-distance": [("dynamic-programming", 0.8), ("strings", 0.2)],
-    "decode-ways": [("dynamic-programming", 0.8), ("strings", 0.2)],
-    "longest-increasing-subsequence": [("dynamic-programming", 0.9), ("arrays", 0.1)],
-    "burst-balloons": [("dynamic-programming", 0.9), ("arrays", 0.1)],
-    "maximum-product-subarray": [("dynamic-programming", 0.7), ("arrays", 0.3)],
+    # --- 1-D Dynamic Programming -------------------------------------------------
+    "climbing-stairs": [("dp-1d", 0.8), ("recursion", 0.2)],
+    "coin-change": [("dp-1d", 1.0)],
+    "house-robber": [("dp-1d", 1.0)],
+    "word-break": [("dp-1d", 0.8), ("strings", 0.2)],
+    "decode-ways": [("dp-1d", 0.8), ("strings", 0.2)],
+    "longest-increasing-subsequence": [("dp-1d", 0.9), ("arrays", 0.1)],
+    "maximum-product-subarray": [("dp-1d", 0.7), ("arrays", 0.3)],
+    # --- 2-D Dynamic Programming -------------------------------------------------
+    "edit-distance": [("dp-2d", 0.8), ("strings", 0.2)],
+    "burst-balloons": [("dp-2d", 0.9), ("arrays", 0.1)],
     # --- Backtracking --------------------------------------------------------------
     "permutations": [("backtracking", 0.9), ("recursion", 0.1)],
     "subsets": [("backtracking", 0.9), ("recursion", 0.1)],
@@ -293,19 +318,19 @@ _QUESTION_SKILL_WEIGHTS: Dict[str, List[Tuple[str, float]]] = {
     ],
     "6d7e8f9a-0b1c-4d2e-3f4a-5b6c7d8e9f0a": [("strings", 0.7), ("two-pointers", 0.3)],
     "1f3e5d7c-9b8a-4c6d-0e2f-4a5b6c7d8e9f": [
-        ("dynamic-programming", 0.8),
+        ("dp-1d", 0.8),
         ("strings", 0.2),
     ],
     "8c3d2e4f-6a5b-4f7c-9d0e-1a2b3c4d5e6f": [
-        ("dynamic-programming", 0.8),
+        ("dp-1d", 0.8),
         ("strings", 0.2),
     ],
     "9e4f5a6b-7c8d-4e9f-0a1b-2c3d4e5f6a7b": [
-        ("dynamic-programming", 0.8),
+        ("dp-1d", 0.8),
         ("strings", 0.2),
     ],
     "4a3f7c1e-5d6b-4e8f-9a0c-2b3d4e5f6a7b": [
-        ("dynamic-programming", 0.7),
+        ("dp-1d", 0.7),
         ("strings", 0.3),
     ],
 }
@@ -343,6 +368,33 @@ def is_roadmap_skill(slug: str) -> bool:
 
 def roadmap_skills() -> List[Skill]:
     return [s for s in SKILLS if s.kind == SkillKind.ROADMAP]
+
+
+# Explicit NeetCode-style bucket order for the roadmap UI. Dict insertion order
+# is not a contract; this tuple is.
+ROADMAP_ORDER: Tuple[str, ...] = (
+    "arrays",
+    "strings",
+    "hash-maps",
+    "two-pointers",
+    "sliding-window",
+    "stacks-queues",
+    "heaps",
+    "recursion",
+    "backtracking",
+    "sorting",
+    "searching",
+    "linked-lists",
+    "trees",
+    "tries",
+    "graphs",
+    "dp-1d",
+    "dp-2d",
+    "greedy",
+    "intervals",
+    "bit-manipulation",
+    "math-geometry",
+)
 
 
 # Alias for analytics plateau rule (plan expects QUESTION_SKILL_MAP) — keeps 109/109 contract.

--- a/backend/tests/simulation/learner_profiles.py
+++ b/backend/tests/simulation/learner_profiles.py
@@ -208,7 +208,7 @@ def profile_many_failed_attempts(user, rng):
         events.append(fail_evt(seq, user, Q_MAX_SUB))
         seq += 1
     expected = {}
-    expect_skill(expected, "dynamic-programming", mastery_ge=0.0)
+    expect_skill(expected, "dp-1d", mastery_ge=0.0)
     return events, expected
 
 
@@ -273,7 +273,7 @@ def profile_ai_diagnosis_dependent(user, rng):
         pass_evt(5, user, Q_MAX_SUB),
     ]
     expected = {}
-    expect_skill(expected, "dynamic-programming", mastery_lt=0.75)
+    expect_skill(expected, "dp-1d", mastery_lt=0.75)
     return events, expected
 
 
@@ -371,7 +371,7 @@ def profile_lucky_guesser(user, rng):
         fail_evt(5, user, Q_MAX_SUB),
     ]
     expected = {}
-    expect_skill(expected, "dynamic-programming", mastery_lt=0.75)
+    expect_skill(expected, "dp-1d", mastery_lt=0.75)
     return events, expected
 
 
@@ -397,14 +397,14 @@ def profile_mixed_skill(user, rng):
         pass_evt(0, user, Q_TWO_SUM),
         pass_evt(1, user, Q_TWO_SUM),
         pass_evt(2, user, Q_TWO_SUM),
-        # Merge-intervals is arrays+sorting; learner is bad at sorting.
+        # Merge-intervals is arrays+intervals; learner is bad at intervals.
         fail_evt(3, user, Q_MERGE, error="wrong_order"),
         fail_evt(4, user, Q_MERGE, error="wrong_order"),
         pass_evt(5, user, Q_MERGE, hints=2),
     ]
     expected = {}
     expect_skill(expected, "hash-maps", mastery_ge=0.2, mastery_lt=0.75)
-    expect_skill(expected, "sorting", errors_ge=2)
+    expect_skill(expected, "intervals", errors_ge=2)
     return events, expected
 
 
@@ -459,9 +459,9 @@ def profile_topic_transfer(user, rng):
     ]
     expected = {}
     # Transfer: two-pointers evidence from reverse-string persists and the
-    # merge-interval practice feeds sorting without resetting anything.
+    # merge-interval practice feeds intervals without resetting anything.
     expect_skill(expected, "two-pointers", mastery_ge=0.2)
-    expect_skill(expected, "sorting", mastery_ge=0.2)
+    expect_skill(expected, "intervals", mastery_ge=0.2)
     return events, expected
 
 

--- a/backend/tests/unit/test_skill_roadmap_tracks.py
+++ b/backend/tests/unit/test_skill_roadmap_tracks.py
@@ -1,0 +1,74 @@
+"""Roadmap vs supporting skill separation (Issue #134).
+
+NeetCode-style roadmap must contain only interview-pattern skills. Supporting
+/ cross-cutting skills stay in the DB + event system for analytics/coaching
+but are excluded from roadmap ordering, progress totals, and primary
+recommendations.
+"""
+
+from app.models.skill_graph_schemas import SkillKind
+from app.services import skill_taxonomy
+
+
+class TestRoadmapSeparation:
+    def test_supporting_slugs_are_exactly_the_five(self):
+        assert set(skill_taxonomy.SUPPORTING_SKILL_SLUGS) == {
+            "programming-fundamentals",
+            "debugging",
+            "testing",
+            "time-complexity",
+            "space-complexity",
+        }
+
+    def test_supporting_skills_carry_supporting_kind(self):
+        by_slug = {s.slug: s for s in skill_taxonomy.SKILLS}
+        for slug in skill_taxonomy.SUPPORTING_SKILL_SLUGS:
+            assert by_slug[slug].kind == SkillKind.SUPPORTING
+
+    def test_roadmap_skills_exclude_supporting(self):
+        roadmap_slugs = {s.slug for s in skill_taxonomy.roadmap_skills()}
+        assert not (roadmap_slugs & set(skill_taxonomy.SUPPORTING_SKILL_SLUGS))
+        # Core interview patterns stay on the roadmap.
+        for slug in ("arrays", "hash-maps", "two-pointers", "graphs"):
+            assert slug in roadmap_slugs
+
+    def test_is_roadmap_skill_helper(self):
+        assert skill_taxonomy.is_roadmap_skill("arrays") is True
+        assert skill_taxonomy.is_roadmap_skill("debugging") is False
+
+
+class TestRoadmapRecommendations:
+    def _repo(self):
+        from tests.simulation.in_memory_repo import InMemorySkillGraphRepository
+
+        from app.services.skill_taxonomy import QUESTION_SKILLS, SKILLS
+
+        repo = InMemorySkillGraphRepository()
+        repo.seed_skills(list(SKILLS))
+        repo.seed_question_skills(
+            [m for mappings in QUESTION_SKILLS.values() for m in mappings]
+        )
+        return repo
+
+    async def _recs(self, include_supporting: bool):
+        from app.services.skill_graph_service import SkillGraphService
+
+        service = SkillGraphService(repository=self._repo())
+        return await service.get_recommendations(
+            "u1", include_supporting=include_supporting
+        )
+
+    def test_default_recommendations_exclude_supporting(self):
+        import asyncio
+
+        recs = asyncio.run(self._recs(include_supporting=False))
+        slugs = {r.skill_slug for r in recs}
+        assert not (slugs & set(skill_taxonomy.SUPPORTING_SKILL_SLUGS))
+
+    def test_opt_in_recommendations_can_include_supporting(self):
+        import asyncio
+
+        recs = asyncio.run(self._recs(include_supporting=True))
+        # Full graph still knows supporting skills; at least the pipeline runs
+        # without error and returns roadmap-first results.
+        assert recs

--- a/backend/tests/unit/test_skill_taxonomy_buckets.py
+++ b/backend/tests/unit/test_skill_taxonomy_buckets.py
@@ -1,0 +1,86 @@
+"""NeetCode bucket alignment (Issue #135).
+
+The roadmap track must expose NeetCode-style buckets: tries, intervals,
+math-geometry, and a 1-D/2-D DP split. The monolithic ``dynamic-programming``
+slug must disappear from both taxonomy and mappings.
+"""
+
+from app.models.skill_graph_schemas import SkillKind
+from app.services import skill_taxonomy
+from app.services.skill_taxonomy import QUESTION_SKILLS, SKILLS
+
+EXPECTED_ORDER = (
+    "arrays",
+    "strings",
+    "hash-maps",
+    "two-pointers",
+    "sliding-window",
+    "stacks-queues",
+    "heaps",
+    "recursion",
+    "backtracking",
+    "sorting",
+    "searching",
+    "linked-lists",
+    "trees",
+    "tries",
+    "graphs",
+    "dp-1d",
+    "dp-2d",
+    "greedy",
+    "intervals",
+    "bit-manipulation",
+    "math-geometry",
+)
+
+
+class TestNeetCodeBuckets:
+    def test_new_roadmap_skills_exist(self):
+        by_slug = {s.slug: s for s in SKILLS}
+        for slug in ("tries", "intervals", "math-geometry", "dp-1d", "dp-2d"):
+            assert slug in by_slug, f"missing roadmap skill '{slug}'"
+            assert by_slug[slug].kind == SkillKind.ROADMAP
+
+    def test_monolith_dp_removed(self):
+        assert "dynamic-programming" not in {s.slug for s in SKILLS}
+        stale = [
+            q
+            for q, maps in QUESTION_SKILLS.items()
+            for m in maps
+            if m.skill_slug == "dynamic-programming"
+        ]
+        assert not stale, f"mappings still reference monolith DP: {stale}"
+
+    def test_roadmap_order_is_explicit_neetcode_order(self):
+        assert tuple(skill_taxonomy.ROADMAP_ORDER) == EXPECTED_ORDER
+        assert set(skill_taxonomy.ROADMAP_ORDER) == set(
+            skill_taxonomy.ROADMAP_SKILL_SLUGS
+        )
+
+    def test_interval_questions_mapped_to_intervals(self):
+        for q in ("merge-intervals", "non-overlapping-intervals", "car-fleet"):
+            slugs = {m.skill_slug for m in QUESTION_SKILLS[q]}
+            assert "intervals" in slugs, f"{q} not mapped to intervals: {slugs}"
+            assert "sorting" not in slugs, f"{q} still mapped to sorting"
+
+    def test_dp_split_classics(self):
+        dp1 = {
+            q
+            for q, maps in QUESTION_SKILLS.items()
+            if any(m.skill_slug == "dp-1d" for m in maps)
+        }
+        assert {
+            "climbing-stairs",
+            "coin-change",
+            "house-robber",
+            "word-break",
+            "decode-ways",
+            "longest-increasing-subsequence",
+            "maximum-product-subarray",
+        } <= dp1
+        dp2 = {
+            q
+            for q, maps in QUESTION_SKILLS.items()
+            if any(m.skill_slug == "dp-2d" for m in maps)
+        }
+        assert {"edit-distance", "burst-balloons"} <= dp2


### PR DESCRIPTION
Stacks on #136 (caveman-reviewed, additive foundation). Adds tries / intervals / math-geometry, splits DP into dp-1d / dp-2d, remaps interval questions off sorting, adds explicit ROADMAP_ORDER. 109/109 coverage + weights-sum-1.0 preserved; 1160 unit + contract green.

Known follow-up (needs your call before I touch deletes): the live DB will retain a stale `dynamic-programming` skill row + its question_skills mappings after reseed (seed script upserts only, never deletes). Say the word and I cut a cleanup migration.

Closes #135