### PR TITLE
feat(141): animation services quality

### DIFF
--- a/backend/app/services/animation_validator.py
+++ b/backend/app/services/animation_validator.py
@@ -12,7 +12,7 @@ AnimationScript Pydantic model downstream.
 
 import logging
 import re
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,36 @@ HEX_COLOR = re.compile(r"^#[0-9a-fA-F]{6}$")
 
 class AnimationValidator:
     """Validate the structural correctness of an animation scene dict."""
+
+    def lint_quality(self, script: Dict[str, Any]) -> List[str]:
+        """Non-blocking cinematic hints: camera, badge, narration quality.
+
+        Never rejects — returns warning strings so the pipeline stays
+        contract-stable while quality regressions become observable.
+        """
+        warnings: List[str] = []
+        if not isinstance(script, dict):
+            return ["script is not an object"]
+        steps = script.get("steps")
+        if not isinstance(steps, list) or not steps:
+            return ["no steps to lint"]
+        if not any(isinstance(s, dict) and s.get("camera") for s in steps):
+            warnings.append("missing camera guidance on all beats")
+        last = steps[-1] if isinstance(steps[-1], dict) else {}
+        if not last.get("badge"):
+            warnings.append("missing complexity badge on final beat")
+        prev = None
+        for i, step in enumerate(steps):
+            if not isinstance(step, dict):
+                continue
+            narration = step.get("narration", "")
+            if not isinstance(narration, str) or not narration.strip():
+                warnings.append(f"beat {i} has empty narration")
+            elif prev is not None and narration.strip() == prev:
+                warnings.append(f"beats {i - 1} and {i} share duplicate narration")
+            if isinstance(narration, str):
+                prev = narration.strip()
+        return warnings
 
     def validate(self, script: Dict[str, Any]) -> Tuple[Optional[Dict[str, Any]], str]:
         """Return (validated_script, "") on success or (None, reason) on failure."""

--- a/backend/app/services/scene_planner.py
+++ b/backend/app/services/scene_planner.py
@@ -21,6 +21,56 @@ def _cell_x(index: int, n: int, cell: float = 88.0, gap: float = 12.0) -> float:
     return round(start + index * (cell + gap), 2)
 
 
+def _root_shape(sid: str, w: float = 140.0, h: float = 48.0) -> Dict[str, Any]:
+    """Container shape so the intro beat's appear target validates."""
+    return {
+        "id": sid,
+        "type": "rect",
+        "x": 0.0,
+        "y": 220.0,
+        "width": w,
+        "height": h,
+        "radius": 10,
+        "fill": tokens.PALETTE["idle_fill"],
+        "stroke": tokens.PALETTE["idle_stroke"],
+        "lineWidth": 2,
+    }
+
+
+def _item_shape(sid: str, x: float = 0.0, y: float = 0.0) -> Dict[str, Any]:
+    """Generic item shape for dynamically referenced ids (stack/tree/graph)."""
+    return {
+        "id": sid,
+        "type": "rect",
+        "x": round(x, 2),
+        "y": round(y, 2),
+        "width": 64.0,
+        "height": 44.0,
+        "radius": 8,
+        "fill": tokens.PALETTE["idle_fill"],
+        "stroke": tokens.PALETTE["idle_stroke"],
+        "lineWidth": 2,
+    }
+
+
+def _edge_shape(sid: str) -> Dict[str, Any]:
+    return {
+        "id": sid,
+        "type": "line",
+        "points": [[-60.0, 0.0], [60.0, 0.0]],
+        "stroke": tokens.PALETTE["idle_stroke"],
+        "lineWidth": 2,
+    }
+
+
+def _ensure_planner_node(
+    known: set, shapes: List[Dict[str, Any]], sid: str, pos: int
+) -> None:
+    if sid not in known:
+        shapes.append(_item_shape(sid, x=(pos % 8) * 80.0 - 280.0, y=0.0))
+        known.add(sid)
+
+
 # ── searching (binary search hero template) ──────────────────────────────────
 
 
@@ -450,39 +500,61 @@ def plan_stack(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
     beats: List[Dict[str, Any]] = [
         {
             "narration": f"{spec.title or spec.algorithm} — Stack"[:300],
-            "shapes": [],
+            "shapes": [_root_shape("stack_base")],
             "motion": [{"target": "stack_base", "op": "appear", "duration": 0.4}],
             "camera": {"action": "reset"},
         }
     ]
+    known = {"stack_base"}
     depth = 0
+    created: List[str] = []
     for step in spec.steps:
         m: List[Dict[str, Any]] = []
+        shapes: List[Dict[str, Any]] = []
         narr = step.label or step.action
         if step.action == "push":
             val = step.values[0] if step.values else "·"
-            m.append({"target": f"stack_{depth}", "op": "appear", "duration": 0.35})
+            sid = f"stack_{depth}"
+            if sid not in known:
+                shapes.append(_item_shape(sid, x=0.0, y=-depth * 60.0))
+                known.add(sid)
+            m.append({"target": sid, "op": "appear", "duration": 0.35})
             m.append(
                 {
-                    "target": f"stack_{depth}",
+                    "target": sid,
                     "op": "move",
                     "to": [0, -depth * 60],
                     "duration": 0.35,
                 }
             )
             narr = f"Push {val}"
+            created.append(sid)
             depth += 1
         elif step.action == "pop":
             depth = max(0, depth - 1)
-            m.append({"target": f"stack_{depth}", "op": "disappear", "duration": 0.3})
+            sid = created.pop() if created else f"stack_{depth}"
+            if sid not in known:
+                m.append(
+                    {"target": "stack_base", "op": "scale", "to": 1.0, "duration": 0.25}
+                )
+            else:
+                m.append(
+                    {
+                        "target": sid,
+                        "op": "move",
+                        "to": [0, 220.0],
+                        "duration": 0.3,
+                    }
+                )
+                m.append({"target": sid, "op": "disappear", "duration": 0.2})
             narr = f"Pop {step.values[0] if step.values else ''}".strip()
         elif step.action == "visit":
             idx = step.index or 0
             m.append(
                 {
-                    "target": f"cell_{idx}",
-                    "op": "fill",
-                    "to": tokens.PALETTE["highlight_fill"],
+                    "target": "stack_base",
+                    "op": "stroke",
+                    "to": tokens.PALETTE["accent"],
                     "duration": 0.3,
                 }
             )
@@ -491,7 +563,7 @@ def plan_stack(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
             m.append(
                 {"target": "stack_base", "op": "scale", "to": 1.0, "duration": 0.25}
             )
-        beats.append({"narration": narr[:300], "shapes": [], "motion": m})
+        beats.append({"narration": narr[:300], "shapes": shapes, "motion": m})
     beats.append(
         {
             "narration": f"{spec.complexity.time}"[:300],
@@ -590,19 +662,25 @@ def plan_tree(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
     beats: List[Dict[str, Any]] = [
         {
             "narration": f"{spec.title or spec.algorithm} — Tree"[:300],
-            "shapes": [],
+            "shapes": [_root_shape("tree_root")],
             "motion": [{"target": "tree_root", "op": "appear", "duration": 0.4}],
             "camera": {"action": "reset"},
         }
     ]
+    known = {"tree_root"}
     for step in spec.steps:
         m: List[Dict[str, Any]] = []
+        shapes: List[Dict[str, Any]] = []
         narr = step.label or step.action
         idx = int(step.index or 0)
+        sid = f"tree_{idx}"
+        if step.action in ("visit", "choose", "backtrack") and sid not in known:
+            shapes.append(_item_shape(sid, x=(idx % 8) * 80.0 - 280.0, y=0.0))
+            known.add(sid)
         if step.action == "visit":
             m.append(
                 {
-                    "target": f"tree_{idx}",
+                    "target": sid,
                     "op": "fill",
                     "to": tokens.PALETTE["highlight_fill"],
                     "duration": 0.3,
@@ -612,7 +690,7 @@ def plan_tree(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
         elif step.action == "choose":
             m.append(
                 {
-                    "target": f"tree_{idx}",
+                    "target": sid,
                     "op": "stroke",
                     "to": tokens.PALETTE["accent"],
                     "duration": 0.3,
@@ -622,7 +700,7 @@ def plan_tree(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
         elif step.action == "backtrack":
             m.append(
                 {
-                    "target": f"tree_{idx}",
+                    "target": sid,
                     "op": "fill",
                     "to": tokens.PALETTE["dim_fill"],
                     "duration": 0.3,
@@ -633,7 +711,7 @@ def plan_tree(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
             m.append(
                 {"target": "tree_root", "op": "scale", "to": 1.0, "duration": 0.25}
             )
-        beats.append({"narration": narr[:300], "shapes": [], "motion": m})
+        beats.append({"narration": narr[:300], "shapes": shapes, "motion": m})
     beats.append(
         {
             "narration": f"{spec.complexity.time}"[:300],
@@ -651,22 +729,27 @@ def plan_tree(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
 
 
 def plan_graph(spec: AlgorithmAnimation, kind: str = "graph") -> List[Dict[str, Any]]:
+    root = f"{kind}_root"
     beats: List[Dict[str, Any]] = [
         {
             "narration": f"{spec.title or spec.algorithm} — {kind.title()}"[:300],
-            "shapes": [],
-            "motion": [{"target": f"{kind}_root", "op": "appear", "duration": 0.4}],
+            "shapes": [_root_shape(root)],
+            "motion": [{"target": root, "op": "appear", "duration": 0.4}],
             "camera": {"action": "reset"},
         }
     ]
+    known = {root}
     for step in spec.steps:
         m: List[Dict[str, Any]] = []
+        shapes: List[Dict[str, Any]] = []
         narr = step.label or step.action
         if step.action == "visit":
             idx = int(step.index or 0)
+            sid = f"node_{idx}"
+            _ensure_planner_node(known, shapes, sid, idx)
             m.append(
                 {
-                    "target": f"node_{idx}",
+                    "target": sid,
                     "op": "fill",
                     "to": tokens.PALETTE["highlight_fill"],
                     "duration": 0.3,
@@ -676,9 +759,14 @@ def plan_graph(spec: AlgorithmAnimation, kind: str = "graph") -> List[Dict[str, 
         elif step.action == "edge":
             a = step.indices[0] if step.indices and len(step.indices) >= 1 else 0
             b = step.indices[1] if step.indices and len(step.indices) >= 2 else 1
+            eid = f"edge_{a}_{b}"
+            if eid not in known:
+                shapes.append(_edge_shape(eid))
+                known.add(eid)
+            _ensure_planner_node(known, shapes, f"node_{b}", b)
             m.append(
                 {
-                    "target": f"edge_{a}_{b}",
+                    "target": eid,
                     "op": "stroke",
                     "to": tokens.PALETTE["accent"],
                     "duration": 0.3,
@@ -694,20 +782,14 @@ def plan_graph(spec: AlgorithmAnimation, kind: str = "graph") -> List[Dict[str, 
             )
             narr = f"Edge {a} → {b}"
         elif step.action == "relax_edge":
+            idx = int(step.indices[0]) if step.indices else 0
+            sid = f"node_{idx}"
+            _ensure_planner_node(known, shapes, sid, idx)
             narr = f"Relax {step.indices}"
-            m.append(
-                {
-                    "target": f"node_{step.indices[0] if step.indices else 0}",
-                    "op": "scale",
-                    "to": 1.05,
-                    "duration": 0.25,
-                }
-            )
+            m.append({"target": sid, "op": "scale", "to": 1.05, "duration": 0.25})
         else:
-            m.append(
-                {"target": f"{kind}_root", "op": "scale", "to": 1.0, "duration": 0.25}
-            )
-        beats.append({"narration": narr[:300], "shapes": [], "motion": m})
+            m.append({"target": root, "op": "scale", "to": 1.0, "duration": 0.25})
+        beats.append({"narration": narr[:300], "shapes": shapes, "motion": m})
     beats.append(
         {
             "narration": f"{spec.complexity.time}"[:300],
@@ -728,13 +810,15 @@ def plan_intervals(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
     beats: List[Dict[str, Any]] = [
         {
             "narration": f"{spec.title or spec.algorithm} — Intervals"[:300],
-            "shapes": [],
+            "shapes": [_root_shape("interval_0", w=180.0)],
             "motion": [{"target": "interval_0", "op": "appear", "duration": 0.4}],
             "camera": {"action": "reset"},
         }
     ]
+    known = {"interval_0"}
     for step in spec.steps:
         m: List[Dict[str, Any]] = []
+        shapes: List[Dict[str, Any]] = []
         narr = step.label or step.action
         if step.action in ("partition", "window"):
             m.append(
@@ -748,9 +832,13 @@ def plan_intervals(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
             narr = f"{step.action} {step.indices or [step.low, step.high]}"
         elif step.action == "visit":
             idx = int(step.index or 0)
+            sid = f"interval_{idx}"
+            if sid not in known:
+                shapes.append(_item_shape(sid, x=0.0, y=idx * 60.0 - 120.0))
+                known.add(sid)
             m.append(
                 {
-                    "target": f"interval_{idx}",
+                    "target": sid,
                     "op": "fill",
                     "to": tokens.PALETTE["highlight_fill"],
                     "duration": 0.3,
@@ -761,7 +849,7 @@ def plan_intervals(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
             m.append(
                 {"target": "interval_0", "op": "scale", "to": 1.0, "duration": 0.25}
             )
-        beats.append({"narration": narr[:300], "shapes": [], "motion": m})
+        beats.append({"narration": narr[:300], "shapes": shapes, "motion": m})
     beats.append(
         {
             "narration": f"{spec.complexity.time}"[:300],
@@ -782,20 +870,30 @@ def plan_backtrack(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
     beats: List[Dict[str, Any]] = [
         {
             "narration": f"{spec.title or spec.algorithm} — Backtracking"[:300],
-            "shapes": [],
+            "shapes": [_root_shape("bt_root")],
             "motion": [{"target": "bt_root", "op": "appear", "duration": 0.4}],
             "camera": {"action": "reset"},
         }
     ]
+    known = {"bt_root"}
     depth = 0
+
+    def _ensure(sid: str, shapes: List[Dict[str, Any]], pos: int) -> None:
+        if sid not in known:
+            shapes.append(_item_shape(sid, x=(pos % 8) * 80.0 - 280.0, y=0.0))
+            known.add(sid)
+
     for step in spec.steps:
         m: List[Dict[str, Any]] = []
+        shapes: List[Dict[str, Any]] = []
         narr = step.label or step.action
         if step.action == "choose":
             idx = int(step.index or depth)
+            sid = f"bt_{idx}"
+            _ensure(sid, shapes, idx)
             m.append(
                 {
-                    "target": f"bt_{idx}",
+                    "target": sid,
                     "op": "fill",
                     "to": tokens.PALETTE["highlight_fill"],
                     "duration": 0.3,
@@ -803,7 +901,7 @@ def plan_backtrack(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
             )
             m.append(
                 {
-                    "target": f"bt_{idx}",
+                    "target": sid,
                     "op": "stroke",
                     "to": tokens.PALETTE["highlight_stroke"],
                     "duration": 0.3,
@@ -813,9 +911,11 @@ def plan_backtrack(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
             depth += 1
         elif step.action == "backtrack":
             idx = int(step.index or max(0, depth - 1))
+            sid = f"bt_{idx}"
+            _ensure(sid, shapes, idx)
             m.append(
                 {
-                    "target": f"bt_{idx}",
+                    "target": sid,
                     "op": "fill",
                     "to": tokens.PALETTE["dim_fill"],
                     "duration": 0.3,
@@ -825,9 +925,11 @@ def plan_backtrack(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
             depth = max(0, depth - 1)
         elif step.action == "visit":
             idx = int(step.index or 0)
+            sid = f"bt_{idx}"
+            _ensure(sid, shapes, idx)
             m.append(
                 {
-                    "target": f"bt_{idx}",
+                    "target": sid,
                     "op": "fill",
                     "to": tokens.PALETTE["highlight_fill"],
                     "duration": 0.3,
@@ -836,7 +938,7 @@ def plan_backtrack(spec: AlgorithmAnimation) -> List[Dict[str, Any]]:
             narr = f"Visit {idx}"
         else:
             m.append({"target": "bt_root", "op": "scale", "to": 1.0, "duration": 0.25})
-        beats.append({"narration": narr[:300], "shapes": [], "motion": m})
+        beats.append({"narration": narr[:300], "shapes": shapes, "motion": m})
     beats.append(
         {
             "narration": f"{spec.complexity.time}"[:300],

--- a/backend/app/services/solution_animation_service.py
+++ b/backend/app/services/solution_animation_service.py
@@ -54,7 +54,78 @@ _COMPLEXITY_BY_ALGO = {
     "binary_search": ("O(log n)", "O(1)"),
     "bubble_sort": ("O(n²)", "O(1)"),
     "linear_search": ("O(n)", "O(1)"),
+    "merge_sort": ("O(n log n)", "O(n)"),
+    "quick_sort": ("O(n log n)", "O(log n)"),
+    "two_sum": ("O(n)", "O(n)"),
+    "clone_graph": ("O(V+E)", "O(V)"),
+    "course_schedule": ("O(V+E)", "O(V)"),
+    "number_of_islands": ("O(m*n)", "O(m*n)"),
+    "coin_change": ("O(n*amount)", "O(amount)"),
+    "climbing_stairs": ("O(n)", "O(1)"),
 }
+
+_COMPLEXITY_BY_FAMILY = {
+    "array": ("O(n)", "O(1)"),
+    "backtrack": ("O(2^n)", "O(n)"),
+    "stack": ("O(n)", "O(n)"),
+    "linked_list": ("O(n)", "O(1)"),
+    "tree": ("O(n)", "O(h)"),
+    "graph": ("O(V+E)", "O(V)"),
+    "grid": ("O(m*n)", "O(m*n)"),
+    "intervals": ("O(n log n)", "O(n)"),
+}
+
+# Compressible trace actions are sampled; everything else is always kept.
+_DOWNSAMPLE_KEEP = frozenset(
+    {
+        "swap",
+        "write",
+        "mark",
+        "found",
+        "not_found",
+        "dp_update",
+        "partition",
+        "edge",
+        "choose",
+        "backtrack",
+        "push",
+        "pop",
+    }
+)
+
+
+def resolve_complexity(entry: Dict[str, Any], algorithm: str) -> tuple:
+    """Resolve (time, space) preferring catalog entry, then algo, then family."""
+    complexity = (entry or {}).get("complexity")
+    if isinstance(complexity, (list, tuple)) and len(complexity) == 2:
+        return (str(complexity[0]), str(complexity[1]))
+    if algorithm in _COMPLEXITY_BY_ALGO:
+        return _COMPLEXITY_BY_ALGO[algorithm]
+    family = (entry or {}).get("family", "")
+    return _COMPLEXITY_BY_FAMILY.get(family, ("O(n)", "O(1)"))
+
+
+def downsample_steps(steps: list, limit: int = 96) -> list:
+    """Cap semantic steps preserving key events and original order."""
+    if len(steps) <= limit:
+        return list(steps)
+    key = [s for s in steps if getattr(s, "action", None) in _DOWNSAMPLE_KEEP]
+    if len(key) >= limit:
+        return key[:limit]
+    others = [s for s in steps if getattr(s, "action", None) not in _DOWNSAMPLE_KEEP]
+    budget = limit - len(key)
+    stride = max(1.0, len(others) / max(budget, 1))
+    sampled_ids = {
+        id(s)
+        for s in (
+            others[round(i * stride)]
+            for i in range(budget)
+            if round(i * stride) < len(others)
+        )
+    }
+    key_ids = {id(s) for s in key}
+    return [s for s in steps if id(s) in key_ids or id(s) in sampled_ids][:limit]
+
 
 _EVENT_TO_ACTION = {
     "compare": "compare",
@@ -78,9 +149,15 @@ _EVENT_TO_ACTION = {
 class SolutionAnimationService:
     """Generate algorithm animations from the canonical solution trace."""
 
+    resolve_complexity = staticmethod(resolve_complexity)
+
     def __init__(self, executor: CodeExecutor):
         self.executor = executor
         self._validator = AnimationValidator()
+
+    def _log_quality(self, algorithm: str, animation: Dict[str, Any]) -> None:
+        for warning in self._validator.lint_quality(animation):
+            logger.warning("Animation quality (%s): %s", algorithm, warning)
 
     async def build_animation(
         self,
@@ -146,6 +223,7 @@ class SolutionAnimationService:
         if planner_animation is not None:
             validated, reason = self._validator.validate(planner_animation)
             if validated is not None:
+                self._log_quality(algorithm, validated)
                 return validated
             logger.warning(
                 "Planner animation for %s failed validation: %s", algorithm, reason
@@ -162,6 +240,7 @@ class SolutionAnimationService:
                 "Compiled animation for %s failed validation: %s", algorithm, reason
             )
             return None
+        self._log_quality(algorithm, validated)
         return validated
 
     def _try_planner(
@@ -177,7 +256,7 @@ class SolutionAnimationService:
                 viz = "sorted-array"
             elif entry["family"] == "array" and algorithm in ("bubble_sort",):
                 viz = "bars"
-            time_c, space_c = _COMPLEXITY_BY_ALGO.get(algorithm, ("O(n)", "O(1)"))
+            time_c, space_c = resolve_complexity(entry, algorithm)
             steps: List[AnimationStepSpec] = []
             for e in events:
                 if e.kind in ("init", "return"):
@@ -230,8 +309,7 @@ class SolutionAnimationService:
                 steps.append(AnimationStepSpec(**kwargs))
             if not steps:
                 return None
-            if len(steps) > 96:
-                steps = steps[:96]
+            steps = downsample_steps(steps, limit=96)
             spec = AlgorithmAnimation(
                 algorithm=algorithm,
                 visualization=viz,  # type: ignore[arg-type]

--- a/backend/tests/unit/test_animation_quality_141.py
+++ b/backend/tests/unit/test_animation_quality_141.py
@@ -1,0 +1,141 @@
+"""Issue #141 — animation quality gates (RED phase).
+
+Covers the four backend quality gaps without touching the frontend renderer:
+1. planner path validates for all non-array families
+2. complexity resolves per-algo/family instead of O(n)/O(1) default
+3. long traces downsample instead of hard-cutting the tail
+4. semantic lint surfaces missing camera/badge/narration quality
+"""
+
+from app.models.animation_spec import (
+    AlgorithmAnimation,
+    AnimationStepSpec,
+    Complexity,
+    InitialState,
+)
+from app.services import scene_planner as planner
+from app.services.animation_validator import AnimationValidator
+from app.services.solution_animation_service import (
+    SolutionAnimationService,
+    resolve_complexity,
+    downsample_steps,
+)
+
+
+def _spec(viz, steps, array=(5, 2, 8, 1, 3)):
+    return AlgorithmAnimation(
+        algorithm=f"test-{viz}",
+        visualization=viz,  # type: ignore[arg-type]
+        initialState=InitialState(array=list(array), extra={}),
+        steps=steps,
+        complexity=Complexity(time="O(n)", space="O(1)"),
+        title=f"Test {viz}",
+    )
+
+
+def _visit_steps(n=3):
+    return [AnimationStepSpec(action="visit", index=i) for i in range(n)]
+
+
+class TestPlannerPathValidates:
+    def _assert_valid(self, beats):
+        validated, reason = AnimationValidator().validate(
+            {"title": "T", "steps": beats}
+        )
+        assert validated is not None, reason
+
+    def test_stack_planner_validates(self):
+        spec = _spec(
+            "stack",
+            [
+                AnimationStepSpec(action="push", values=[1]),
+                AnimationStepSpec(action="push", values=[2]),
+                AnimationStepSpec(action="pop", values=[2]),
+            ],
+        )
+        self._assert_valid(planner.plan_stack(spec))
+
+    def test_tree_planner_validates(self):
+        spec = _spec("tree", _visit_steps(3))
+        self._assert_valid(planner.plan_tree(spec))
+
+    def test_graph_planner_validates(self):
+        spec = _spec("graph", _visit_steps(3))
+        self._assert_valid(planner.plan_graph(spec, "graph"))
+
+    def test_intervals_planner_validates(self):
+        spec = _spec("intervals", _visit_steps(3))
+        self._assert_valid(planner.plan_intervals(spec))
+
+    def test_backtrack_planner_validates(self):
+        spec = _spec("backtrack", _visit_steps(3))
+        self._assert_valid(planner.plan_backtrack(spec))
+
+
+class TestComplexityResolution:
+    def test_sorting_gets_nlogn_not_default(self):
+        time_c, space_c = resolve_complexity({"family": "array"}, "merge_sort")
+        assert time_c == "O(n log n)"
+
+    def test_graph_bfs_gets_vertex_edge_complexity(self):
+        time_c, _ = resolve_complexity({"family": "graph"}, "clone_graph")
+        assert time_c == "O(V+E)"
+
+    def test_entry_complexity_takes_precedence(self):
+        entry = {"family": "array", "complexity": ("O(n)", "O(n)")}
+        assert resolve_complexity(entry, "two_sum") == ("O(n)", "O(n)")
+
+    def test_unknown_array_falls_back_to_family_default(self):
+        time_c, space_c = resolve_complexity({"family": "array"}, "some_unknown_algo")
+        assert time_c and space_c
+
+
+class TestDownsampling:
+    def test_long_trace_keeps_key_events(self):
+        steps = [
+            AnimationStepSpec(action="compare", indices=[0, 1]) for _ in range(200)
+        ]
+        steps.append(AnimationStepSpec(action="mark", index=0))
+        capped = downsample_steps(steps, limit=96)
+        assert len(capped) <= 96
+        assert any(s.action == "mark" for s in capped)
+
+    def test_service_cap_helper_exists(self):
+        assert callable(downsample_steps)
+        assert len(downsample_steps(_visit_steps(3), limit=96)) == 3
+
+
+class TestSemanticLint:
+    def test_lint_flags_missing_camera_and_badge(self):
+        script = {
+            "title": "T",
+            "steps": [
+                {"narration": "a", "shapes": [], "motion": []},
+                {"narration": "a", "shapes": [], "motion": []},
+                {"narration": "", "shapes": [], "motion": []},
+            ],
+        }
+        warnings = AnimationValidator().lint_quality(script)
+        assert any("camera" in w.lower() for w in warnings)
+        assert any("badge" in w.lower() for w in warnings)
+        assert any("narration" in w.lower() for w in warnings)
+
+    def test_lint_quiet_on_cinematic_beats(self):
+        beats = planner.plan_array(
+            _spec(
+                "array",
+                [
+                    AnimationStepSpec(action="compare", indices=[0, 1]),
+                    AnimationStepSpec(action="swap", indices=[0, 1]),
+                    AnimationStepSpec(action="mark", index=2),
+                ],
+                array=[3, 1, 2],
+            )
+        )
+        warnings = AnimationValidator().lint_quality({"title": "T", "steps": beats})
+        assert warnings == []
+
+    def test_service_exposes_resolve_complexity(self):
+        assert callable(SolutionAnimationService.resolve_complexity) or callable(
+            resolve_complexity
+        )

--- a/backend/tests/unit/test_solution_animation_service.py
+++ b/backend/tests/unit/test_solution_animation_service.py
@@ -187,6 +187,8 @@ class TestBuildAnimation:
         assert animation is not None
         validated, reason = AnimationValidator().validate(animation)
         assert validated is not None, reason
-        assert "stack_box" in {
-            op["target"] for step in animation["steps"] for op in step["motion"]
-        }
+        # #141: the cinematic planner path now validates for stack, so it wins
+        # over the family-compiler fallback (stack_box). Pin the planner scene.
+        targets = {op["target"] for step in animation["steps"] for op in step["motion"]}
+        assert "stack_base" in targets
+        assert AnimationValidator().lint_quality(animation) == []


### PR DESCRIPTION
Closes #141

## What
Backend-only animation quality (no frontend renderer change, contract-stable):
- Planner path validates for all 8 families (stack/tree/graph/grid/intervals/backtrack emit real container shapes; stack pop carries move+disappear for the transform-op rule)
- Per-algo/family complexity resolution (entry > algo map > family default) instead of O(n)/O(1) fallback
- Key-event-preserving downsampling (limit 96) instead of hard head-cut
- Non-blocking AnimationValidator.lint_quality (camera/badge/narration) logged by SolutionAnimationService

## Tests (TDD red->green)
- New backend/tests/unit/test_animation_quality_141.py (14 tests: planner validation x5, complexity x4, downsampling x2, lint x3)
- Updated test_stack_family_question_dispatches_to_stack_compiler to pin planner path (stack_base + clean lint) instead of compiler fallback
- Full backend unit suite: 1175 passed; ruff check + format clean