### PR TITLE
feat(skill-graph): prune stale dynamic-programming taxonomy rows

### DIFF
--- a/backend/alembic/versions/c9d0e1f2a3b4_prune_dynamic_programming_taxonomy.py
+++ b/backend/alembic/versions/c9d0e1f2a3b4_prune_dynamic_programming_taxonomy.py
@@ -1,0 +1,117 @@
+"""prune stale dynamic-programming taxonomy rows
+
+Revision ID: c9d0e1f2a3b4
+Revises: a3b4c5d6e7f8
+Create Date: 2026-09-03
+
+Why this exists
+---------------
+#135 split the monolithic ``dynamic-programming`` skill into ``dp-1d`` /
+``dp-2d`` and moved interval questions off ``sorting``. The seed script
+upserts only, so databases seeded before #135 keep rows that attribute
+events to an unknown slug (orphaned per-user states, invisible in the
+graph). This is a data-only migration (no schema change):
+
+- ensure the ``dp-1d`` skill row exists (the seed backfills its details)
+- remap ``user_skill_states`` ``dynamic-programming`` -> ``dp-1d``,
+  preserving mastery/evidence (``dp-1d`` states cannot pre-exist, so the
+  unique ``(user_id, skill_slug)`` constraint stays safe)
+- delete ``question_skills`` rows pointing at ``dynamic-programming``
+- delete the ``skills`` row ``dynamic-programming``
+
+Pair-level leftovers (e.g. the old ``(merge-intervals, sorting)`` pairing,
+where ``sorting`` is still a valid slug) are owned by the seed prune in
+``scripts/seed_skill_graph.py`` — run the seed after migrating.
+
+``learning_events`` history is immutable and untouched; re-ingest already
+ignores unknown slugs, so old events cannot corrupt the graph.
+
+Deploy order: ``alembic upgrade head`` BEFORE ``seed_skill_graph.py`` —
+otherwise the seed's skills-row prune would cascade-delete ``dp`` user
+states instead of this migration remapping them.
+
+The downgrade is best-effort (restores the skill row + old mappings for
+questions that exist); user states are never moved back.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c9d0e1f2a3b4"
+down_revision: Union[str, Sequence[str], None] = "a3b4c5d6e7f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Pre-#135 (question_id, weight) pairs for the monolith, used only by the
+# best-effort downgrade. Frozen in time — never import the live taxonomy here.
+_DP_PAIRS = (
+    ("longest-valid-parentheses", 0.3),
+    ("binary-tree-maximum-path-sum", 0.2),
+    ("climbing-stairs", 0.8),
+    ("coin-change", 1.0),
+    ("house-robber", 1.0),
+    ("word-break", 0.8),
+    ("edit-distance", 0.8),
+    ("decode-ways", 0.8),
+    ("longest-increasing-subsequence", 0.9),
+    ("burst-balloons", 0.9),
+    ("maximum-product-subarray", 0.7),
+    ("1f3e5d7c-9b8a-4c6d-0e2f-4a5b6c7d8e9f", 0.8),
+    ("8c3d2e4f-6a5b-4f7c-9d0e-1a2b3c4d5e6f", 0.8),
+    ("9e4f5a6b-7c8d-4e9f-0a1b-2c3d4e5f6a7b", 0.8),
+    ("4a3f7c1e-5d6b-4e8f-9a0c-2b3d4e5f6a7b", 0.7),
+)
+
+
+def upgrade() -> None:
+    """Remap dp states to dp-1d; delete stale dp rows. Re-runnable."""
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "INSERT INTO skills (slug, name, description, prerequisite_ids) "
+            "VALUES ('dp-1d', '1-D Dynamic Programming', '', '[\"recursion\"]') "
+            "ON CONFLICT (slug) DO NOTHING"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE user_skill_states SET skill_slug = 'dp-1d' "
+            "WHERE skill_slug = 'dynamic-programming'"
+        )
+    )
+    conn.execute(
+        sa.text("DELETE FROM question_skills WHERE skill_slug = 'dynamic-programming'")
+    )
+    conn.execute(sa.text("DELETE FROM skills WHERE slug = 'dynamic-programming'"))
+
+
+def downgrade() -> None:
+    """Best-effort restore of the skill row + old mappings. User states stay."""
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "INSERT INTO skills (slug, name, description, prerequisite_ids) "
+            "VALUES ('dynamic-programming', 'Dynamic Programming', '', "
+            "'[\"recursion\"]') ON CONFLICT (slug) DO NOTHING"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "INSERT INTO question_skills (id, question_id, skill_slug, weight) "
+            "SELECT :row_id, q.id, 'dynamic-programming', :weight "
+            "FROM questions q WHERE q.id = :question_id "
+            "ON CONFLICT (id) DO NOTHING"
+        ),
+        [
+            {
+                "row_id": f"{question_id}:dynamic-programming",
+                "question_id": question_id,
+                "weight": weight,
+            }
+            for question_id, weight in _DP_PAIRS
+        ],
+    )

--- a/backend/app/models/skill_graph_schemas.py
+++ b/backend/app/models/skill_graph_schemas.py
@@ -36,6 +36,11 @@ class Trend(str, Enum):
     STABLE = "stable"
 
 
+class SkillKind(str, Enum):
+    ROADMAP = "roadmap"
+    SUPPORTING = "supporting"
+
+
 class Skill(BaseModel):
     slug: str = Field(..., description="Unique skill slug")
     name: str = Field(..., description="Human-readable skill name")
@@ -43,6 +48,10 @@ class Skill(BaseModel):
     parent_id: Optional[str] = Field(None, description="Parent skill slug (hierarchy)")
     prerequisite_ids: List[str] = Field(
         default_factory=list, description="Skills that must be mastered first"
+    )
+    kind: SkillKind = Field(
+        default=SkillKind.ROADMAP,
+        description="Roadmap (interview-pattern) vs supporting (cross-cutting)",
     )
 
 

--- a/backend/app/services/skill_graph_service.py
+++ b/backend/app/services/skill_graph_service.py
@@ -23,6 +23,7 @@ from app.services.skill_graph_rules import (
     mastery_for_status,
     recommend,
 )
+from app.services.skill_taxonomy import SUPPORTING_SKILL_SLUGS
 
 
 class SkillGraphService:
@@ -150,11 +151,38 @@ class SkillGraphService:
         ]
         return SkillGraphResponse(skills=summaries, edges=edges)
 
+    async def get_roadmap(
+        self, user_id: str, now: Optional[datetime] = None
+    ) -> SkillGraphResponse:
+        """Roadmap-track graph: supporting skills excluded from progress totals.
+
+        Full per-skill state stays available via ``get_graph`` (analytics /
+        coaching context); this view is what the NeetCode-style roadmap renders.
+        """
+        full = await self.get_graph(user_id, now=now)
+        supporting = set(SUPPORTING_SKILL_SLUGS)
+        roadmap_skills = [s for s in full.skills if s.skill_slug not in supporting]
+        roadmap_edges = [
+            e
+            for e in full.edges
+            if e.source not in supporting and e.target not in supporting
+        ]
+        return SkillGraphResponse(skills=roadmap_skills, edges=roadmap_edges)
+
     async def get_recommendations(
-        self, user_id: str, now: Optional[datetime] = None, limit: int = 5
+        self,
+        user_id: str,
+        now: Optional[datetime] = None,
+        limit: int = 5,
+        include_supporting: bool = False,
     ) -> List[Recommendation]:
         now = now or datetime.now(timezone.utc)
         skills_by_slug, question_skills_by_q = await self._load_taxonomy()
+        if not include_supporting:
+            supporting = set(SUPPORTING_SKILL_SLUGS)
+            skills_by_slug = {
+                slug: s for slug, s in skills_by_slug.items() if slug not in supporting
+            }
         states = await self.repository.get_states(user_id)
 
         skill_names = {slug: s.name for slug, s in skills_by_slug.items()}

--- a/backend/app/services/skill_taxonomy.py
+++ b/backend/app/services/skill_taxonomy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Tuple
 
-from app.models.skill_graph_schemas import QuestionSkill, Skill, SkillStatus
+from app.models.skill_graph_schemas import QuestionSkill, Skill, SkillKind, SkillStatus
 
 # Curated, deterministic skill taxonomy. Parent/child gives hierarchy;
 # prerequisite_ids define ordering that recommendations must respect.
@@ -12,6 +12,7 @@ SKILLS: List[Skill] = [
         slug="programming-fundamentals",
         name="Programming Fundamentals",
         description="Basic syntax, variables, control flow, functions.",
+        kind=SkillKind.SUPPORTING,
     ),
     Skill(
         slug="arrays",
@@ -120,24 +121,28 @@ SKILLS: List[Skill] = [
         name="Debugging",
         description="Reading error output, isolating failure, reproducing bugs.",
         prerequisite_ids=["programming-fundamentals"],
+        kind=SkillKind.SUPPORTING,
     ),
     Skill(
         slug="testing",
         name="Testing",
         description="Edge cases, unit assertions, input/output validation.",
         prerequisite_ids=["programming-fundamentals"],
+        kind=SkillKind.SUPPORTING,
     ),
     Skill(
         slug="time-complexity",
         name="Time Complexity",
         description="Big-O analysis, identifying dominant operations.",
         prerequisite_ids=["programming-fundamentals"],
+        kind=SkillKind.SUPPORTING,
     ),
     Skill(
         slug="space-complexity",
         name="Space Complexity",
         description="Auxiliary memory analysis, in-place vs. extra space.",
         prerequisite_ids=["programming-fundamentals"],
+        kind=SkillKind.SUPPORTING,
     ),
 ]
 
@@ -317,6 +322,28 @@ def _build_question_skills() -> Dict[str, List[QuestionSkill]]:
 
 
 QUESTION_SKILLS: Dict[str, List[QuestionSkill]] = _build_question_skills()
+
+# Roadmap vs supporting track (Issue #134, NeetCode conventions). Supporting
+# skills stay in the DB + event system for analytics/coaching context but are
+# excluded from roadmap ordering, progress totals, and primary recommendations.
+# Derived from Skill.kind so there is a single source of truth; no DB migration
+# needed (seed script upserts taxonomy fields, ORM rows remain kind-agnostic).
+SUPPORTING_SKILL_SLUGS: Tuple[str, ...] = tuple(
+    s.slug for s in SKILLS if s.kind == SkillKind.SUPPORTING
+)
+ROADMAP_SKILL_SLUGS: Tuple[str, ...] = tuple(
+    s.slug for s in SKILLS if s.kind == SkillKind.ROADMAP
+)
+_SUPPORTING_SLUGS: frozenset = frozenset(SUPPORTING_SKILL_SLUGS)
+
+
+def is_roadmap_skill(slug: str) -> bool:
+    return slug not in _SUPPORTING_SLUGS
+
+
+def roadmap_skills() -> List[Skill]:
+    return [s for s in SKILLS if s.kind == SkillKind.ROADMAP]
+
 
 # Alias for analytics plateau rule (plan expects QUESTION_SKILL_MAP) — keeps 109/109 contract.
 QUESTION_SKILL_MAP: Dict[str, List[Tuple[str, float]]] = _QUESTION_SKILL_WEIGHTS

--- a/backend/app/services/skill_taxonomy.py
+++ b/backend/app/services/skill_taxonomy.py
@@ -99,10 +99,22 @@ SKILLS: List[Skill] = [
         prerequisite_ids=["trees"],
     ),
     Skill(
-        slug="dynamic-programming",
-        name="Dynamic Programming",
-        description="Overlapping subproblems, memoization, tabulation.",
+        slug="tries",
+        name="Tries",
+        description="Prefix trees, word search, autocomplete.",
+        prerequisite_ids=["trees"],
+    ),
+    Skill(
+        slug="dp-1d",
+        name="1-D Dynamic Programming",
+        description="Linear subproblems, memoization over indices.",
         prerequisite_ids=["recursion"],
+    ),
+    Skill(
+        slug="dp-2d",
+        name="2-D Dynamic Programming",
+        description="Grid and string-table subproblems, two-dimensional tables.",
+        prerequisite_ids=["dp-1d"],
     ),
     Skill(
         slug="greedy",
@@ -111,9 +123,21 @@ SKILLS: List[Skill] = [
         prerequisite_ids=["arrays"],
     ),
     Skill(
+        slug="intervals",
+        name="Intervals",
+        description="Merging and scheduling overlapping ranges.",
+        prerequisite_ids=["sorting"],
+    ),
+    Skill(
         slug="bit-manipulation",
         name="Bit Manipulation",
         description="XOR tricks, masks, two's-complement arithmetic.",
+        prerequisite_ids=["programming-fundamentals"],
+    ),
+    Skill(
+        slug="math-geometry",
+        name="Math & Geometry",
+        description="Arithmetic tricks, combinatorics, coordinate geometry.",
         prerequisite_ids=["programming-fundamentals"],
     ),
     Skill(
@@ -168,8 +192,8 @@ _QUESTION_SKILL_WEIGHTS: Dict[str, List[Tuple[str, float]]] = {
     "first-missing-positive": [("arrays", 0.7), ("hash-maps", 0.3)],
     "product-of-array-except-self": [("arrays", 0.8), ("time-complexity", 0.2)],
     "missing-number": [("arrays", 0.6), ("bit-manipulation", 0.4)],
-    "merge-intervals": [("sorting", 0.5), ("arrays", 0.5)],
-    "non-overlapping-intervals": [("greedy", 0.7), ("sorting", 0.3)],
+    "merge-intervals": [("intervals", 0.5), ("arrays", 0.5)],
+    "non-overlapping-intervals": [("greedy", 0.7), ("intervals", 0.3)],
     # --- Two Pointers -----------------------------------------------------
     "reverse-string": [("strings", 0.5), ("two-pointers", 0.5)],
     "valid-palindrome": [("two-pointers", 0.7), ("strings", 0.3)],
@@ -203,9 +227,9 @@ _QUESTION_SKILL_WEIGHTS: Dict[str, List[Tuple[str, float]]] = {
     ],
     "min-stack": [("stacks-queues", 0.8), ("arrays", 0.2)],
     "daily-temperatures": [("stacks-queues", 0.8), ("arrays", 0.2)],
-    "car-fleet": [("stacks-queues", 0.6), ("sorting", 0.4)],
+    "car-fleet": [("stacks-queues", 0.6), ("intervals", 0.4)],
     "largest-rectangle-in-histogram": [("stacks-queues", 0.8), ("two-pointers", 0.2)],
-    "longest-valid-parentheses": [("stacks-queues", 0.7), ("dynamic-programming", 0.3)],
+    "longest-valid-parentheses": [("stacks-queues", 0.7), ("dp-1d", 0.3)],
     # --- Heaps & Priority Queues -------------------------------------------
     "top-k-frequent-elements": [("heaps", 0.7), ("hash-maps", 0.3)],
     "k-closest-points-to-origin": [("heaps", 0.7), ("sorting", 0.3)],
@@ -240,7 +264,7 @@ _QUESTION_SKILL_WEIGHTS: Dict[str, List[Tuple[str, float]]] = {
     "validate-binary-search-tree": [("trees", 0.8), ("recursion", 0.2)],
     "kth-smallest-element-in-a-bst": [("trees", 0.8), ("searching", 0.2)],
     "lowest-common-ancestor-of-a-binary-tree": [("trees", 0.8), ("recursion", 0.2)],
-    "binary-tree-maximum-path-sum": [("trees", 0.8), ("dynamic-programming", 0.2)],
+    "binary-tree-maximum-path-sum": [("trees", 0.8), ("dp-1d", 0.2)],
     # --- Graphs ----------------------------------------------------------------
     "number-of-islands": [("graphs", 1.0)],
     "clone-graph": [("graphs", 0.8), ("hash-maps", 0.2)],
@@ -249,16 +273,17 @@ _QUESTION_SKILL_WEIGHTS: Dict[str, List[Tuple[str, float]]] = {
     "word-ladder": [("graphs", 0.7), ("searching", 0.3)],
     "word-search": [("backtracking", 0.8), ("graphs", 0.2)],
     "e42b2609-8b2c-49a0-9fa3-b7145df07bc3": [("graphs", 0.6), ("heaps", 0.4)],
-    # --- Dynamic Programming -----------------------------------------------------
-    "climbing-stairs": [("dynamic-programming", 0.8), ("recursion", 0.2)],
-    "coin-change": [("dynamic-programming", 1.0)],
-    "house-robber": [("dynamic-programming", 1.0)],
-    "word-break": [("dynamic-programming", 0.8), ("strings", 0.2)],
-    "edit-distance": [("dynamic-programming", 0.8), ("strings", 0.2)],
-    "decode-ways": [("dynamic-programming", 0.8), ("strings", 0.2)],
-    "longest-increasing-subsequence": [("dynamic-programming", 0.9), ("arrays", 0.1)],
-    "burst-balloons": [("dynamic-programming", 0.9), ("arrays", 0.1)],
-    "maximum-product-subarray": [("dynamic-programming", 0.7), ("arrays", 0.3)],
+    # --- 1-D Dynamic Programming -------------------------------------------------
+    "climbing-stairs": [("dp-1d", 0.8), ("recursion", 0.2)],
+    "coin-change": [("dp-1d", 1.0)],
+    "house-robber": [("dp-1d", 1.0)],
+    "word-break": [("dp-1d", 0.8), ("strings", 0.2)],
+    "decode-ways": [("dp-1d", 0.8), ("strings", 0.2)],
+    "longest-increasing-subsequence": [("dp-1d", 0.9), ("arrays", 0.1)],
+    "maximum-product-subarray": [("dp-1d", 0.7), ("arrays", 0.3)],
+    # --- 2-D Dynamic Programming -------------------------------------------------
+    "edit-distance": [("dp-2d", 0.8), ("strings", 0.2)],
+    "burst-balloons": [("dp-2d", 0.9), ("arrays", 0.1)],
     # --- Backtracking --------------------------------------------------------------
     "permutations": [("backtracking", 0.9), ("recursion", 0.1)],
     "subsets": [("backtracking", 0.9), ("recursion", 0.1)],
@@ -293,19 +318,19 @@ _QUESTION_SKILL_WEIGHTS: Dict[str, List[Tuple[str, float]]] = {
     ],
     "6d7e8f9a-0b1c-4d2e-3f4a-5b6c7d8e9f0a": [("strings", 0.7), ("two-pointers", 0.3)],
     "1f3e5d7c-9b8a-4c6d-0e2f-4a5b6c7d8e9f": [
-        ("dynamic-programming", 0.8),
+        ("dp-1d", 0.8),
         ("strings", 0.2),
     ],
     "8c3d2e4f-6a5b-4f7c-9d0e-1a2b3c4d5e6f": [
-        ("dynamic-programming", 0.8),
+        ("dp-1d", 0.8),
         ("strings", 0.2),
     ],
     "9e4f5a6b-7c8d-4e9f-0a1b-2c3d4e5f6a7b": [
-        ("dynamic-programming", 0.8),
+        ("dp-1d", 0.8),
         ("strings", 0.2),
     ],
     "4a3f7c1e-5d6b-4e8f-9a0c-2b3d4e5f6a7b": [
-        ("dynamic-programming", 0.7),
+        ("dp-1d", 0.7),
         ("strings", 0.3),
     ],
 }
@@ -343,6 +368,33 @@ def is_roadmap_skill(slug: str) -> bool:
 
 def roadmap_skills() -> List[Skill]:
     return [s for s in SKILLS if s.kind == SkillKind.ROADMAP]
+
+
+# Explicit NeetCode-style bucket order for the roadmap UI. Dict insertion order
+# is not a contract; this tuple is.
+ROADMAP_ORDER: Tuple[str, ...] = (
+    "arrays",
+    "strings",
+    "hash-maps",
+    "two-pointers",
+    "sliding-window",
+    "stacks-queues",
+    "heaps",
+    "recursion",
+    "backtracking",
+    "sorting",
+    "searching",
+    "linked-lists",
+    "trees",
+    "tries",
+    "graphs",
+    "dp-1d",
+    "dp-2d",
+    "greedy",
+    "intervals",
+    "bit-manipulation",
+    "math-geometry",
+)
 
 
 # Alias for analytics plateau rule (plan expects QUESTION_SKILL_MAP) — keeps 109/109 contract.

--- a/backend/scripts/seed_skill_graph.py
+++ b/backend/scripts/seed_skill_graph.py
@@ -2,7 +2,14 @@
 """Seed the skill taxonomy + question-skill mappings into Supabase.
 
 Idempotent and re-runnable: upserts by natural key (skills.slug,
-question_skills.question_id+skill_slug) and never deletes unrelated rows.
+question_skills.question_id+skill_slug), then prunes taxonomy-unknown rows
+so past renames (e.g. #135's ``dynamic-programming`` split) self-heal
+instead of attributing events to unknown slugs. Never deletes rows outside
+the taxonomy-owned ``skills`` / ``question_skills`` tables.
+
+Deploy order: run ``alembic upgrade head`` BEFORE this seed — the taxonomy
+cleanup migration remaps user states first, otherwise this prune would
+cascade-delete them.
 
 Usage:
     DATABASE_URL=postgresql://... python scripts/seed_skill_graph.py
@@ -51,6 +58,47 @@ def _create_engine():
     if search_path:
         kwargs["connect_args"] = {"server_settings": {"search_path": search_path}}
     return create_async_engine(_get_database_url(), poolclass=NullPool, **kwargs)
+
+
+async def _prune_stale_rows(session) -> int:
+    """Delete taxonomy-unknown skills and question-skill pairs.
+
+    The seed owns the taxonomy-defined content of these tables: ``skills``
+    rows are exactly ``SKILLS``, and ``question_skills`` rows for
+    taxonomy-covered questions are exactly ``QUESTION_SKILLS`` pairs.
+    Anything else is stale (a past rename) and must go, otherwise events
+    attribute to unknown slugs. Rows for questions outside the taxonomy
+    are left alone — this seed cannot judge them.
+    """
+    pruned = 0
+    valid_slugs = {s.slug for s in SKILLS}
+    stale_skills = (
+        (
+            await session.execute(
+                select(SkillORM).where(SkillORM.slug.not_in(valid_slugs))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for row in stale_skills:
+        await session.delete(row)
+        pruned += 1
+
+    expected_pairs = {
+        (question_id, m.skill_slug)
+        for question_id, mappings in QUESTION_SKILLS.items()
+        for m in mappings
+    }
+    pairs = (await session.execute(select(QuestionSkillORM))).scalars().all()
+    for row in pairs:
+        if (
+            row.question_id in QUESTION_SKILLS
+            and (row.question_id, row.skill_slug) not in expected_pairs
+        ):
+            await session.delete(row)
+            pruned += 1
+    return pruned
 
 
 async def seed() -> int:
@@ -115,8 +163,11 @@ async def seed() -> int:
                 else:
                     existing.weight = mapping.weight
 
+        pruned = await _prune_stale_rows(session)
+
         await session.commit()
     await engine.dispose()
+    print(f"Skill graph seed pruned {pruned} stale taxonomy rows.")
     return total
 
 

--- a/backend/tests/integration/test_seed_skill_prune.py
+++ b/backend/tests/integration/test_seed_skill_prune.py
@@ -1,0 +1,98 @@
+"""Seed prune: stale taxonomy rows are removed on reseed (Issue #138).
+
+The seed owns the ``skills`` table and the taxonomy-covered
+``question_skills`` pairs, so rows the taxonomy no longer defines
+(e.g. post-#135 ``dynamic-programming``) must be pruned, not left to
+attribute events to unknown slugs. Reseed must be a no-op afterwards.
+"""
+
+import asyncio
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from app.models.orm import QuestionSkillORM, SkillORM
+from tests.conftest import _test_db_url, _test_engine_kwargs
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _counts() -> tuple[int, int, int]:
+    engine = create_async_engine(
+        _test_db_url(), poolclass=NullPool, **_test_engine_kwargs()
+    )
+    try:
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with maker() as session:
+            stale_skills = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(SkillORM)
+                    .where(SkillORM.slug == "dynamic-programming")
+                )
+            ).scalar_one()
+            stale_pairs = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(QuestionSkillORM)
+                    .where(QuestionSkillORM.skill_slug == "dynamic-programming")
+                )
+            ).scalar_one()
+            total_pairs = (
+                await session.execute(
+                    select(func.count()).select_from(QuestionSkillORM)
+                )
+            ).scalar_one()
+            return stale_skills, stale_pairs, total_pairs
+    finally:
+        await engine.dispose()
+
+
+async def _plant_stale_rows() -> None:
+    engine = create_async_engine(
+        _test_db_url(), poolclass=NullPool, **_test_engine_kwargs()
+    )
+    try:
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with maker() as session:
+            # Ordered commits: the pair's FK requires the skill row first.
+            session.add(
+                SkillORM(
+                    slug="dynamic-programming",
+                    name="Dynamic Programming",
+                    description="",
+                    prerequisite_ids=[],
+                )
+            )
+            await session.commit()
+            session.add(
+                QuestionSkillORM(
+                    id="two-sum:dynamic-programming",
+                    question_id="two-sum",
+                    skill_slug="dynamic-programming",
+                    weight=1.0,
+                )
+            )
+            await session.commit()
+    finally:
+        await engine.dispose()
+
+
+class TestSeedSkillPrune:
+    def test_reseed_prunes_stale_rows_and_is_idempotent(self, test_client):
+        _run(_plant_stale_rows())
+
+        from scripts.seed_skill_graph import seed
+
+        _run(seed())
+
+        stale_skills, stale_pairs, total_pairs = _run(_counts())
+        assert stale_skills == 0
+        assert stale_pairs == 0
+        assert total_pairs > 0, "seed must not wipe valid mappings"
+
+        _run(seed())
+        assert _run(_counts()) == (0, 0, total_pairs)

--- a/backend/tests/migrations/test_taxonomy_cleanup.py
+++ b/backend/tests/migrations/test_taxonomy_cleanup.py
@@ -1,0 +1,141 @@
+"""Data migration: prune stale ``dynamic-programming`` taxonomy rows (#138).
+
+#135 split the monolith into ``dp-1d``/``dp-2d`` and moved interval
+questions off ``sorting``. Seed upserts only, so live DBs keep stale rows
+that attribute events to an unknown slug. The migration must cover all:
+
+- ``skills`` row ``dynamic-programming`` deleted
+- ``question_skills`` rows for unknown slugs deleted
+- ``user_skill_states`` ``dynamic-programming`` remapped to ``dp-1d``
+  (``dp-1d`` states cannot pre-exist, so the unique constraint is safe)
+- ``learning_events`` history left immutable
+- re-runnable (second upgrade is a no-op); downgrade restores the skill row
+"""
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+PARENT = "a3b4c5d6e7f8"
+
+
+def _sync_engine(url: str):
+    return create_engine(url.replace("postgresql+asyncpg://", "postgresql+psycopg://"))
+
+
+def _exec(url: str, sql: str, params: dict | None = None) -> None:
+    eng = _sync_engine(url)
+    try:
+        with eng.connect() as conn:
+            conn.execute(text(sql), params or {})
+            conn.commit()
+    finally:
+        eng.dispose()
+
+
+def _scalar(url: str, sql: str, params: dict | None = None):
+    eng = _sync_engine(url)
+    try:
+        with eng.connect() as conn:
+            return conn.execute(text(sql), params or {}).scalar()
+    finally:
+        eng.dispose()
+
+
+def _seed_stale_rows(url: str) -> None:
+    _exec(
+        url,
+        "INSERT INTO users (id, username, email, hashed_password, created_at, "
+        "is_active) VALUES ('u-cleanup', 'cleanupuser', 'cleanup@test.com', "
+        "'x', now(), 1) ON CONFLICT (id) DO NOTHING",
+    )
+    _exec(
+        url,
+        "INSERT INTO questions (id, title, difficulty, category, company_tags, "
+        "description, starter_code, examples, test_cases, hints, constraints, "
+        "is_interactive) VALUES ('coin-change', 'Coin Change', 'medium', "
+        "'dynamic-programming', '[]', 'desc', '{}', '[]', '[]', '[]', '[]', 0) "
+        "ON CONFLICT (id) DO NOTHING",
+    )
+    _exec(
+        url,
+        "INSERT INTO skills (slug, name, description, prerequisite_ids) "
+        "VALUES ('dynamic-programming', 'Dynamic Programming', '', '[]') "
+        "ON CONFLICT (slug) DO NOTHING",
+    )
+    _exec(
+        url,
+        "INSERT INTO question_skills (id, question_id, skill_slug, weight) "
+        "VALUES ('coin-change:dynamic-programming', 'coin-change', "
+        "'dynamic-programming', 1.0) ON CONFLICT (id) DO NOTHING",
+    )
+    _exec(
+        url,
+        "INSERT INTO user_skill_states (id, user_id, skill_slug, mastery_score, "
+        "confidence, evidence_count, recent_error_count, distinct_question_ids, "
+        "last_seen_at, updated_at) VALUES ('u-cleanup:dynamic-programming', "
+        "'u-cleanup', 'dynamic-programming', 0.5, 0.3, 4, 1, '[]', now(), now()) "
+        "ON CONFLICT (id) DO NOTHING",
+    )
+
+
+def test_cleanup_migration_prunes_and_remaps(
+    alembic_config: Config, migration_url: str
+) -> None:
+    command.upgrade(alembic_config, "head")
+    command.downgrade(alembic_config, PARENT)
+    _seed_stale_rows(migration_url)
+    command.upgrade(alembic_config, "head")
+
+    assert (
+        _scalar(
+            migration_url,
+            "SELECT COUNT(*) FROM skills WHERE slug = 'dynamic-programming'",
+        )
+        == 0
+    )
+    assert (
+        _scalar(
+            migration_url,
+            "SELECT COUNT(*) FROM question_skills "
+            "WHERE skill_slug = 'dynamic-programming'",
+        )
+        == 0
+    )
+    remapped = _scalar(
+        migration_url,
+        "SELECT mastery_score FROM user_skill_states "
+        "WHERE user_id = 'u-cleanup' AND skill_slug = 'dp-1d'",
+    )
+    assert remapped is not None and abs(float(remapped) - 0.5) < 1e-6
+    assert (
+        _scalar(
+            migration_url,
+            "SELECT COUNT(*) FROM user_skill_states "
+            "WHERE skill_slug = 'dynamic-programming'",
+        )
+        == 0
+    )
+
+    # Re-runnable: a second upgrade changes nothing.
+    before = _scalar(migration_url, "SELECT COUNT(*) FROM question_skills")
+    command.upgrade(alembic_config, "head")
+    assert _scalar(migration_url, "SELECT COUNT(*) FROM question_skills") == before
+
+    # Downgrade restores the skill row (best-effort); re-upgrade cleans again.
+    command.downgrade(alembic_config, PARENT)
+    assert (
+        _scalar(
+            migration_url,
+            "SELECT COUNT(*) FROM skills WHERE slug = 'dynamic-programming'",
+        )
+        == 1
+    )
+    command.upgrade(alembic_config, "head")
+    assert (
+        _scalar(
+            migration_url,
+            "SELECT COUNT(*) FROM skills WHERE slug = 'dynamic-programming'",
+        )
+        == 0
+    )

--- a/backend/tests/simulation/learner_profiles.py
+++ b/backend/tests/simulation/learner_profiles.py
@@ -208,7 +208,7 @@ def profile_many_failed_attempts(user, rng):
         events.append(fail_evt(seq, user, Q_MAX_SUB))
         seq += 1
     expected = {}
-    expect_skill(expected, "dynamic-programming", mastery_ge=0.0)
+    expect_skill(expected, "dp-1d", mastery_ge=0.0)
     return events, expected
 
 
@@ -273,7 +273,7 @@ def profile_ai_diagnosis_dependent(user, rng):
         pass_evt(5, user, Q_MAX_SUB),
     ]
     expected = {}
-    expect_skill(expected, "dynamic-programming", mastery_lt=0.75)
+    expect_skill(expected, "dp-1d", mastery_lt=0.75)
     return events, expected
 
 
@@ -371,7 +371,7 @@ def profile_lucky_guesser(user, rng):
         fail_evt(5, user, Q_MAX_SUB),
     ]
     expected = {}
-    expect_skill(expected, "dynamic-programming", mastery_lt=0.75)
+    expect_skill(expected, "dp-1d", mastery_lt=0.75)
     return events, expected
 
 
@@ -397,14 +397,14 @@ def profile_mixed_skill(user, rng):
         pass_evt(0, user, Q_TWO_SUM),
         pass_evt(1, user, Q_TWO_SUM),
         pass_evt(2, user, Q_TWO_SUM),
-        # Merge-intervals is arrays+sorting; learner is bad at sorting.
+        # Merge-intervals is arrays+intervals; learner is bad at intervals.
         fail_evt(3, user, Q_MERGE, error="wrong_order"),
         fail_evt(4, user, Q_MERGE, error="wrong_order"),
         pass_evt(5, user, Q_MERGE, hints=2),
     ]
     expected = {}
     expect_skill(expected, "hash-maps", mastery_ge=0.2, mastery_lt=0.75)
-    expect_skill(expected, "sorting", errors_ge=2)
+    expect_skill(expected, "intervals", errors_ge=2)
     return events, expected
 
 
@@ -459,9 +459,9 @@ def profile_topic_transfer(user, rng):
     ]
     expected = {}
     # Transfer: two-pointers evidence from reverse-string persists and the
-    # merge-interval practice feeds sorting without resetting anything.
+    # merge-interval practice feeds intervals without resetting anything.
     expect_skill(expected, "two-pointers", mastery_ge=0.2)
-    expect_skill(expected, "sorting", mastery_ge=0.2)
+    expect_skill(expected, "intervals", mastery_ge=0.2)
     return events, expected
 
 

--- a/backend/tests/unit/test_skill_roadmap_tracks.py
+++ b/backend/tests/unit/test_skill_roadmap_tracks.py
@@ -1,0 +1,74 @@
+"""Roadmap vs supporting skill separation (Issue #134).
+
+NeetCode-style roadmap must contain only interview-pattern skills. Supporting
+/ cross-cutting skills stay in the DB + event system for analytics/coaching
+but are excluded from roadmap ordering, progress totals, and primary
+recommendations.
+"""
+
+from app.models.skill_graph_schemas import SkillKind
+from app.services import skill_taxonomy
+
+
+class TestRoadmapSeparation:
+    def test_supporting_slugs_are_exactly_the_five(self):
+        assert set(skill_taxonomy.SUPPORTING_SKILL_SLUGS) == {
+            "programming-fundamentals",
+            "debugging",
+            "testing",
+            "time-complexity",
+            "space-complexity",
+        }
+
+    def test_supporting_skills_carry_supporting_kind(self):
+        by_slug = {s.slug: s for s in skill_taxonomy.SKILLS}
+        for slug in skill_taxonomy.SUPPORTING_SKILL_SLUGS:
+            assert by_slug[slug].kind == SkillKind.SUPPORTING
+
+    def test_roadmap_skills_exclude_supporting(self):
+        roadmap_slugs = {s.slug for s in skill_taxonomy.roadmap_skills()}
+        assert not (roadmap_slugs & set(skill_taxonomy.SUPPORTING_SKILL_SLUGS))
+        # Core interview patterns stay on the roadmap.
+        for slug in ("arrays", "hash-maps", "two-pointers", "graphs"):
+            assert slug in roadmap_slugs
+
+    def test_is_roadmap_skill_helper(self):
+        assert skill_taxonomy.is_roadmap_skill("arrays") is True
+        assert skill_taxonomy.is_roadmap_skill("debugging") is False
+
+
+class TestRoadmapRecommendations:
+    def _repo(self):
+        from tests.simulation.in_memory_repo import InMemorySkillGraphRepository
+
+        from app.services.skill_taxonomy import QUESTION_SKILLS, SKILLS
+
+        repo = InMemorySkillGraphRepository()
+        repo.seed_skills(list(SKILLS))
+        repo.seed_question_skills(
+            [m for mappings in QUESTION_SKILLS.values() for m in mappings]
+        )
+        return repo
+
+    async def _recs(self, include_supporting: bool):
+        from app.services.skill_graph_service import SkillGraphService
+
+        service = SkillGraphService(repository=self._repo())
+        return await service.get_recommendations(
+            "u1", include_supporting=include_supporting
+        )
+
+    def test_default_recommendations_exclude_supporting(self):
+        import asyncio
+
+        recs = asyncio.run(self._recs(include_supporting=False))
+        slugs = {r.skill_slug for r in recs}
+        assert not (slugs & set(skill_taxonomy.SUPPORTING_SKILL_SLUGS))
+
+    def test_opt_in_recommendations_can_include_supporting(self):
+        import asyncio
+
+        recs = asyncio.run(self._recs(include_supporting=True))
+        # Full graph still knows supporting skills; at least the pipeline runs
+        # without error and returns roadmap-first results.
+        assert recs

--- a/backend/tests/unit/test_skill_taxonomy_buckets.py
+++ b/backend/tests/unit/test_skill_taxonomy_buckets.py
@@ -1,0 +1,86 @@
+"""NeetCode bucket alignment (Issue #135).
+
+The roadmap track must expose NeetCode-style buckets: tries, intervals,
+math-geometry, and a 1-D/2-D DP split. The monolithic ``dynamic-programming``
+slug must disappear from both taxonomy and mappings.
+"""
+
+from app.models.skill_graph_schemas import SkillKind
+from app.services import skill_taxonomy
+from app.services.skill_taxonomy import QUESTION_SKILLS, SKILLS
+
+EXPECTED_ORDER = (
+    "arrays",
+    "strings",
+    "hash-maps",
+    "two-pointers",
+    "sliding-window",
+    "stacks-queues",
+    "heaps",
+    "recursion",
+    "backtracking",
+    "sorting",
+    "searching",
+    "linked-lists",
+    "trees",
+    "tries",
+    "graphs",
+    "dp-1d",
+    "dp-2d",
+    "greedy",
+    "intervals",
+    "bit-manipulation",
+    "math-geometry",
+)
+
+
+class TestNeetCodeBuckets:
+    def test_new_roadmap_skills_exist(self):
+        by_slug = {s.slug: s for s in SKILLS}
+        for slug in ("tries", "intervals", "math-geometry", "dp-1d", "dp-2d"):
+            assert slug in by_slug, f"missing roadmap skill '{slug}'"
+            assert by_slug[slug].kind == SkillKind.ROADMAP
+
+    def test_monolith_dp_removed(self):
+        assert "dynamic-programming" not in {s.slug for s in SKILLS}
+        stale = [
+            q
+            for q, maps in QUESTION_SKILLS.items()
+            for m in maps
+            if m.skill_slug == "dynamic-programming"
+        ]
+        assert not stale, f"mappings still reference monolith DP: {stale}"
+
+    def test_roadmap_order_is_explicit_neetcode_order(self):
+        assert tuple(skill_taxonomy.ROADMAP_ORDER) == EXPECTED_ORDER
+        assert set(skill_taxonomy.ROADMAP_ORDER) == set(
+            skill_taxonomy.ROADMAP_SKILL_SLUGS
+        )
+
+    def test_interval_questions_mapped_to_intervals(self):
+        for q in ("merge-intervals", "non-overlapping-intervals", "car-fleet"):
+            slugs = {m.skill_slug for m in QUESTION_SKILLS[q]}
+            assert "intervals" in slugs, f"{q} not mapped to intervals: {slugs}"
+            assert "sorting" not in slugs, f"{q} still mapped to sorting"
+
+    def test_dp_split_classics(self):
+        dp1 = {
+            q
+            for q, maps in QUESTION_SKILLS.items()
+            if any(m.skill_slug == "dp-1d" for m in maps)
+        }
+        assert {
+            "climbing-stairs",
+            "coin-change",
+            "house-robber",
+            "word-break",
+            "decode-ways",
+            "longest-increasing-subsequence",
+            "maximum-product-subarray",
+        } <= dp1
+        dp2 = {
+            q
+            for q, maps in QUESTION_SKILLS.items()
+            if any(m.skill_slug == "dp-2d" for m in maps)
+        }
+        assert {"edit-distance", "burst-balloons"} <= dp2


### PR DESCRIPTION
Stacks on #137 <- #136. Covers all stale post-#135 artifacts (user-approved deletes):

- Alembic `c9d0e1f2a3b4` (data-only, no schema drift): ensures `dp-1d` skill row, remaps `user_skill_states` dp->dp-1d (mastery preserved, unique constraint safe), deletes dp `question_skills` + `skills` rows. Re-runnable; best-effort downgrade restores skill row + old mappings.
- Seed prune (`_prune_stale_rows`): taxonomy-unknown skills + pairs deleted on every reseed so future renames self-heal. Pair-level leftovers (old sorting pairings) owned here.
- `learning_events` history untouched (re-ingest already ignores unknown slugs).

Deploy order: `alembic upgrade head` BEFORE seed, else the seed prune cascade-deletes dp states instead of remapping them.

Verify: migration suite 8/8 (roundtrip + drift + cleanup), unit/contract 1160 green, skill integration 10/10, ruff clean.

Closes #138