### PR TITLE
docs: re-audit living docs against origin/main (51f7a02)

### DIFF
--- a/Docs/AUDIT_REPORT.md
+++ b/Docs/AUDIT_REPORT.md
@@ -11,6 +11,20 @@
 > to Markdown (`README.md`, `Progress.md`, `Ideas.md`). References to SQLite,
 > file-based storage, or side docs such as `Goal.md`/`Phase2.md` describe the
 > audit-time state and are not current.**
+>
+> **Note (Sep 04, 2026, `docs/no-issue-docs-sync`):** Still historical — the body
+> below is preserved as written. Landed since Aug 14 and NOT reflected in the
+> scored sections: durable rescue queue (F2), mistake-memory error-graph + SM-2
+> (F6), full skill mapping (F3, now 26 skills: 21 roadmap + 5 supporting after
+> `#134`/`#135`/`#138`), C/Java curricula (F5), SQL `COUNT(*)` pushdown (M-04),
+> Redis workspace persistence (`#124`), adapter-state durability (`#133`,
+> head `b4c5d6e7f8a1`), anonymous course-list cache (`#144`), learner-context
+> + coach warm + `surface` split (`#125`/`#131`/`#132`), 8-family animation
+> planner + quality gates (`#141`), non-skippable `ANIMATION` validation gate,
+> SEC-1..4 (httpOnly refresh + CSRF, in-process limiter replacing slowapi,
+> markdown sanitize, Piston SSRF guard), security headers, debug guard,
+> CI workflows, and question-delete cache invalidation (`#143`). For current
+> status see `Progress.md` / `Ideas.md` / `README.md` (audited Sep 04).
 
 ---
 

--- a/Docs/PENDING_WORK_PLAN.md
+++ b/Docs/PENDING_WORK_PLAN.md
@@ -14,9 +14,9 @@ remaining product, quality, testing, and ops backlog.
 
 ## Phase 0 — Ops (no code, do first)
 
-### OPS-1 · Apply pending migrations to live Supabase — ✅ DONE (already at head e1f2a3b4c5d6, verified)
-- **What:** `alembic upgrade head` (head = `e1f2a3b4c5d6`) via `DIRECT_URL` (session pooler).
-- **Applies:** `c8d0e1f2a3b4` (repair `rate_limit_events` + `request_count`), `d9e1f2a3b4c5` (`submissions`), `e1f2a3b4c5d6` (public `request_count`).
+### OPS-1 · Apply pending migrations to live Supabase — ✅ DONE (at head b4c5d6e7f8a1, verified)
+- **What:** `alembic upgrade head` (head = `b4c5d6e7f8a1`) via `DIRECT_URL` (session pooler).
+- **Applies since `e1f2a3b4c5d6`:** `f2a3b4c5d6e7` (`rescue_queue`), `a3b4c5d6e7f8` (`review_cards`), `c9d0e1f2a3b4` (taxonomy DP prune), `b4c5d6e7f8a1` (`coaching_interactions` + `execution_jobs` + `submissions` status columns).
 - **Verify:** `alembic heads` = single head; `alembic current` = head; `/health/` → `questions_db == "ok"`.
 - **Dep:** none. **Blocks:** any backend deploy.
 
@@ -68,15 +68,16 @@ as a tiny, re-entry step — the "no-loss economy" of the mistake-memory moat.
 - Reuse the `RescueIntervention` concept already referenced in `Progress.md`
   (checkpoints + flow maps exist). Add a durable record:
   - `rescue_queue` table: `id (uuid pk)`, `user_id (fk)`, `question_id (fk)`,
-    `status` (`abandoned` | `due` | `completed` | `dismissed`),
+    `status` (`abandoned` | `completed` | `dismissed` — "due" is **derived**,
+    `status='abandoned' AND due_at <= now()`),
     `first_abandoned_at`, `due_at` (next re-surface time),
     `resurface_count`, `last_intervention_at`, `created_at`, `updated_at`.
   - Index: `(user_id, status, due_at)` — the "what's due for me today" query.
 - Idempotent upsert: one open row per (user, question).
 
 **API surface (new `app/api/rescue.py`, port + `sql_*` repo)**
-- `GET /api/rescue/due` — due items for the current user (filter
-  `status='due' AND due_at <= now`, ordered by `due_at`).
+- `GET /api/rescue/due` — due items for the current user (derived:
+  `status='abandoned' AND due_at <= now`, ordered by `due_at`).
 - `POST /api/rescue/{question_id}/abandon` — mark abandoned, set
   `due_at = tomorrow 09:00 local` (first time), or push one day out on repeat
   abandonment; idempotent.
@@ -97,7 +98,7 @@ as a tiny, re-entry step — the "no-loss economy" of the mistake-memory moat.
 - Backend (integration, fresh client + mocked repo):
   - abandon → row created with `due_at` tomorrow; re-abandon same question
     is idempotent (no duplicate rows).
-  - `due` returns only rows where `due_at <= now` and `status='due'`.
+  - `due` returns only rows where `due_at <= now` and `status='abandoned'` (due is derived, never stored).
   - complete/dismiss transition the row; dismissed never re-surfaces.
 - Frontend: hook calls the API on abandon; queue renders due items; solving
   removes the item.
@@ -113,7 +114,9 @@ as a tiny, re-entry step — the "no-loss economy" of the mistake-memory moat.
 
 ---
 
-### F3 · Skill-graph mapping 21 → 109 🟠 — every question recommendable
+### F3 · Skill-graph mapping 21 → 109 🟠 — every question recommendable — ✅ DONE (Aug 23; taxonomy reworked Sep 04)
+
+> Sep 04 note: the live inventory is now 107 ids (`backend/tests/fixtures/live_question_ids.json`); taxonomy is 26 skills (21 roadmap in NeetCode `ROADMAP_ORDER` + 5 supporting, `#134`/`#135`); stale DP rows pruned (`c9d0e1f2a3b4`, `#138`).
 
 **Goal / user value**
 "Practice Next" only works for questions mapped to skills. Today 25 mapping
@@ -155,13 +158,13 @@ question resolves a skill-based next-step.
 **Effort:** Medium (mostly taxonomy curation).
 
 **Definition of done**
-- 109/109 mapped in the taxonomy; `question_skills` ≥ 109 rows on live;
+- 109/109 mapped in the taxonomy (superseded Sep 04: 107 live ids — see note at the top of this section); `question_skills` ≥ 109 rows on live;
   every mapping resolves to a real question; recommendations non-empty for
   mapped questions.
 
 ---
 
-### F5 · C / Java curricula 🟡 — curriculum breadth
+### F5 · C / Java curricula 🟡 — curriculum breadth — ✅ DONE (Aug 23: 5 modules / 35 lessons each, 30/30 Piston verified)
 
 **Goal / user value**
 The curriculum is Python-only today. C and Java unlock the language-oriented
@@ -212,7 +215,7 @@ lessons, structured like Python Fundamentals (modules → lessons → exercises)
 | M-01 | Split `LessonPage.tsx` (381 lines) into `EditorPanel`/`ChatPanel`/`LessonSidebar`/`ProgressBar` | existing lesson page tests keep passing | High |
 | M-02 | Split `schemas.py` (500 lines) into `coach/execution/question` modules | import parity test | Medium |
 | M-03 | Add TanStack Query; replace manual `useEffect` fetch hooks | existing hook tests (15 files) stay green | Medium |
-| M-04 | Fix N+1 filtered count — `total = len(summaries)` → SQL `COUNT(*)` in repo | assert repo issues a single `COUNT` query (query-count spy) | Low |
+| M-04 | Fix N+1 filtered count — `total = len(summaries)` → SQL `COUNT(*)` in repo (✅ DONE: `func.count()` in `sql_question_repository.py`) | assert repo issues a single `COUNT` query (query-count spy) | Low |
 | M-07 | Keyset cursor pagination for `/api/questions` + admin list endpoints | contract test for `next_cursor` response shape | Medium |
 | L-01 | Standardize on `lucide-react`; drop `@radix-ui/react-icons` | visual/typecheck | Low |
 | L-02 | Move hardcoded Tailwind colors to CSS custom properties | snapshot | Low |

--- a/Docs/TEST_ENVIRONMENT.md
+++ b/Docs/TEST_ENVIRONMENT.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **IMP — the current Supabase project is the TEST database, and the Google
 > OAuth integration is TEST OAuth. A production database is NOT configured yet.**
-> Last verified: 2026-08-15.
+> Last verified: 2026-08-15 (migration head re-verified Sep 04, 2026: `b4c5d6e7f8a1`).
 
 This document is the source of truth for how the **test** environment is wired.
 Nothing here is production.
@@ -131,7 +131,7 @@ curl -X POST http://localhost:8000/api/auth/supabase -H "Content-Type: applicati
 The test DB is migrated to Alembic head:
 
 ```
-alembic_version = e1f2a3b4c5d6
+alembic_version = b4c5d6e7f8a1
 ```
 
 Apply/re-run (against the test project, session pooler):
@@ -143,8 +143,17 @@ export DATABASE_URL="$(grep '^DIRECT_URL=' .env | cut -d= -f2- | tr -d '\"')"
 ```
 
 **Never** run tests against the test project DB — the test suite uses a local
-Postgres (`postgres:16` on `127.0.0.1:5433`) and refuses non-local hosts
-(`backend/tests/db_guard.py`).
+Postgres (`postgres:16` on `127.0.0.1:5433` in the example below; `conftest.py`
+defaults to `127.0.0.1:5432` when `DATABASE_URL` is unset) and refuses non-local hosts
+(`backend/tests/db_guard.py`, overridable only with `ALLOW_PRODUCTION_TEST_DB=1`).
+
+Test isolation details (`backend/tests/conftest.py`):
+- Each run creates an isolated schema (`codecoach_test`, or `codecoach_test_gwN`
+  per xdist worker) set via `DATABASE_SEARCH_PATH`, and drops it afterwards.
+- Shared auth builders: `backend/tests/fixtures/auth_helpers.py`
+  (`register_headers`, `register_user_headers`, `admin_headers`, `aregister_headers`).
+- Seed bank: 50 questions (5 hand-written + 45 generated) plus the 107 live ids
+  (`backend/tests/fixtures/live_question_ids.json`).
 
 ---
 

--- a/Ideas.md
+++ b/Ideas.md
@@ -2,7 +2,7 @@
 
 > Status legend: 🔴 Not started · 🟡 Partial / foundation only · 🟢 Mostly built · ✅ Done
 > Trackable with checkboxes — tick `[x]` as work lands.
-> Audit date: Sep 02, 2026 (branch `feat/125-coach-skill-context-cache` — audited against code). Companion status doc: [Progress.md](./Progress.md).
+> Audit date: Sep 04, 2026 (branch `docs/no-issue-docs-sync`, origin/main `51f7a02` — audited against code). Companion status doc: [Progress.md](./Progress.md).
 
 This is a **closed / private** product. Defensibility therefore rides on the
 product's own data and UX personality, not on an open-source community.
@@ -11,14 +11,14 @@ product's own data and UX personality, not on an open-source community.
 
 | # | Idea | Status | Key blocker |
 |---|------|--------|-------------|
-| 1 | Mistake-memory moat | ✅ Done (+ learner-context shipped `f246c4a`) | No blocker — submissions + error graph + SM-2 + analytics + learner-context caching landed; backfill only |
-| 2 | Segment moat | 🟡 | No professor/class dashboard |
+| 1 | Mistake-memory moat | ✅ Done (+ learner-context `f246c4a`, adapter-state `#133`) | No blocker — submissions + error graph + SM-2 + analytics + learner-context + adapter-state audit landed; backfill only |
+| 2 | Segment moat | 🟡 | No professor/class dashboard (course list now anonymously cached, `#144`) |
 | 3 | Forgetting-curve UI | ✅ Done | None — `/dashboard` memory graph live |
 | 4 | Never-alone rescue contract | ✅ Done | None — durable queue + T1→T2→T3 live; flow-map retired to animate |
-| 5 | See-how-you-think replay | 🟡 | `ProblemFlowMap` static list, not journey replay |
-| 6 | Live interviewer theater | 🔴 | Needs session/event engine |
-| 7 | Time-travel debugging | 🟡 | `trace_instrumenter` exists for animation only; needs generic user-code tracing |
-| 8 | Reverse interview | 🔴 | Cheap — `CoachingMode.SENIOR` + prompt not yet added |
+| 5 | See-how-you-think replay | 🟡 | `ProblemFlowMap` static list, not journey replay (workspace code/chat now persisted — more journey data) |
+| 6 | Live interviewer theater | 🔴 | Needs session/event engine (surface split + coach warm are new primitives) |
+| 7 | Time-travel debugging | 🟡 | `trace_instrumenter` exists for animation only + `#141` quality gates; needs generic user-code tracing |
+| 8 | Reverse interview | 🔴 | Cheap — `CoachingMode.SENIOR` + prompt not yet added (`surface` is the seam) |
 | 9 | Honourable mentions | 🔴 | Backlog |
 
 ---
@@ -35,17 +35,17 @@ Why it's leverage: every session compounds switching cost. Five years of a
 user's mistake-history is a moat nobody can walk into. This is the thing you
 gather user data for.
 
-### Status: ✅ Done — plus learner-context shipped (`f246c4a` Sep 02)
+### Status: ✅ Done — plus learner-context shipped (`f246c4a` Sep 02) and adapter-state durability (`#133` Sep 04)
 
 **Detailed explanation:** The core product promise is that every run/submit/diagnosis
 a user makes is persisted per-user. From that history we derive (a) an error graph
 linking questions → failing concepts → recurring error signatures, (b) a spaced-repetition
 scheduler (SM-2/FSRS) that quizzes you on your _own_ past bugs, and (c) learning-analytics
-signals like "recursion plateau detected." Now **unblocked**: `SubmissionORM` (`submissions` table, `d9e1f2a3b4c5`) is live, and `LearnerContextService` (`backend/app/services/learner_context_service.py`, `backend/app/core/cache_keys.py`) composes cached skill graph + recent attempts into coach prompts (`feat/125`).
+signals like "recursion plateau detected." Now **unblocked**: `SubmissionORM` (`submissions` table, `d9e1f2a3b4c5`) is live, and `LearnerContextService` (`backend/app/services/learner_context_service.py`, `backend/app/core/cache_keys.py`) composes cached skill graph + recent attempts into coach prompts (`feat/125`). Since Sep 04 every coach/exec/submit call is also durability-tracked: `coaching_interactions` + `execution_jobs` + `submissions.status` (migration `b4c5d6e7f8a1`, `CoachingAdapter`/`ExecutionAdapter`, `adapter_state_recovery` worker, `GET /api/coach/interactions`).
 
 **The critical gap (was):** the codebase stored completed lessons (`course_progress`),
 usage events, and skill-graph learning events, but never persisted actual code attempts
-— now **RESOLVED**: `submissions` + `review_cards` + `error_graph` + learner-context `f246c4a` are at head; diagnosis capture remains the only open wire (Piston `run`/`submit` already best-effort).
+— now **RESOLVED**: `submissions` + `review_cards` + `error_graph` + learner-context `f246c4a` + adapter-state `#133` are at head; diagnosis capture remains the only open wire (Piston `run`/`submit` already best-effort, coach/exec `sent`-states now auditable).
 
 ### Progress
 
@@ -56,7 +56,8 @@ usage events, and skill-graph learning events, but never persisted actual code a
 - [x] Spaced-repetition scheduler producing review sessions from own past bugs (SM-2, `/api/reviews/*`)
 - [x] Learning-analytics signals ("recursion plateau detected")
 - [x] Learner-aware coaching (shipped `f246c4a`): `LearnerContextService` + `cache_keys.py` + `PromptBuilder` injection + `submit`/`skills` invalidation + `MainWorkspace` full description + `learner-context-invalidated` refresh
-- [ ] Backfill/adopt for existing questions where feasible
+- [x] Adapter-state durability (shipped `#133`): `coaching_interactions` + `execution_jobs` + `submissions.status` (`b4c5d6e7f8a1`), `CoachingAdapter`/`ExecutionAdapter` sent-tracking, `adapter_state_recovery` worker, `GET /api/coach/interactions`
+- [ ] Backfill/adopt for existing questions where feasible (`scripts/backfill_skill_graph.py` emits idempotent `backfill:{submission.id}` events)
 
 ### Next steps
 
@@ -78,10 +79,10 @@ Closed-source lets you be ruthlessly niche without community backlash:
 Why it's leverage: giants fight for the crowded middle (interview grinders).
 Owning one underserved segment makes you the default, not a choice.
 
-### Status: 🟡 Partial — curriculum exists, no professor ecosystem
+### Status: 🟡 Partial — curriculum exists, no professor ecosystem (course list anonymously cached `#144`)
 
 **Detailed explanation:** The curriculum half is built: Python Fundamentals —
-modules, lessons, progress tracking, exercises, `/learn`. The segment-moat half
+modules, lessons, progress tracking, exercises, `/learn` — served from the DB through a cached `CourseService` (anonymous list in Redis, 30s + stampede lock, invalidated on admin writes). The segment-moat half
 is not: there is no professor/class dashboard, no roster/classroom model, and no
 first-30-days onboarding funnel. The "one professor = a whole class" flywheel
 needs a teaching view.
@@ -192,19 +193,19 @@ Why it's a moat: it needs your full attempt-history (the data you're already
 gathering for idea #1), and it makes users look back at themselves — rare and
 addictive. Nobody else can show you your brain.
 
-### Status: 🟡 Partial — per-solve `ProblemFlowMap` static list, not journey replay — code-audited Sep 02
+### Status: 🟡 Partial — per-solve `ProblemFlowMap` static list, not journey replay — code-audited Sep 04
 
 **Detailed explanation:** The flow-map feature (`frontend/src/components/rescue/ProblemFlowMap.tsx`,
 static checkpoint list, plus `frontend/src/components/visualization/` for animations) shows a checkpoint map
 for a single solve. It is **not** a replay of the user's _attempt journey_ (every
-attempt, where they errored, how their code evolved). `submissions` history is now persisted (#1 done), so the data layer is unblocked — the renderer/timeline is still missing. Former AI flow-map was retired to `animate`.
+attempt, where they errored, how their code evolved). `submissions` history is now persisted (#1 done) and the workspace journey is captured (Redis draft code + chat + last exec/submit via `WorkspaceService`, `#124`) — the renderer/timeline is still missing. Former AI flow-map was retired to `animate`.
 
 ### Progress
 
 - [x] Flow-map checkpoint list (`ProblemFlowMap.tsx`) + rescue checkpoints (`rescue.checkpoints.ts`)
 - [x] Animation visualization infra (`AnimationPlayer.tsx`, `AnimationScriptRenderer.tsx`) for canonical solutions only
 - [x] AI diagnosis of a submission (deterministic fallback)
-- [x] Persist full attempt journey per problem — **unblocked** (`submissions` now live, needs journey query)
+- [x] Persist full attempt journey per problem — **unblocked** (`submissions` now live + workspace Redis code/chat/last-exec via `WorkspaceService`, needs journey query)
 - [ ] Animated replay timeline over the stored journey
 - [ ] "Where you errored / what you almost got" highlights
 
@@ -228,12 +229,12 @@ answer. Fail = the interviewer "loses interest."
 Why it's a moat: a UX personality and a live-reaction paradigm can't be copied by
 adding database tables. Immersive, shareable, high retention.
 
-### Status: 🔴 Not started — streaming foundation exists
+### Status: 🔴 Not started — streaming foundation exists (+ surface split / warm primitives Sep 04)
 
 **Detailed explanation:** The key foundation already exists: the backend streams
 AI coaching via SSE (`POST /coach/stream` in `backend/app/api/coach.py`), the
 frontend consumes it via `coaching.service.ts` / `coaching.hook.ts`, and the
-editor (`CodeEditor.tsx`, Monaco) can emit change events. What's missing is the
+editor (`CodeEditor.tsx`, Monaco) can emit change events. New since Sep 04: the coach has a `surface` split — `questions` (graph-aware, fetches learner-context) vs `learn` (graph-free) — and `POST /api/coach/warm` pre-warms learner-context on question enter (`useCoachWarm`), both natural session-engine primitives. What's missing is the
 _session engine_: a per-session interviewer state machine (attempts, last code
 snapshot, curveball cursor, persona mood) that reacts to editor debounce +
 run/pass events and pushes structured `CoachEvent`s (probe / interrupt /
@@ -243,6 +244,7 @@ history required.
 ### Progress
 
 - [x] SSE streaming coach endpoint (`POST /coach/stream`)
+- [x] Coach `surface` split (`questions` graph-aware vs `learn` graph-free, `#131`) + warm prefetch (`POST /api/coach/warm`, `useCoachWarm`, `#132`)
 - [x] Frontend streaming consumption (`coaching.service.ts` / `coaching.hook.ts`)
 - [x] Monaco editor change events (debounce hookup needed)
 - [ ] Interview session schema + event union (`probe`/`interrupt`/`requirement_change`/`reveal`/`escalate`)
@@ -271,11 +273,11 @@ position, variables mutating, the exact frame where a value went wrong.
 Why it's a moat: genuinely modern technology, not a gamification skin — it makes
 "watch the bug happen" possible. Self-contained and demo-able with zero user data.
 
-### Status: 🟡 Partial — canonical tracing only (Sep 02 audit)
+### Status: 🟡 Partial — canonical tracing only + quality gates (Sep 04 audit)
 
 **Detailed explanation:** Piston (`piston_service.py`) is stdout/exit-code only —
 it has **no step/trace support**. Canonical-solution tracing **is** built for animations:
-`backend/app/services/trace_instrumenter.py:35` `wrap_traced_solution` injects `__trace` helper + JSON-array dump, `trace_parser.py:112` `parse_trace` normalizes `init`/`compare`/`swap`/`pointer`/`mark`/…/`return` events, `SolutionAnimationService` compiles them into `AnimationScript` for `GET /api/coach/animate`. **Missing:** generic AST-instrumented tracing of the *student's* code (Python `ast` + JS transform) producing a scrubbable `TraceTimeline` (`TraceStep`/`TraceFrame` schemas, `POST /trace`), plus `TimelineScrubber` (play/pause, var inspector) and line-highlight overlay on `CodeEditor.tsx`. Former AI flow-map is now animate.
+`backend/app/services/trace_instrumenter.py:35` `wrap_traced_solution` injects `__trace` helper + JSON-array dump, `trace_parser.py:112` `parse_trace` normalizes `init`/`compare`/`swap`/`pointer`/`mark`/…/`return` events, `SolutionAnimationService` compiles them into `AnimationScript` for `GET /api/coach/animate` — now through an 8-family scene planner with complexity resolution, 96-step downsampling, and a `lint_quality` gate (`#141`). **Missing:** generic AST-instrumented tracing of the *student's* code (Python `ast` + JS transform) producing a scrubbable `TraceTimeline` (`TraceStep`/`TraceFrame` schemas, `POST /trace`), plus `TimelineScrubber` (play/pause, var inspector) and line-highlight overlay on `CodeEditor.tsx`. Former AI flow-map is now animate.
 
 ### Progress
 
@@ -308,7 +310,7 @@ follow-ups until you've taught it.
 Why it's leverage: cheap to ship first (no realtime needed) and it validates the
 shared persona engine that powers ideas #6 and #7.
 
-### Status: 🔴 Not started — cheapest genuinely-new win
+### Status: 🔴 Not started — cheapest genuinely-new win (coach `surface` is the seam)
 
 **Detailed explanation:** `CoachingMode` (`backend/app/models/schemas.py`) already
 has hint/review/explain/debug/freeform/animate. This adds a `senior` mode where the
@@ -371,12 +373,14 @@ numbered ideas when chosen.
 
 ---
 
-## Suggested execution order (updated Sep 02 — code-audited)
+## Suggested execution order (updated Sep 04 — code-audited)
 
-1. **#8 Reverse interview** — smallest effort, validates the persona engine (`CoachingMode.SENIOR`, `coaching_prompts.py` junior persona, mode picker) — cheapest genuinely-new win
-2. **#6 Live interviewer theater** — flagship, rides existing SSE (`POST /coach/stream`) + persona engine from #8
-3. **#5 Attempt-journey replay** — now **unblocked** by #1 `submissions` (audited Sep 02); animate with existing `ProblemFlowMap` + `AnimationPlayer`
-4. **#7 Time-travel debugging — student-code path** — canonical trace done; add generic `TracingExecutor` + `POST /trace` + `TimelineScrubber`
+1. **#8 Reverse interview** — smallest effort, validates the persona engine (`CoachingMode.SENIOR`, `coaching_prompts.py` junior persona, mode picker; plugs into the `surface` seam) — cheapest genuinely-new win
+2. **#6 Live interviewer theater** — flagship, rides existing SSE (`POST /coach/stream`) + `surface` split + warm prefetch + persona engine from #8
+3. **#5 Attempt-journey replay** — now **unblocked** by #1 `submissions` + workspace Redis journey (`WorkspaceService`); animate with existing `ProblemFlowMap` + `AnimationPlayer`
+4. **#7 Time-travel debugging — student-code path** — canonical trace done + `#141` quality gates; add generic `TracingExecutor` + `POST /trace` + `TimelineScrubber`
 5. **#2 professor dashboard** — define `class`/`roster` model + class-level views (reads existing `course_progress`)
 6. **#1 residual** — diagnosis capture
 7. **#9 Honourable mentions** — promote after #8: adversarial twin / takeover (cheap, no data)
+
+> Taxonomy note (Sep 04, `#134`/`#135`/`#138`): the skill inventory is now 26 skills — 21 roadmap buckets in NeetCode `ROADMAP_ORDER` plus 5 supporting skills kept for analytics/coaching context. "Practice Next" and any roadmap UI must use the roadmap track (`is_roadmap_skill` / `get_roadmap`), not the full skill list.

--- a/Progress.md
+++ b/Progress.md
@@ -1,6 +1,6 @@
 # Progress — CodeCoach AI
 
-> Last updated: September 02, 2026 (branch `feat/125-coach-skill-context-cache`) — audited against code.
+> Last updated: September 04, 2026 (branch `docs/no-issue-docs-sync`, origin/main `51f7a02`) — audited against code.
 
 This is the project's living status document. It is kept in sync with the code:
 if a section lists a feature as **Built**, that capability exists in the current
@@ -10,7 +10,7 @@ codebase. Feature-by-feature status with checkboxes lives in [Ideas.md](./Ideas.
 
 | Phase                           | Status              | Notes                                                                                                                     |
 | ------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Phase 1 — DSA Practice          | **Mostly complete** | 109/100 questions in DB (33 Easy / 50 Medium / 26 Hard); skill-graph "Practice Next" shipped (109/109 mapped, F3); `submissions`/`review_cards`/`rescue_queue` at head; learner-context cache landed |
+| Phase 1 — DSA Practice          | **Mostly complete** | 107 live questions (`live_question_ids.json`), 107/107 skill-mapped (F3); `submissions`/`review_cards`/`rescue_queue`/`coaching_interactions`/`execution_jobs` at head (`b4c5d6e7f8a1`); learner-context cache + coach warm landed; taxonomy split into 21 roadmap + 5 supporting skills |
 | Phase 2 — Programming Languages | **Partial**         | Python Fundamentals + C Programming + Java Programming shipped (5 modules each); DBMS/OOP/WebDev/MCQ still Phase 3        |
 | Phase 3 — Future Modules        | **Planned**         | DBMS, OOP, Web Dev, MCQ, Classroom                                                                                        |
 
@@ -20,17 +20,17 @@ codebase. Feature-by-feature status with checkboxes lives in [Ideas.md](./Ideas.
 
 | Feature               | Status | Notes                                                                                                                                              |
 | --------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| AI Coaching           | ✅     | 6 modes (hint, review, explain, debug, freeform, animate), SSE streaming, structured JSON; lesson-aware + learner-aware (skill + recent-attempt blocks) |
-| Code Execution        | ✅     | Piston; Python / JavaScript / Java wrappers; run + validate endpoints                                                                              |
-| Submit & Grade        | ✅     | Visible + hidden test cases, pass/fail; `submit` emits idempotent `LearningEvent sub:{id}` to skill graph, `run` captures `question_id` crashes |
-| Question Bank         | ✅     | CRUD, search, filter, `/stats` aggregates; admin management (`/api/questions`, `/api/admin/questions`)                                            |
-| Question Validation   | ✅     | 7 validation use cases (structure, tests, starter, solution, time, signature, output format)                                                       |
-| Curriculum            | ✅     | Python Fundamentals — 5 modules, 36 lessons (21 theory + 15 exercises); C + Java — 5 modules, 35 lessons each (20 theory + 15 exercises)         |
-| Lesson-aware Coaching | ✅     | Lesson context injected into AI prompts (`PromptBuilder._lesson_context_block`)                                                                    |
+| AI Coaching           | ✅     | 6 modes (hint, review, explain, debug, freeform, animate), SSE streaming, structured JSON; lesson-aware + learner-aware (skill + recent-attempt blocks); `surface=questions` (graph-aware) vs `surface=learn` (graph-free, `#131`); background warm via `POST /api/coach/warm` (`useCoachWarm`, `#132`) |
+| Code Execution        | ✅     | Piston; Python / JavaScript / Java wrappers; run + validate endpoints; version self-heal + `exec:run` cache (`piston_service.py`)                                                                              |
+| Submit & Grade        | ✅     | Visible + hidden test cases, pass/fail; `submit` emits idempotent `LearningEvent sub:{id}` to skill graph, `run` captures `question_id` crashes; graded through `submit_grading_service` with adapter-state tracking (`sent → submitted → graded/failed`, `#133`) |
+| Question Bank         | ✅     | CRUD, search, filter, `/stats` aggregates (SQL `COUNT(*)` pushdown, `M-04`); paginated list + summary-column search; admin management (`/api/questions`, `/api/admin/questions`); delete invalidates detail cache (`#143`)                                            |
+| Question Validation   | ✅     | 7 validation use cases (structure, tests, starter, solution, time, signature, output format) + non-skippable `ANIMATION` gate (`animation.steps >= 3`)                                                       |
+| Curriculum            | ✅     | Python Fundamentals — 5 modules, 36 lessons (21 theory + 15 exercises); C + Java — 5 modules, 35 lessons each (20 theory + 15 exercises); anonymous list served from Redis cache (30s + stampede lock, `#144`)         |
+| Lesson-aware Coaching | ✅     | Lesson context injected into AI prompts (`PromptBuilder._lesson_context_block`); required for `surface=learn` (`require_lesson_context_for_learn`)                                                                    |
 | Learner-aware Coaching | ✅     | `LearnerContextService` composes cached skill graph (weakest 3) + recent attempts (last 3) into system prompt; `GroqService` v7 hash skips cache when personalized; invalidated on `submit`/`skills` writes (`feat/125`) |
-| Solution Animations   | ✅     | Generate → validate → compile → play; canonical-solution `__trace` pipeline (`trace_instrumenter` + `trace_parser` + `SolutionAnimationService`); flow-map retired |
-| Skill Graph           | ✅     | Learning events → mastery per skill; statuses new/learning/developing/strong/needs_review; decay + prerequisites; 22 skills, 212 rows (109/109 mapped, F3) |
-| Practice Next         | ✅     | Recommended-questions API (`GET /api/skills/me/recommended-questions`) + UI queue on `/problems` via `useRecommendedQuestions` (109/109 mapped, silent refresh on `learner-context-invalidated`)    |
+| Solution Animations   | ✅     | Generate → validate → compile → play; canonical-solution `__trace` pipeline (`trace_instrumenter` + `trace_parser` + `SolutionAnimationService`); 8-family scene planner (`array/stack/linked_list/tree/graph/intervals/backtrack/searching`, `scene_planner.py`) with complexity resolution, 96-step downsampling, and `lint_quality` gate (`#141`); flow-map retired |
+| Skill Graph           | ✅     | Learning events → mastery per skill; statuses new/learning/developing/strong/needs_review; decay + prerequisites; 26 skills (21 roadmap in NeetCode `ROADMAP_ORDER` + 5 supporting for analytics/coaching context, `#134`/`#135`); stale DP rows pruned (`c9d0e1f2a3b4`, `#138`); 107/107 mapped (F3); idempotent `backfill_skill_graph.py` |
+| Practice Next         | ✅     | Recommended-questions API (`GET /api/skills/me/recommended-questions`) + UI queue on `/problems` via `useRecommendedQuestions` (107/107 mapped, silent refresh on `learner-context-invalidated`); roadmap-only view via `get_roadmap` + `GET /api/skills/boilerplate`    |
 | Rescue Contract       | ✅     | `RescueIntervention` + `ProblemFlowMap` (static checkpoint list via `rescue.checkpoints.ts`, flow-map retired); durable `rescue_queue` (`f2a3b4c5d6e7`) + `/api/rescue/*` ("Back tomorrow"); T1(4m)→T2(+5m AI hint)→T3(+5m re-plan) via `useRescueContract` |
 | Auth                  | ✅     | Email/password (JWT + bcrypt), refresh tokens, Supabase OAuth (Google) — "Continue with Google" button on `/login`                                 |
 | Usage Metering        | ✅     | Daily input/output token caps, `X-Usage-*` headers, Redis-backed limits                                                                            |
@@ -41,19 +41,21 @@ codebase. Feature-by-feature status with checkboxes lives in [Ideas.md](./Ideas.
 | Memory Graph          | ✅     | Forgetting-curve dashboard (Idea #3): `GET /api/memory/graph` aggregates review cards + submissions by `category` into per-topic energy-cost view (`daysSinceLastTouch`, `dueCount`, `lapses`); `MemoryGraph.tsx` sorted by `energyCostMinutes`; student `/dashboard` route with MemoryGraph + RescueDueQueue + ReviewsDueQueue; Header adds Dashboard link |
 | Learning Analytics    | ✅     | Plateau detection `GET /api/analytics/signals` (recursion plateau etc.), 7d window, bounded 1000; banner on `/dashboard`                            |
 | Admin Panel           | ✅     | Dashboard, users, questions, curriculum, usage analytics, abuse reports; Header shows **Admin Dashboard** link when `user.role ∈ {admin, super_admin}` (desktop + mobile, gated on `isHydrated`) |
-| Workspace UX          | ✅     | Monaco editor (CSP `worker-src blob:` fix `e51ddf4`), themes, resizable panels, onboarding tour, toasts                                               |
-| Infrastructure        | ✅     | Docker Compose (backend, frontend, redis, piston), Alembic, Supabase single DB, OpenNext build                                                     |
+| Workspace UX          | ✅     | Monaco editor (CSP `worker-src blob:` fix `e51ddf4`), themes, resizable panels, onboarding tour, toasts; draft code + last-visited + AI chat persisted to Redis (7d TTL, `PUT/GET/DELETE /api/workspace/*`, `useWorkspace` 800ms debounce, `#124`)                                               |
+| Workspace Persistence | ✅     | `WorkspaceService` (code, meta, last-visited, chat ≤20 msgs, last exec/submit snapshot; 51KB/5k-char caps, degrade-open) + `coach.py` best-effort chat append; last-visited resume on `/problems` |
+| Adapter-State Durability | ✅  | Every coach/exec/submit call tracked `sent → completed/failed` (`coaching_interactions`, `execution_jobs`, `submissions.status`, migration `b4c5d6e7f8a1`); stale rows recovered by `adapter_state_recovery` worker; `GET /api/coach/interactions` audit (`#133`) |
+| Infrastructure        | ✅     | Docker Compose (backend, frontend, redis, piston), Alembic (head `b4c5d6e7f8a1`), Supabase single DB, OpenNext build                                                     |
 
 ### Partial / foundation
 
 | Feature                | Status | What exists                                      | What's missing                                |
 | ---------------------- | ------ | ------------------------------------------------ | --------------------------------------------- |
 | Curriculum breadth     | ✅ C+Java live | **C Programming & Java Programming committed (F5)** | ML/PromptEng/R/JS source JSON parked; DBMS/OOP/WebDev/MCQ not started |
-| Question bank volume   | ✅ 109/109 | 109 seeded in DB (33 Easy / 50 Medium / 26 Hard), 109/109 skill-mapped (F3, 212 rows) | — |
-| ~~Rescue re-surface loop~~ | ✅ DONE (Aug 24) | Durable queue: `rescue_queue` + `/api/rescue/due` + "Back tomorrow" UI; dismissals permanent; T1→T2→T3 escalation now wired to AI coach | Time-based escalation ✅ DONE |
-| Attempt-journey replay | 🟡     | `ProblemFlowMap` checkpoint list (static) + `submissions` history now persisted; animation infra (`trace_parser`) for canonical solutions only | Animated replay timeline over own journey + "where you errored" highlights |
-| Interview theater      | 🟡     | SSE streaming (`POST /coach/stream`) + Monaco `onCodeChange` + `CoachingService` | Session/event engine + `InterviewSessionService` + `InterviewTheater` UI (Idea #6) |
-| Time-travel debugging  | 🟡     | `trace_instrumenter`/`trace_parser` for canonical-solution animation traces only | Generic AST tracing for user code + `POST /trace` + `TimelineScrubber` (Idea #7) |
+| Question bank volume   | ✅ 107/107 | 107 live questions (`live_question_ids.json`), 107/107 skill-mapped (F3) | — |
+| ~~Rescue re-surface loop~~ | ✅ DONE (Aug 24) | Durable queue: `rescue_queue` + `/api/rescue/due` + "Back tomorrow" UI; dismissals permanent (`status` stored as `abandoned/completed/dismissed`, `due` derived from `due_at`); T1→T2→T3 escalation now wired to AI coach | Time-based escalation ✅ DONE |
+| Attempt-journey replay | 🟡     | `ProblemFlowMap` checkpoint list (static) + `submissions` history persisted + workspace Redis journey data (draft code, chat, last exec/submit via `WorkspaceService`); animation infra (`trace_parser` + 8-family planner) for canonical solutions only | Animated replay timeline over own journey + "where you errored" highlights |
+| Interview theater      | 🟡     | SSE streaming (`POST /coach/stream`) + Monaco `onCodeChange` + `CoachingService`; `surface` split (graph-aware `questions` vs graph-free `learn`) + `POST /api/coach/warm` prefetch (`useCoachWarm`) as session primitives | Session/event engine + `InterviewSessionService` + `InterviewTheater` UI (Idea #6) |
+| Time-travel debugging  | 🟡     | `trace_instrumenter`/`trace_parser` for canonical-solution animation traces only (now with `#141` quality gates: complexity, 96-step downsample, `lint_quality`) | Generic AST tracing for user code + `POST /trace` + `TimelineScrubber` (Idea #7) |
 
 ### Planned
 
@@ -76,12 +78,12 @@ codebase. Feature-by-feature status with checkboxes lives in [Ideas.md](./Ideas.
 - **Backend:** FastAPI + Pydantic v2, Clean Architecture (ports / adapters / services / sql repositories)
 - **Frontend:** Next.js 14 (App Router), React 18, TypeScript, Tailwind CSS, Monaco Editor
 - **Database:** Supabase PostgreSQL (async SQLAlchemy) — the **only** database; Alembic migrations
- - **Cache / Limits:** Redis for request/rate-limit + learner-context (`coach:ctx` 60s, `skills:graph` 60s, `submissions:recent` 30s, `skills:recs` 60s)
+ - **Cache / Limits:** Redis for request/rate-limit + learner-context (`coach:ctx` 60s, `skills:graph` 60s, `submissions:recent` 30s, `skills:recs` 60s) + workspace (`workspace:*` 7d: code, chat, last-visited) + anonymous course list (30s + stampede lock) + question detail (300s, SCAN invalidation) + Piston runtimes (3600s); TTLs centralized in `cache_keys.py` + `config.py`
  - **Code Execution:** Piston (self-hosted Docker container)
-- **AI:** Groq (openai/gpt-oss-120b, openai/gpt-oss-20b; `animate` mode override) with per-user daily token metering; `cache_keys.py` centralized TTLs
-- **Auth:** Email/password (bcrypt + JWT) + Supabase OAuth (Google)
-- **Rate Limiting:** slowapi per-minute per-user limit (default 60/min), per-mode coach/run/submit limits
-- **Migrations:** `backend/alembic/versions/` — initial (`ca0a9c3babd2`), admin (`4476164f80b7`), usage (`7fc9e8c06939`, `a1b2c3d4e5f6`, `c8d0e1f2a3b4`), plan (`a5369fbca804`), skill-graph (`5bb567dd8649`), submissions (`d9e1f2a3b4c5`), review_cards (`a3b4c5d6e7f8`), rescue_queue (`f2a3b4c5d6e7`); head = `e1f2a3b4c5d6` on TEST
+ - **AI:** Groq (openai/gpt-oss-120b, openai/gpt-oss-20b; `animate` mode override) with per-user daily token metering; `cache_keys.py` centralized TTLs
+ - **Auth:** Email/password (bcrypt + JWT) + Supabase OAuth (Google)
+ - **Rate Limiting:** in-process per-minute per-user limiter (`middleware/rate_limit.py`, slowapi replacement; default 60/min), per-mode coach/run/submit limits
+ - **Migrations:** `backend/alembic/versions/` — initial (`ca0a9c3babd2`), admin (`4476164f80b7`), usage (`7fc9e8c06939`, `a1b2c3d4e5f6`, `c8d0e1f2a3b4`), plan (`a5369fbca804`), skill-graph (`5bb567dd8649`), submissions (`d9e1f2a3b4c5`), review_cards (`a3b4c5d6e7f8`), rescue_queue (`f2a3b4c5d6e7`), taxonomy prune (`c9d0e1f2a3b4`), adapter-state (`b4c5d6e7f8a1`); head = `b4c5d6e7f8a1`
 
 > **IMP — Environment status:** The currently wired Supabase project
 > (`qazpxjpcvsjbmgbzuxxp`) is the **TEST** database and the Google OAuth is
@@ -93,14 +95,14 @@ codebase. Feature-by-feature status with checkboxes lives in [Ideas.md](./Ideas.
 
 | Suite                            | Count    | Status     |
 | -------------------------------- | -------- | ---------- |
-| Backend unit tests               | 53 files | ✅ Passing |
-| Backend integration tests        | 23 files | ✅ Passing |
-| Backend security tests           | 7 files  | ✅ Passing |
-| Backend performance tests        | 4 files  | ✅ Passing |
-| Backend contract tests (OpenAPI) | 2 files  | ✅ Passing |
-| Backend skill-graph simulation   | 8 files  | ✅ Passing |
-| Backend migration tests          | 5 files  | ✅ Passing |
-| Frontend unit/component tests    | 76 files | ✅ Passing |
+| Backend unit tests               | 82 files | ✅ Passing |
+| Backend integration tests        | 33 files | ✅ Passing |
+| Backend security tests           | 5 files  | ✅ Passing |
+| Backend performance tests        | 2 files  | ✅ Passing |
+| Backend contract tests (OpenAPI) | 1 file   | ✅ Passing |
+| Backend skill-graph simulation   | 2 files  | ✅ Passing |
+| Backend migration tests          | 2 files  | ✅ Passing |
+| Frontend unit/component tests    | 80 files | ✅ Passing |
 | E2E (Playwright)                 | 15 specs | ✅ Passing |
 
 See [backend/tests/README.md](./backend/tests/README.md) for how to run each tier.
@@ -126,6 +128,14 @@ See [backend/tests/README.md](./backend/tests/README.md) for how to run each tie
 
 ## Recent Changes
 
+- **Docs sync (Sep 04, branch `docs/no-issue-docs-sync`, origin/main `51f7a02`):** living docs re-audited against code — migration head `e1f2a3b4c5d6` → `b4c5d6e7f8a1`, skill inventory 22 → 26 (21 roadmap + 5 supporting), live-question inventory 109 → 107, test-file counts corrected, and the entries below recorded.
+- **Redis workspace persistence (Sep 04, `#124`, `be17372`):** draft code, meta, last-visited, AI chat, and last exec/submit snapshot persist to Redis (7d TTL, `REDIS_TTL_WORKSPACE/CHAT/LAST_EXEC`) via `WorkspaceService` + `PUT/GET/DELETE /api/workspace/*`; frontend `useWorkspace` hydrates on open and saves on an 800ms debounce (auth-gated); last-visited resume on `/problems`; coach appends chat best-effort.
+- **Adapter-state persistence (Sep 04, `#133`):** migration `b4c5d6e7f8a1` adds `coaching_interactions` + `execution_jobs` and `submissions.status/idempotency_key/execution_job_id/request_id`; `CoachingAdapter`/`ExecutionAdapter` record `sent → completed/failed` around every external call; `adapter_state_recovery` flips stale rows; `GET /api/coach/interactions` exposes the audit trail.
+- **Anonymous course-list cache + seed bank + auth helpers (Sep 04, `#144`/`#145`, `b8e64a6`):** `CourseService` serves the anonymous course list from Redis (30s TTL + stampede lock), invalidated on admin writes; test `conftest.py` ships a 50-question seed bank (5 hand + 45 generated) and `tests/fixtures/auth_helpers.py` shares `register/admin` header builders.
+- **Skill taxonomy rework (Sep 03–04, `#134`/`#135`/`#138`):** supporting skills (`programming-fundamentals`, `debugging`, `testing`, `time/space-complexity`) reclassified out of the roadmap track but kept for analytics/coaching (`SkillKind`); roadmap aligned to 21 NeetCode buckets (`ROADMAP_ORDER`, `dp-1d`/`dp-2d` split); stale DP rows pruned (migration `c9d0e1f2a3b4`); total 26 skills.
+- **Animation quality gates (Sep 03, `#141`, `d9df93c`):** planner validation, complexity resolution, 96-step downsampling, and `lint_quality` enforcement in `animation_validator.py`; 8-family `scene_planner.py` (~980 lines) covers the full canonical bank.
+- **Coach surfaces + warm cache (Sep 03, `#131`/`#132`):** `surface=questions` fetches learner-context (graph-aware) while `surface=learn` stays graph-free (`X-Surface` header); `POST /api/coach/warm` (202 `hit/warming/disabled`, `COACH_WARM_ENABLED`) pre-warms learner-context on question enter via `useCoachWarm`.
+- **Question delete cache invalidation (Sep 04, `#143`, `76eb565`):** admin question/course/module/lesson deletes now invalidate the question-detail and course-list caches (regression test `test_delete_question_drops_detail_cache`).
 - **Learner-context personalization (Sep 02, branch `feat/125-coach-skill-context-cache`, `f246c4a`):** `LearnerContextService` composes weakest-3 skill blocks + last-3 submission blocks (truncated 500-char code, 120-char sig) cached via `backend/app/core/cache_keys.py` (`coach:ctx` 60s, `skills:graph` 60s, `submissions:recent` 30s); `PromptBuilder.build()` appends `learner_context`/`submission_context`; `GroqService` v7 hash skips cache when personalized; `POST /api/coach/` always-on for authed (degrade open), `POST /api/submit/` emits idempotent `LearningEvent sub:{id}` and invalidates `coach:ctx`/`skills:graph`/`submissions:recent`/`skills:recs:*`; `skills.py` ingests also invalidate; `MainWorkspace.tsx:82` + `useRecommendedQuestions` dispatch/listen `learner-context-invalidated`; `Problem` now full description (title+category+difficulty+desc+examples+constraints) not just title.
 - **Monaco CSP fix (Sep 02, `e51ddf4`):** restores editor rendering blocked by CSP `worker-src`/`script-src` + dynamic import; `worker-src blob:` verified, `AnimateLauncher` iframe `frame-src` still allowed.
 - **Admin Header link (Aug 24):** `Header.tsx` now shows an **Admin Dashboard** link (`/admin`, `data-testid="header-admin-link"` + mobile `header-admin-link-mobile`) when `useAuth().user.role` is `admin` or `super_admin` (gated on `isHydrated && isAuthenticated`). Desktop island nav (hidden on mobile, icon `LayoutDashboard`) + mobile overlay menu. TDD: 5 new tests in `Header.test.tsx` (admin, super_admin visible; user/unauth/unhydrated hidden) — 11/11 green, full suite 643/643.
@@ -193,12 +203,12 @@ See [backend/tests/README.md](./backend/tests/README.md) for how to run each tie
   the Motion Canvas viewer (`AnimateLauncher` iframe to `:9000`; unblocked both
   `animate-flow` stub and `viewer-render` real-render specs — now 51/51 chromium).
 - ~~Skill taxonomy maps 21 of the 109 live questions~~ — **RESOLVED (Aug 23):**
-  F3 mapped all 109 (212 `question_skills` rows live, 0 dead ids, 0 unmapped);
+  F3 mapped the bank (107/107 live ids, 0 dead ids, 0 unmapped);
   coverage now guarded by `tests/unit/test_skill_taxonomy.py` + snapshot fixture.
+  Taxonomy reworked Sep 04: 26 skills (21 roadmap + 5 supporting, `#134`/`#135`), DP prune (`#138`).
 - ~~C/Java curricula planned but not yet committed~~ — **RESOLVED (Aug 23, F5):** both committed (`backend/data/courses/{c,java}/` 5/35 each, 30/30 Piston verified).
-- ~~Live DB migration pending~~ — **DONE (Aug 15):** live Supabase is at head
-  `e1f2a3b4c5d6`; verified `rate_limit_events`, `user_daily_usage.request_count`,
-  `submissions`, and `question_skills` all exist on live; `alembic upgrade head`
+- ~~Live DB migration pending~~ — **DONE:** live Supabase is at head
+  `b4c5d6e7f8a1`; `alembic upgrade head`
   is a clean no-op.
-- Docs were stale (Aug 14/24) — audited Sep 02 against code (branch `feat/125-coach-skill-context-cache`); flow-map retired to animate, `CoachingMode` 6 modes, `data/courses` only `c`/`java`.
+- Docs were stale (Aug 14/24) — audited Sep 04 against code (branch `docs/no-issue-docs-sync`, origin/main `51f7a02`); flow-map retired to animate, `CoachingMode` 6 modes, `data/courses` only `c`/`java`.
 - See [Ideas.md](./Ideas.md) for the product backlog and roadmap

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Private, proprietary project — no public fork/PR intake. See [AGENTS.md](./AGE
 
 CodeCoach AI is an AI-assisted coding practice platform for university students. It combines:
 
-- **DSA practice** — 109 problems (33 Easy / 50 Medium / 26 Hard) across ~19 categories (Arrays & Hashing, Two Pointers, Sliding Window, Trees & Recursion, Dynamic Programming, Graphs, Linked Lists, Binary Search, …) with Python, JavaScript, and Java starter code, seeded in Supabase.
+- **DSA practice** — 107 live questions (`backend/tests/fixtures/live_question_ids.json`) across a 26-skill taxonomy (21 roadmap buckets in NeetCode order + 5 supporting skills) with Python, JavaScript, and Java starter code, seeded in Supabase.
 - **Language curriculum** — Python Fundamentals (5 modules, 36 lessons: 21 theory + 15 exercises) plus C Programming and Java Programming (5 modules, 35 lessons each: 20 theory + 15 exercises). All content is served from `/learn`; the data model supports arbitrary languages.
 - **AI coaching** — hint, review, explain, debug, freeform, and animate (six modes) via Groq, with SSE streaming and structured JSON responses.
 - **Submit & grade** — isolated Piston execution against visible + hidden test cases, with pass/fail reporting.
@@ -60,22 +60,24 @@ Coaching runs on a platform-owned Groq key with per-user daily token caps — st
 
 ## Features
 
-State is kept in sync with code — audited Sep 02, 2026 on branch `feat/125-coach-skill-context-cache` (see [Progress.md](./Progress.md) and [Ideas.md](./Ideas.md)).
+State is kept in sync with code — audited Sep 04, 2026 on branch `docs/no-issue-docs-sync` (see [Progress.md](./Progress.md) and [Ideas.md](./Ideas.md)).
 
 ### Built
 
 | Feature | Description |
 |---|---|
-| **AI Coaching** | 6 modes (hint, review, explain, debug, freeform, animate) via Groq — structured JSON + SSE streaming (`POST /api/coach`, `POST /api/coach/stream`); lesson-aware + **learner-aware** (`feat/125` `LearnerContextService`: weakest-3 skills + last-3 attempts injected) |
-| **Code Execution** | Piston container — Python, JavaScript, Java; smart code wrapping for stdin→call→stdout harness (`GET/POST /api/run`, `/api/run/validate`, `/api/run/languages`) |
-| **Submit & Grade** | `POST /api/submit` (idempotent `LearningEvent sub:{id}` → skill graph) and `POST /api/run` (optional `question_id` crash capture); visible + hidden cases, `GET /api/submissions/me` history |
-| **Question Bank** | DSA questions with CRUD, search, filtering by difficulty/category/company tags + `/stats` aggregates (`/api/questions`) |
-| **Curriculum** | Python Fundamentals (5/36), C Programming (5/35), Java Programming (5/35) — `/learn` dashboard, module tree, lesson viewer, adjacent-lesson navigation, progress tracking |
-| **Lesson-aware Coaching** | Lesson context injected into every AI prompt; theory vs exercise layouts |
-| **Solution Animations** | Generate → validate → compile → play structured step animations (animate mode, canonical-solution `__trace` pipeline via `trace_instrumenter`/`trace_parser`/`SolutionAnimationService`, flow-map retired; `AnimationPlayer`, Motion Canvas `viewer.html` on `:9000`) |
-| **Skill Graph** | Learning events (run, submit, hint, diagnosis, review) → mastery/status, trends, decay, prerequisite-aware graphs (tables `skills`, `question_skills`, `learning_events`, `user_skill_states`; 22 skills, 212 rows, 109/109 mapped) |
-| **Practice Next** | `GET /api/skills/me/recommended-questions` deterministic queue respecting prerequisites; `useRecommendedQuestions` on `/problems` with `learner-context-invalidated` silent refresh |
-| **Rescue Contract** | Never-alone intervention: `useRescueContract` T1(4m)→T2(+5m AI hint)→T3(+5m re-plan), `RescueIntervention` + `ProblemFlowMap` (static checkpoint list via `rescue.checkpoints.ts`, flow-map retired), durable `rescue_queue` (`f2a3b4c5d6e7`) + `/api/rescue/*` re-surface (`Back tomorrow` on `/problems`) |
+| **AI Coaching** | 6 modes (hint, review, explain, debug, freeform, animate) via Groq — structured JSON + SSE streaming (`POST /api/coach`, `POST /api/coach/stream`); lesson-aware + **learner-aware** (`LearnerContextService`: weakest-3 skills + last-3 attempts injected); `surface=questions` (graph-aware) vs `surface=learn` (graph-free); background warm via `POST /api/coach/warm` (`useCoachWarm`) |
+| **Code Execution** | Piston container — Python, JavaScript, Java; smart code wrapping for stdin→call→stdout harness (`GET/POST /api/run`, `/api/run/validate`, `/api/run/languages`); runtime-version self-heal + result cache |
+| **Submit & Grade** | `POST /api/submit` (idempotent `LearningEvent sub:{id}` → skill graph) and `POST /api/run` (optional `question_id` crash capture); visible + hidden cases, `GET /api/submissions/me` history; graded via `submit_grading_service` with adapter-state tracking |
+| **Question Bank** | DSA questions with CRUD, search, filtering by difficulty/category/company tags + `/stats` aggregates (SQL `COUNT(*)` pushdown); paginated list + summary-column search; admin delete invalidates detail cache (`/api/questions`) |
+| **Curriculum** | Python Fundamentals (5/36), C Programming (5/35), Java Programming (5/35) — `/learn` dashboard, module tree, lesson viewer, adjacent-lesson navigation, progress tracking; anonymous course list served from Redis (30s + stampede lock) |
+| **Lesson-aware Coaching** | Lesson context injected into every AI prompt; theory vs exercise layouts; required for `surface=learn` |
+| **Solution Animations** | Generate → validate → compile → play structured step animations (animate mode, canonical-solution `__trace` pipeline via `trace_instrumenter`/`trace_parser`/`SolutionAnimationService`, 8-family scene planner with complexity resolution + 96-step downsampling + `lint_quality` gate, flow-map retired; `AnimationPlayer`, Motion Canvas `viewer.html` on `:9000`) |
+| **Skill Graph** | Learning events (run, submit, hint, diagnosis, review) → mastery/status, trends, decay, prerequisite-aware graphs (tables `skills`, `question_skills`, `learning_events`, `user_skill_states`; 26 skills = 21 roadmap + 5 supporting, 107/107 mapped) + idempotent `backfill_skill_graph.py` |
+| **Practice Next** | `GET /api/skills/me/recommended-questions` deterministic queue respecting prerequisites (+ `GET /api/skills/boilerplate` roadmap view); `useRecommendedQuestions` on `/problems` with `learner-context-invalidated` silent refresh |
+| **Rescue Contract** | Never-alone intervention: `useRescueContract` T1(4m)→T2(+5m AI hint)→T3(+5m re-plan), `RescueIntervention` + `ProblemFlowMap` (static checkpoint list via `rescue.checkpoints.ts`, flow-map retired), durable `rescue_queue` (`f2a3b4c5d6e7`; stored statuses `abandoned/completed/dismissed`, `due` derived) + `/api/rescue/*` re-surface (`Back tomorrow` on `/problems`) |
+| **Adapter-State Durability** | Every coach/exec/submit call tracked `sent → completed/failed` (`coaching_interactions`, `execution_jobs`, `submissions.status`, migration `b4c5d6e7f8a1`); stale-row recovery worker; `GET /api/coach/interactions` audit |
+| **Workspace Persistence** | Draft code + last-visited + AI chat + last exec/submit snapshot in Redis (7d TTL, caps 51KB / 20 msgs / 5k chars, degrade-open) via `WorkspaceService` + `PUT/GET/DELETE /api/workspace/*`; `useWorkspace` hydrate + 800ms debounce; last-visited resume on `/problems` |
 | **Attempt History** | `submissions` table (`d9e1f2a3b4c5`, attempt_index, error_signature) — every graded submit + crashed `run?question_id`; foundation for #1/#3/#5 |
 | **Error Graph** | `GET /api/mistakes/graph` — per-user mistake graph derived from attempt history (signatures, occurrences, affected questions, first/last seen, resolution) |
 | **Spaced Repetition** | SM-2 rotation over own bugs (`review_cards` `a3b4c5d6e7f8`, `/api/reviews/due`, `POST /api/reviews/{id}/grade`); `run` and `submit` observe failures/passes best-effort |
@@ -85,25 +87,25 @@ State is kept in sync with code — audited Sep 02, 2026 on branch `feat/125-coa
 | **Usage Metering** | Per-user daily input/output token caps, `X-Usage-*` headers, Redis-backed limits |
 | **Plans & Gates** | Per-user plan field and quota-gated coaching (free 20 req/day, paid 500), usage bar, `UpgradeModal` |
 | **Admin Panel** | Dashboard, users, questions, curriculum, validation, usage/rate-limit analytics, abuse reports; Header shows Dashboard + Admin links (role-gated) |
-| **Workspace UX** | Monaco editor (CSP `worker-src blob:` fix `e51ddf4`), dark/light theme, resizable panels, onboarding tour, toasts, hydration guard, `/dashboard` memory-first entry |
-| **Infrastructure** | Docker Compose (backend, frontend, redis, piston), Alembic (head `e1f2a3b4c5d6`), Supabase as the single DB, Cloudflare Workers (OpenNext) build |
-| **Learner-aware Coaching** | `feat/125` `f246c4a`: `LearnerContextService` + `cache_keys` central TTLs + `GroqService` v7 hash + prompt injection; invalidated on `submit`/`skills` |
+| **Workspace UX** | Monaco editor (CSP `worker-src blob:` fix `e51ddf4`), dark/light theme, resizable panels, onboarding tour, toasts, hydration guard, `/dashboard` memory-first entry, last-visited resume |
+| **Infrastructure** | Docker Compose (backend, frontend, redis, piston), Alembic (head `b4c5d6e7f8a1`), Supabase as the single DB, Cloudflare Workers (OpenNext) build |
+| **Learner-aware Coaching** | `LearnerContextService` + `cache_keys` central TTLs + `GroqService` v7 hash + prompt injection; invalidated on `submit`/`skills`; pre-warmed via `POST /api/coach/warm` |
 
 ### Partial / foundation
 
 | Feature | What exists | What's missing |
 |---|---|---|
 | **Curriculum breadth** | Python, C, Java live (F5) | DBMS/SQL, OOP/Design Patterns, Web Dev, MCQ — Phase 3; `backend/data/courses` only `c/`+`java/` |
-| **Attempt-journey replay** | `ProblemFlowMap` static list + `submissions` history now persisted; animation infra for canonical solutions only | Animated replay timeline over own journey + "where you errored" highlights (Idea #5) |
-| **Interview theater** | SSE streaming + Monaco `onCodeChange` | Session/event engine + `InterviewSessionService` + `InterviewTheater` UI (Idea #6) |
-| **Time-travel debugging** | `trace_instrumenter`/`trace_parser` for `animate` only | Generic AST tracing for student code + `POST /trace` + `TimelineScrubber` (Idea #7) |
-| **Classroom / Segment moat** | Courses + progress tracking | Professor/class dashboard, roster model (Idea #2) |
+| **Attempt-journey replay** | `ProblemFlowMap` static list + `submissions` history persisted + workspace Redis journey (draft code, chat, last exec/submit); animation infra for canonical solutions only (8-family planner + `#141` gates) | Animated replay timeline over own journey + "where you errored" highlights (Idea #5) |
+| **Interview theater** | SSE streaming + Monaco `onCodeChange` + coach `surface` split + `POST /api/coach/warm` prefetch | Session/event engine + `InterviewSessionService` + `InterviewTheater` UI (Idea #6) |
+| **Time-travel debugging** | `trace_instrumenter`/`trace_parser` for `animate` only (now with complexity + downsample + `lint_quality` gates) | Generic AST tracing for student code + `POST /trace` + `TimelineScrubber` (Idea #7) |
+| **Classroom / Segment moat** | Courses + progress tracking + anonymously cached course list | Professor/class dashboard, roster model (Idea #2) |
 
-### Planned — audited Sep 02
+### Planned — audited Sep 04
 
 | Phase | Scope |
 |---|---|
-| **Phase 1 — DSA** | Learner-context shipped (`feat/125`); attempt-journey replay (unblocked by `submissions`); onboarding polish |
+| **Phase 1 — DSA** | Learner-context shipped; coach surfaces + warm landed; attempt-journey replay (unblocked by `submissions` + workspace journey); onboarding polish |
 | **Phase 2 — Curriculum** | Context-aware coaching per lesson (now learner-aware); ML/PromptEng/R/JS source JSON parked |
 | **Phase 3 — Expand** | DBMS/SQL, OOP/Design Patterns, Web Dev, theory/MCQ type, classroom dashboard (Idea #2) |
 | **Next up** | **Idea #8 Reverse interview** (`CoachingMode.SENIOR` + junior persona) — cheapest win, validates persona engine for #6 |
@@ -121,7 +123,7 @@ State is kept in sync with code — audited Sep 02, 2026 on branch `feat/125-coa
 | **Code Execution** | Piston (self-hosted Docker, `PistonService` adapter) |
 | **AI Coach** | Groq (`openai/gpt-oss-120b` / `openai/gpt-oss-20b`, animate override) via `api.groq.com/openai/v1` |
 | **Database** | Supabase PostgreSQL (async SQLAlchemy) — **the only database** |
-| **Cache / Limits** | Redis 7-alpine |
+| **Cache / Limits** | Redis 7-alpine — rate/request tracking, learner-context, workspace (7d), anonymous course list (30s + lock), question detail, Piston runtimes |
 | **Auth** | JWT (python-jose), bcrypt, Supabase OAuth (Google) |
 | **Migrations** | Alembic (`backend/alembic/`) |
 | **Testing** | pytest (backend), Vitest + Testing Library + MSW (frontend), Playwright (E2E) |
@@ -135,16 +137,20 @@ State is kept in sync with code — audited Sep 02, 2026 on branch `feat/125-coa
 ```
 backend/app/
   ports/          Abstract interfaces (ABCs) — repositories, code executor, coaching provider
-  adapters/       Concrete adapters (code_wrappers, coaching_prompts, response parser, formatter)
-  use_cases/      Single-responsibility validation logic (question validation)
+  adapters/       Concrete adapters (code_wrappers, coaching_prompts, coaching_adapter,
+                  execution_adapter, submit_grading_service, response parser, formatter)
+  use_cases/      Single-responsibility validation logic (question validation, incl. ANIMATION gate)
   services/       Business logic wrapping ports (Groq, Piston, skill_graph, sm2, memory_graph,
-                   error_graph, learning_analytics, rescue, review, animations, usage, submissions)
+                   error_graph, learning_analytics, rescue, review, animations + scene_planner,
+                   usage, submissions, course (cached), question_bank, workspace,
+                   learner_context, adapter_state_recovery)
   repositories/   SQLAlchemy impls (sql_*) — Supabase/PostgreSQL only
   api/            Thin FastAPI route handlers (auth, coach, run, submit, questions, courses,
-                   progress, skills, submissions, rescue, reviews, memory, mistakes, analytics, admin, health)
+                   progress, skills, submissions, rescue, reviews, memory, mistakes, analytics,
+                   workspace, admin, health)
   models/         Pydantic schemas (request/response + domain enums — TopicMemory, AnalyticsSignal, …)
   core/           Database engine/session (async_session_maker), settings, security (JWT/bcrypt)
-  middleware/     Rate limiting (slowapi), security headers (CSP, HSTS, X-Frame-Options)
+  middleware/     Rate limiting (in-process limiter), security headers (CSP, HSTS, X-Frame-Options)
   dependencies/   FastAPI Depends() injection wiring (app/api/dependencies.py)
 ```
 
@@ -154,7 +160,8 @@ backend/app/
 frontend/src/
   app/            Next.js App Router — /, /problems/[id], /learn, /dashboard, /admin, /login, /privacy …
   features/       {auth, coaching, code-execution, question, curriculum, skill-graph,
-                   rescue, review, memory, analytics, animation, usage} → {hook, service, types, *.test.*}
+                   rescue, review, memory, analytics, animation, usage, workspace} → {hook, service, types, *.test.*}
+                   (coaching includes `use-coach-warm`; skill-graph includes `SkillGraphInline`)
   components/     Reusable UI (editor, chat, sidebar, header, layout, rescue, visualization, admin, ui/*)
   lib/            HTTP client port/adapter (FetchClient / HttpClient), shuffle, fetch-client
   hooks/          Shared hooks (useLocalStorage, useDebounce, useWorkspaceMode)
@@ -164,7 +171,7 @@ frontend/src/
 
 **Key decisions**
 
-- **Supabase/PostgreSQL is the single source of truth** — questions, courses/modules/lessons, users, progress, submissions, review_cards, rescue_queue, usage, and skill-graph state all live in PostgreSQL; the app never reads content from the filesystem at runtime. See [backend/docs/CURRICULUM_DEPLOYMENT.md](./backend/docs/CURRICULUM_DEPLOYMENT.md).
+- **Supabase/PostgreSQL is the single source of truth** — questions, courses/modules/lessons, users, progress, submissions, coaching_interactions, execution_jobs, review_cards, rescue_queue, usage, and skill-graph state all live in PostgreSQL; the app never reads content from the filesystem at runtime. Committed JSON under `backend/data/courses/{c,java}/` is a transient bootstrap source consumed by `sync_local_to_db.py` only. See [backend/docs/CURRICULUM_DEPLOYMENT.md](./backend/docs/CURRICULUM_DEPLOYMENT.md).
 - **Platform-owned Groq key** — server-side key; per-user input/output tokens metered with daily caps on coach endpoints.
 - **Deterministic skill graph & learning analytics** — mastery + plateau signals derived via pure, unit-tested rules (`skill_graph_rules.py`, `sm2_rules.py`, `error_graph_rules.py`, `learning_analytics_rules.py`); recommendations respect taxonomy prerequisites; analytics is bounded (1000 recent submissions, 7-day window) and fail-safe (500 → empty list).
 - **Code wrapping** — every Piston language has a `_wrap_<language>_code` adapter converting bare function definitions into a stdin→call→stdout harness.
@@ -180,16 +187,16 @@ frontend/src/
 | `questions` | Bank (difficulty, category, starter_code JSON, test_cases, hints, company_tags GIN) |
 | `courses`, `modules`, `lessons` | Curriculum (language, order, theory/exercise, linked question) |
 | `course_progress` | Per-user lesson progress (continue-where-you-left-off) |
-| `submissions` | Attempt history (user_id, question_id, language, code, passed, error_signature, attempt_index, created_at) — `d9e1f2a3b4c5` |
+| `submissions` | Attempt history (user_id, question_id, language, code, passed, error_signature, attempt_index, status, idempotency_key, execution_job_id, created_at) — `d9e1f2a3b4c5` + `b4c5d6e7f8a1` |
+| `coaching_interactions`, `execution_jobs` | Adapter-state audit (sent/completed/failed per coach + exec call, stale-row recovery) — `b4c5d6e7f8a1` |
 | `review_cards` | SM-2 cards (user_id, question_id, error_signature unique, state active/scheduled, ease, interval_days, lapses, due_at) — `a3b4c5d6e7f8` |
 | `rescue_queue` | Abandoned-problem re-surface (user_id, question_id unique partial open, due_at 09:00, dismissed) — `f2a3b4c5d6e7` |
 | `usage_*`, `rate_limit_events`, `user_daily_usage` | AI usage events, daily counters, rate-limit tracking (Redis-backed) |
-| `skills`, `question_skills`, `learning_events`, `user_skill_states` | Skill graph (definitions, question↔skill, per-user events + mastery) — `5bb567dd8649` (22 skills) |
-| `admin_*`, `audit_logs` | Admin sessions + audit trail |
+| `skills`, `question_skills`, `learning_events`, `user_skill_states` | Skill graph (definitions, question↔skill, per-user events + mastery) — `5bb567dd8649` + taxonomy prune `c9d0e1f2a3b4` (26 skills: 21 roadmap + 5 supporting) |
 
-> **Live DB (Supabase `qazpxjpcvsjbmgbzuxxp`, TEST, Sep 02, 2026 — audited):** `alembic current` = `e1f2a3b4c5d6` (head); `public` holds 109 questions, `courses`/`modules`/`lessons` seeded (Python 5/36 + C 5/35 + Java 5/35), `review_cards`/`rescue_queue` verified, 212 `question_skills` rows (109/109 mapped, F3). No `class`/`roster`/`trace` tables. Flow-map retired. `CoachingMode` has 6 modes (no `SENIOR`).
+> **Live DB (Supabase `qazpxjpcvsjbmgbzuxxp`, TEST, Sep 04, 2026 — audited):** `alembic current` = `b4c5d6e7f8a1` (head); `public` holds 107 live questions, `courses`/`modules`/`lessons` seeded (Python 5/36 + C 5/35 + Java 5/35), `review_cards`/`rescue_queue`/`coaching_interactions`/`execution_jobs` verified, 107/107 skill-mapped (F3; 26 skills: 21 roadmap + 5 supporting). No `class`/`roster`/`trace` tables. Flow-map retired. `CoachingMode` has 6 modes (no `SENIOR`).
 
-Migrations in `backend/alembic/versions/` (initial, admin, usage, user plan, skill-graph, review_cards, rescue_queue). Tests use an isolated `codecoach_test` schema (`DATABASE_SEARCH_PATH`).
+Migrations in `backend/alembic/versions/` (initial, admin, usage, user plan, skill-graph, submissions, review_cards, rescue_queue, taxonomy prune, adapter-state). Tests use an isolated `codecoach_test` schema (`DATABASE_SEARCH_PATH`; per-worker `codecoach_test_gwN` under xdist).
 
 ## Getting Started
 
@@ -252,9 +259,11 @@ Content lives in the database. Initial data can be bootstrapped idempotently fro
 
 ```bash
 cd backend
-python scripts/sync_local_to_db.py                 # uses DATABASE_URL; upserts questions/courses/modules/lessons
+python scripts/sync_local_to_db.py                 # uses DATABASE_URL; upserts questions/courses/modules/lessons (ANIMATION full-validate gate enforced)
 python scripts/seed_admin.py                       # promote auditadmin → admin
-python scripts/seed_skill_graph.py                 # rescues skill graph after mapping changes
+python scripts/seed_skill_graph.py                 # rescues skill graph after mapping changes (upserts taxonomy kinds)
+python scripts/backfill_skill_graph.py             # idempotent backfill of learning events from submissions
+python scripts/seed_e2e.py                         # E2E question bank
 DATABASE_URL=postgresql://... python scripts/verify_course_exercises.py  # 30/30 Piston checks for C/Java
 ```
 
@@ -283,6 +292,13 @@ DATABASE_URL=postgresql://postgres.<ref>.<region>.pooler.supabase.com:6543/postg
 DAILY_TOKEN_INPUT_CAP=250000
 DAILY_TOKEN_OUTPUT_CAP=125000
 USER_RATE_LIMIT_PER_MINUTE=60
+COACH_WARM_ENABLED=true                          # background learner-context pre-warm on question enter
+COURSE_LIST_TTL_SECONDS=30                       # anonymous course-list Redis cache
+REDIS_TTL_WORKSPACE=604800                       # 7d — draft code + last-visited
+REDIS_TTL_CHAT=604800                            # 7d — per-question chat history
+REDIS_TTL_LAST_EXEC=604800                       # 7d — last execution / submit snapshot
+WORKSPACE_CODE_MAX_BYTES=51200
+CHAT_HISTORY_MAX_MESSAGES=20
 SUPABASE_URL=https://your-project-id.supabase.co
 SUPABASE_ANON_KEY=sb_publishable_...              # publishable key (public)
 PISTON_API_URL=http://localhost:2000/api/v2        # Docker compose sets http://piston:2000/api/v2
@@ -313,22 +329,23 @@ Interactive docs at `/docs` (Swagger) and `/redoc`. Selected routes:
 |---|---|---|---|
 | **Health** | `GET /health`, `GET /health/` | — | Dependency checks (`questions_db`, `piston`, `redis`) |
 | **Auth** | `POST /api/auth/register`, `POST /api/auth/login`, `POST /api/auth/refresh` | — / Bearer | JWT + Supabase OAuth callback |
-| **Questions** | `GET /api/questions`, `GET /api/questions/{id}`, `GET /api/questions/search?q=` | — | Trailing slash handled (`/api/questions` + `/api/questions/`) |
+| **Questions** | `GET /api/questions`, `GET /api/questions/{id}`, `GET /api/questions/search?q=` | — | Paginated list + summary-column search; trailing slash handled (`/api/questions` + `/api/questions/`) |
 | **Run** | `POST /api/run` (+ `question_id` optional crash capture) | Optional | Piston; validation `POST /api/run/validate` |
-| **Submit** | `POST /api/submit` | Bearer | Grades + best-effort submission + SM-2 observe |
+| **Submit** | `POST /api/submit` | Bearer | Grades + best-effort submission + SM-2 observe + adapter-state tracking |
 | **Submissions** | `GET /api/submissions/me` | Bearer | Own attempt history |
-| **Coach** | `POST /api/coach`, `POST /api/coach/stream` (SSE) | Bearer | 6 modes, per-user daily caps, `X-Usage-*` headers |
-| **Skills** | `GET /api/skills/graph`, `GET /api/skills/recommendations` | Bearer | Mastery + Practice Next |
+| **Coach** | `POST /api/coach`, `POST /api/coach/stream` (SSE), `POST /api/coach/warm` (202 pre-warm), `GET /api/coach/interactions` | Bearer | 6 modes (`surface=questions|learn`), per-user daily caps, `X-Usage-*` headers |
+| **Skills** | `GET /api/skills/graph`, `GET /api/skills/me/skills`, `GET /api/skills/boilerplate`, `GET /api/skills/me/recommended-questions` | Bearer | Mastery + roadmap view + Practice Next |
 | **Mistakes** | `GET /api/mistakes/graph` | Bearer | Error graph from attempt history |
 | **Reviews** | `GET /api/reviews/due`, `POST /api/reviews/{id}/grade` | Bearer | SM-2 queue |
 | **Memory** | `GET /api/memory/graph` | Bearer | Forgetting-curve topics (Idea #3) |
 | **Analytics** | `GET /api/analytics/signals` | Bearer | Plateau signals (recursion plateau etc., 7d window) |
 | **Rescue** | `GET /api/rescue/due`, `POST /api/rescue/{id}/abandon|complete|dismiss` | Bearer | Re-surface queue |
-| **Courses** | `GET /api/courses`, `GET /api/courses/{id}`, lessons, progress | Bearer | Curriculum + `/api/progress` |
-| **Admin** | `GET /api/admin/*` (stats, users, questions, courses, usage, validation) | Admin | Role-gated `admin`/`super_admin` |
-| **Debug** | `GET /debug/*` | — | Dev-only diagnostics |
+| **Courses** | `GET /api/courses`, `GET /api/courses/{id}`, lessons, progress | Bearer (list also anonymous, cached) | Curriculum + `/api/progress` |
+| **Workspace** | `PUT/GET/DELETE /api/workspace/code/{id}`, `GET /api/workspace/last-visited`, `GET /api/workspace/chat/{id}`, `GET /api/workspace/meta/{id}` | Bearer | Redis-persisted drafts, chat, resume |
+| **Admin** | `GET /api/admin/*` (stats, users, questions, courses, usage, validation) | Admin | Role-gated `admin`/`super_admin`; writes invalidate course/question caches |
+| **Debug** | `GET /debug/*` | — | Dev-only diagnostics (404 in production) |
 
-Error semantics: `HTTPException` → 4xx client, unexpected → 5xx via global handler; rate-limit 429 via `slowapi`/`rescue`/`usage` middleware.
+Error semantics: `HTTPException` → 4xx client, unexpected → 5xx via global handler; rate-limit 429 via in-process limiter + `usage` middleware.
 
 ## Testing
 
@@ -338,25 +355,25 @@ Error semantics: `HTTPException` → 4xx client, unexpected → 5xx via global h
 cd backend
 pip install -r requirements.txt -r tests/test_requirements.txt
 DATABASE_URL=postgresql://codecoach:codecoach@127.0.0.1:5433/codecoach_test \
-  python -m pytest tests/unit/            # 53 files (incl. memory_graph)
-python -m pytest tests/integration/       # 23 files (needs isolated Postgres schema)
-python -m pytest tests/contract/          # 2 files (OpenAPI response contracts)
-python -m pytest tests/security/          # 7 files
-python -m pytest tests/performance/       # 4 files
-python -m pytest tests/migrations/        # 5 files
-python -m pytest tests/simulation/        # 8 files (skill-graph)
+  python -m pytest tests/unit/            # 82 files (incl. memory_graph, animation quality, adapter-state)
+python -m pytest tests/integration/       # 33 files (needs isolated Postgres schema)
+python -m pytest tests/contract/          # 1 file (OpenAPI response contracts)
+python -m pytest tests/security/          # 5 files
+python -m pytest tests/performance/       # 2 files
+python -m pytest tests/migrations/        # 2 files
+python -m pytest tests/simulation/        # 2 files (skill-graph)
 python -m pytest                          # all tiers; coverage via qa/enforce_coverage_budget.py
 ruff check . && ruff format . --check     # lint gate
 ```
 
-Tests use an isolated `codecoach_test` schema (`DATABASE_SEARCH_PATH`); never touch production. Flaky tests are quarantined via `tests/enforce_flaky_quarantine.py`.
+Tests use an isolated `codecoach_test` schema (`DATABASE_SEARCH_PATH`; per-worker `codecoach_test_gwN` under xdist); never touch production. Shared auth builders live in `tests/fixtures/auth_helpers.py`; the 50-question seed bank + 107 live ids (`fixtures/live_question_ids.json`) come from `conftest.py`. Flaky tests are quarantined via `tests/enforce_flaky_quarantine.py`.
 
 ### Frontend (Vitest)
 
 ```bash
 cd frontend
 pnpm install
-pnpm test:run                    # 76 files (Vitest + Testing Library + MSW)
+pnpm test:run                    # 80 files (Vitest + Testing Library + MSW)
 pnpm lint                        # ESLint (0 warnings)
 pnpm typecheck                   # tsc --noEmit (0 errors)
 ```
@@ -397,20 +414,24 @@ See [AGENTS.md](./AGENTS.md) for the full mandatory rules and [Progress.md](./Pr
 CodeCoach-AI/
 ├── backend/
 │   ├── app/
-│   │   ├── api/               # coach, run, submit, submissions, questions, skills, mistakes,
-│   │   │                      # reviews, memory, rescue, courses, progress, admin, auth, health, debug
-│   │   ├── adapters/          # code_wrappers, coaching_prompts, response parser, formatter
-│   │   ├── use_cases/         # question validation (structure, test_cases, starter_code, solution, time, signature, output_format)
-│   │   ├── services/          # groq, piston, skill_graph, sm2, memory_graph, error_graph,
-│   │   │                      # rescue, review, animations, usage, submissions, course, question …
-│   │   ├── repositories/      # sql_* (Supabase/PostgreSQL only)
-│   │   ├── ports/             # Abstract interfaces (ABCs)
-│   │   ├── models/            # Pydantic schemas + domain enums (Question, ReviewCard, TopicMemory, RescueItem …)
-│   │   ├── core/              # database (async engine), config (get_settings), security (JWT/bcrypt)
-│   │   ├── middleware/        # rate_limit (slowapi), security_headers (CSP)
-│   │   └── dependencies/      # FastAPI Depends() wiring (app/api/dependencies.py)
-│   ├── alembic/               # migrations (initial, admin, usage, skill-graph, review_cards, rescue_queue)
-│   ├── scripts/               # sync_local_to_db, seed_admin, seed_skill_graph, verify_course_exercises, animate_coverage
+ │   │   ├── api/               # coach, run, submit, submissions, questions, skills, mistakes,
+ │   │   │                      # reviews, memory, rescue, courses, progress, workspace, admin, auth, health, debug
+ │   │   ├── adapters/          # code_wrappers, coaching_prompts, coaching_adapter, execution_adapter,
+ │   │   │                      # submit_grading_service, response parser, formatter
+ │   │   ├── use_cases/         # question validation (structure, test_cases, starter_code, solution, time, signature, output_format, animation gate)
+ │   │   ├── services/          # groq, piston, skill_graph, sm2, memory_graph, error_graph,
+ │   │   │                      # rescue, review, animations + scene_planner, usage, submissions, course (cached),
+ │   │   │                      # question_bank, workspace, learner_context, adapter_state_recovery …
+ │   │   ├── repositories/      # sql_* (Supabase/PostgreSQL only)
+ │   │   ├── ports/             # Abstract interfaces (ABCs)
+ │   │   ├── models/            # Pydantic schemas + domain enums (Question, ReviewCard, TopicMemory, RescueItem …)
+ │   │   ├── core/              # database (async engine), config (get_settings), security (JWT/bcrypt)
+ │   │   ├── middleware/        # rate_limit (in-process limiter), security_headers (CSP)
+ │   │   └── dependencies/      # FastAPI Depends() wiring (app/api/dependencies.py)
+ │   ├── alembic/               # migrations (initial, admin, usage, skill-graph, submissions,
+ │   │                            # review_cards, rescue_queue, taxonomy prune, adapter-state — head b4c5d6e7f8a1)
+ │   ├── scripts/               # sync_local_to_db, seed_admin, seed_skill_graph, backfill_skill_graph,
+ │   │                            # seed_e2e, verify_course_exercises, animate_coverage
 │   ├── tests/                 # unit, integration, contract, security, performance, simulation, migrations
 │   └── docs/                  # CURRICULUM_DEPLOYMENT.md
 ├── frontend/
@@ -434,26 +455,27 @@ CodeCoach-AI/
 
 - **Docker Compose (production):** `docker compose up -d --build` builds `pip install` / `npm run build` into images. No volume mounts; `PistonService` + `Redis` + `Supabase` wired via env.
 - **Cloudflare Workers (frontend):** OpenNext build — `NEXT_PUBLIC_*` must be set as build args, not runtime env.
-- **Supabase migrations:** `alembic upgrade head` against the pooler (handles `pgbouncer=true` stripping, `%`-escaping, `asyncpg` statement-cache off). Verified Aug 24: `e1f2a3b4c5d6` on TEST.
+- **Supabase migrations:** `alembic upgrade head` against the pooler (handles `pgbouncer=true` stripping, `%`-escaping, `asyncpg` statement-cache off). Verified Sep 04: `b4c5d6e7f8a1` on TEST.
 - **Health:** `GET /health` checks `questions_db`, `piston`, `redis`; Docker `HEALTHCHECK` gates `backend`.
 
 ## Security
 
 - Input validated at API boundaries (Pydantic); auth via JWT + bcrypt + Supabase OAuth; role-gated admin routes.
-- Rate limiting via `slowapi` (coach/run/submit/rescue per-user) + `UsageService` token caps; 429 → `Retry-After` + `X-Usage-*`.
+- Rate limiting via in-process limiter (`middleware/rate_limit.py`, coach/run/submit/rescue per-user) + `UsageService` token caps; 429 → `Retry-After` + `X-Usage-*`.
 - Security headers: `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy`, and CSP (`default-src 'self'` + `frame-src` viewer allowlist, `worker-src blob:` for Monaco).
 - Secrets only from `.env` / env — never committed or logged; least privilege on all auth/authz paths.
-- See `backend/tests/security/` for 7 committed security suites (auth, execution, rate-limit, etc.).
+- See `backend/tests/security/` for 5 committed security suites (auth, execution, input validation, etc.).
 
-## Roadmap — audited Sep 02, 2026 (branch `feat/125-coach-skill-context-cache`)
+## Roadmap — audited Sep 04, 2026 (branch `docs/no-issue-docs-sync`)
 
 ```
 Phase 1 ─── DSA Practice (current focus)
-├── 109 / 100 questions ─── 33 Easy / 50 Medium / 26 Hard (109/109 skill-mapped, F3, 212 rows)
-├── Practice Next / skill-graph recommendations (shipped; silent refresh on learner-context invalidation)
-├── Mistake-memory (submissions d9e1f2a3b4c5 + error graph + SM-2 a3b4c5d6e7f8 + Memory Graph /dashboard + Learning Analytics signals) (F6 + Idea #3 done Aug 24)
+├── 107 live questions (107/107 skill-mapped, F3; 26 skills = 21 roadmap + 5 supporting)
+├── Practice Next / skill-graph recommendations (shipped; silent refresh on learner-context invalidation; roadmap-only view)
+├── Mistake-memory (submissions + error graph + SM-2 + Memory Graph /dashboard + Learning Analytics signals + adapter-state audit) (F6 + Idea #3 + #133 done)
 ├── Rescue contract — durable queue f2a3b4c5d6e7 + T1→T2→T3 escalation (Idea #4 done Aug 24, ProblemFlowMap static list; flow-map retired to animate)
-├── Learner-aware coaching (shipped Sep 02 `f246c4a`): LearnerContextService + cache_keys + prompt injection + skill emission
+├── Learner-aware coaching (shipped `f246c4a`): LearnerContextService + cache_keys + prompt injection + skill emission; coach surfaces (`questions`/`learn`) + warm prefetch landed Sep 04
+├── Workspace persistence (shipped `#124`): Redis drafts + chat + last-visited (7d); adapter-state durability (shipped `#133`)
 └── Next: attempt-journey replay (now unblocked) + reverse interview (#8, CoachingMode.SENIOR)
 
 Phase 2 ─── Programming Language Curriculum
@@ -472,9 +494,9 @@ Phase 3 ─── Future Modules
 Backlog — Ideas #6 (InterviewTheater), #7 (student-code POST /trace + TimelineScrubber), #9 honourable mentions (adversarial twin, takeover, …)
 ```
 
-Detailed per-idea status (9 ideas + honourable mentions) lives in [Ideas.md](./Ideas.md) — audited Sep 02; #1/#3/#4 done + #5 unblocked + #8 next; flow-map retired.
+Detailed per-idea status (9 ideas + honourable mentions) lives in [Ideas.md](./Ideas.md) — audited Sep 04; #1/#3/#4 done + #5 unblocked + #8 next; flow-map retired.
 
-## Known Gaps — code-audited Sep 02
+## Known Gaps — code-audited Sep 04
 
 - No full attempt-journey animated replay yet (`ProblemFlowMap` is static checkpoint list; `submissions` history now persisted and unblocks it, but timeline + highlights missing — Idea #5; former AI flow-map retired).
 - No interview-theater session engine / interviewer UI (`CoachingMode` has 6 modes, no `SENIOR`; no `InterviewSessionService`, no `POST /interview` — Idea #6/`#8`; streaming + Monaco foundation only).

--- a/backend/docs/CURRICULUM_DEPLOYMENT.md
+++ b/backend/docs/CURRICULUM_DEPLOYMENT.md
@@ -2,8 +2,9 @@
 
 The **database (PostgreSQL/Supabase) is the single source of truth** for
 questions, courses, modules, lessons, exercises, starter code, and test cases.
-There are no checked-in data files: the application never reads content from
-the filesystem at runtime.
+The application never reads content from the filesystem at runtime. Committed
+JSON under `backend/data/courses/{c,java}/` is a transient bootstrap source
+consumed by `sync_local_to_db.py` only.
 
 ## Data model
 
@@ -15,6 +16,12 @@ the filesystem at runtime.
 | `lessons`        | Lesson content (theory/exercise, order, question link) |
 | `users`          | Accounts (auth, roles, plans)                       |
 | `course_progress`| Per-user progress                                   |
+| `submissions`    | Attempt history (incl. adapter-state status columns) |
+| `coaching_interactions`, `execution_jobs` | Adapter-state audit              |
+| `rescue_queue`   | Abandoned-problem re-surface queue                  |
+| `review_cards`   | SM-2 spaced-repetition cards                        |
+| `skills`, `question_skills`, `learning_events`, `user_skill_states` | Skill graph |
+| `usage_*`, `rate_limit_events`, `user_daily_usage` | Usage metering |
 
 All application repositories are SQL-backed (see `app/repositories/`) and are
 selected unconditionally by `app/api/dependencies.py`.
@@ -22,10 +29,19 @@ selected unconditionally by `app/api/dependencies.py`.
 ## One-time bootstrap from a JSON export
 
 `backend/scripts/sync_local_to_db.py` upserts a local JSON export
-(`questions/sample_questions.json` + `data/courses/**`) into the database. It
+(`backend/questions/sample_questions.json` + `backend/data/courses/**`) into the database. It
 is **idempotent and non-destructive**: missing rows are inserted, existing
 rows with the same ID are updated, and unrelated database data is never
 deleted. Safe to re-run.
+
+> Note: `backend/questions/` is currently absent from the checkout — only
+> `backend/data/courses/{c,java}/` exists. The sync script's question path
+> resolves relative to `backend/`; syncing questions requires that export to
+> be present.
+
+New questions pass the `full_validate` gate (including the non-skippable
+`ANIMATION` use case: `examples[0].input` must trace and the family must
+compile via `scene_planner.py` + `AnimationValidator`).
 
 ```bash
 python scripts/sync_local_to_db.py            # uses DATABASE_URL from .env
@@ -39,4 +55,7 @@ runtime; the database remains the canonical store.
 
 Test fixtures are defined in code (`tests/conftest.py`) and seed the isolated
 `codecoach_test` schema directly — no data files are involved. The sync
-utility itself is covered by `tests/unit/test_local_sync.py`.
+utility itself is covered by `tests/unit/test_local_sync.py`. Shared auth
+builders live in `tests/fixtures/auth_helpers.py`; the live-question inventory
+is pinned in `tests/fixtures/live_question_ids.json` (107 ids). Tests refuse
+non-local databases (`tests/db_guard.py`) unless `ALLOW_PRODUCTION_TEST_DB=1`.

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -12,19 +12,22 @@ as the Supabase production database).
 
 ```
 tests/
-├── conftest.py                 # Fixtures: app, client, isolated schema, auth mocks
+├── conftest.py                 # Fixtures: app, client, isolated schema, auth mocks, 50-question seed bank
+├── db_guard.py                 # Refuses non-local DB hosts (ALLOW_PRODUCTION_TEST_DB=1 override)
 ├── db_helpers.py               # Schema creation/teardown helpers
 ├── test_requirements.txt       # Test-only dependencies
 ├── fixtures/
 │   ├── factories.py            # Test data generators
+│   ├── auth_helpers.py         # Shared register/admin header builders
+│   ├── live_question_ids.json  # Pinned live-question inventory (107 ids)
 │   └── mock_coaching_provider.py
-├── unit/            (53 files) # Services, rules, wrappers, repositories (sql_*), validators
-├── integration/    (23 files)  # Endpoints against the app + isolated DB schema
-├── contract/        (2 files)  # OpenAPI response-contract validation
-├── security/        (7 files)  # Auth, injection, CORS, headers, abuse detection
-├── performance/     (4 files)  # Load / concurrency / rate-limit stress
-├── simulation/      (8 files)  # Deterministic skill-graph learner simulations
-├── migrations/      (5 files)  # Alembic up/down + schema-vs-model drift
+├── unit/            (82 files) # Services, rules, wrappers, repositories (sql_*), validators
+├── integration/    (33 files)  # Endpoints against the app + isolated DB schema
+├── contract/        (1 file)   # OpenAPI response-contract validation
+├── security/        (5 files)  # Auth, injection, CORS, headers, abuse detection
+├── performance/     (2 files)  # Load / concurrency / rate-limit stress
+├── simulation/      (2 files)  # Deterministic skill-graph learner simulations
+├── migrations/      (2 files)  # Alembic up/down + schema-vs-model drift
 ├── enforce_flaky_quarantine.py # CI gate for the flaky-test manifest
 └── flaky-quarantine.json       # Quarantined flaky tests (must stay green)
 ```
@@ -33,9 +36,23 @@ tests/
 
 Tests never touch the production schema. `conftest.py` creates an isolated
 `codecoach_test` schema on the same PostgreSQL server pointed at by
-`DATABASE_URL` and drops it after the run.
+`DATABASE_URL` and drops it after the run (per-worker `codecoach_test_gwN`
+schemas under xdist, selected via `DATABASE_SEARCH_PATH`).
 
 Local Postgres (recommended for speed):
+
+```bash
+docker run -d --name codecoach-testdb -e POSTGRES_DB=codecoach_test \
+  -e POSTGRES_USER=codecoach -e POSTGRES_PASSWORD=codecoach \
+  -p 5433:5432 postgres:16-alpine
+
+export DATABASE_URL=postgresql://codecoach:codecoach@127.0.0.1:5433/codecoach_test
+export DATABASE_SEARCH_PATH=codecoach_test
+```
+
+> Port note: the `-p 5433:5432` mapping above exposes container port 5432 as
+> host port 5433. `conftest.py` defaults to `127.0.0.1:5432` when `DATABASE_URL`
+> is unset — always export `DATABASE_URL` explicitly as shown.
 
 ```bash
 docker run -d --name codecoach-testdb -e POSTGRES_DB=codecoach_test \


### PR DESCRIPTION
Trivial no-issue docs-only work (no Issue; docs-only, no TDD loop per AGENTS.md).

Re-audits all living docs against code at origin/main 51f7a02 (local main was stale at e868832):

- Progress.md / Ideas.md / README.md: migration head e1f2a3b4c5d6 -> b4c5d6e7f8a1, 109 -> 107 live questions, 22 -> 26 skills (21 roadmap + 5 supporting), corrected test-file counts, slowapi -> in-process limiter
- Records newly-merged work: #124 redis workspace, #133 adapter-state, #144 course cache + 50-question seed bank, #134/#135/#138 taxonomy, #141 animation quality, #131 surfaces, #132 warm, #143 delete invalidation
- Docs/: historical-audit addendum, OPS-1 head, F2 derived-due fix, F3/F5/M-04 marked DONE
- TEST_ENVIRONMENT / CURRICULUM_DEPLOYMENT / tests-README: heads, counts, port note, fixtures, missing tables/routes

Every factual claim verified against code (migration chain, live_question_ids count 107, skill_taxonomy 26 skills, route paths, config keys, seed-bank size).